### PR TITLE
add effects to user preferences and advanced option

### DIFF
--- a/MCprep_addon/conf.py
+++ b/MCprep_addon/conf.py
@@ -39,7 +39,7 @@ def init():
 	# Used to print out extra information, set false with distribution
 	# -----------------------------------------------
 	global dev
-	dev = True
+	dev = False
 
 	global v
 	v = True  # $VERBOSE, UI setting

--- a/MCprep_addon/conf.py
+++ b/MCprep_addon/conf.py
@@ -39,7 +39,7 @@ def init():
 	# Used to print out extra information, set false with distribution
 	# -----------------------------------------------
 	global dev
-	dev = False
+	dev = True
 
 	global v
 	v = True  # $VERBOSE, UI setting

--- a/MCprep_addon/mcprep_ui.py
+++ b/MCprep_addon/mcprep_ui.py
@@ -559,6 +559,21 @@ class McprepPreference(bpy.types.AddonPreferences):
 			p = col.operator("mcprep.openfolder", text="Open skin folder")
 			p.folder = self.skin_path
 
+			row = layout.row()
+			row.scale_y = 0.7
+			row.label(text="Effects")
+			box = layout.box()
+			split = util.layout_split(box, factor=factor_width)
+			col = split.column()
+			col.label(text="Effect folder")
+			col = split.column()
+			col.prop(self, "effects_path", text="")
+			split = util.layout_split(box, factor=factor_width)
+			col = split.column()
+			col = split.column()
+			p = col.operator("mcprep.openfolder", text="Open effects folder")
+			p.folder = self.effects_path
+
 			# misc settings
 			row = layout.row()
 			row.prop(self, "verbose")
@@ -1525,6 +1540,26 @@ def effects_spawner(self, context):
 	ops.location = util.get_cuser_location(context)
 	ops.frame = context.scene.frame_current
 
+	col = layout.column()
+	if not scn_props.show_settings_effect:
+		col.prop(
+			scn_props, "show_settings_effect",
+			text="Advanced", icon="TRIA_RIGHT")
+	else:
+		col.prop(
+			scn_props, "show_settings_effect",
+			text="Advanced", icon="TRIA_DOWN")
+		box = col.box()
+		b_row = box.row()
+		b_col = b_row.column(align=False)
+		b_col.label(text="Effects")
+		subrow = b_col.row(align=True)
+		subrow.prop(context.scene, "mcprep_effects_path", text="")
+		b_row = box.row()
+		b_col = b_row.column(align=True)
+		b_col.operator("mcprep.reload_effects",
+			text="Reload effects")
+
 
 class MCPREP_PT_spawn(bpy.types.Panel):
 	"""MCprep panel for mob spawning"""
@@ -1774,6 +1809,10 @@ class McprepProps(bpy.types.PropertyGroup):
 		default=False)
 	show_settings_spawner = bpy.props.BoolProperty(
 		name="show spawner settings",
+		description="Show extra MCprep panel settings",
+		default=False)
+	show_settings_effect = bpy.props.BoolProperty(
+		name="show effect settings",
 		description="Show extra MCprep panel settings",
 		default=False)
 


### PR DESCRIPTION
For certain user want to change the effect path to another location through preferences and through the advanced dropdown and resolve the symlink issue, user created or when the addon added through vscode debug extension. https://github.com/TheDuckCow/MCprep/issues/338

I'm not sure about adding reset path for consistency.