### PR TITLE
Added OBJ header parsing to determine feature compatibility

### DIFF
--- a/MCprep_addon/conf.py
+++ b/MCprep_addon/conf.py
@@ -31,45 +31,6 @@ except:
 # ADDON GLOBAL VARIABLES AND INITIAL SETTINGS
 # -----------------------------------------------------------------------------
 
-
-class ObjHeaderOptions:
-	def __init__(self):
-		self._exporter = None
-		self._file_type = None
-	
-	"""
-	Wrapper functions to avoid typos causing issues
-	"""
-	def set_mineways(self):
-		self._exporter = "Mineways"
-	def set_jmc2obj(self):
-		self._exporter = "jmc2obj"
-
-	def set_atlas(self):
-		self._file_type = "ATLAS"
-	def set_seperated(self):
-		self._file_type = "INDIVIDUAL_TILES"
-
-	"""
-	Determines if the OBJ is compatible with textureswap
-	"""
-	def texture_swap_compatible(self):
-		if self._file_type == "INDIVIDUAL_TILES":
-			return True
-		return False
-
-	"""
-	Returns the exporter used
-	"""
-	def exporter(self):
-		return self._exporter if self._exporter is not None else "(choose)"
-
-	"""
-	Returns the type of textures
-	"""
-	def texture_type(self):
-		return self._file_type if self._file_type is not None else "NONE"
-
 def init():
 
 	# -----------------------------------------------
@@ -124,9 +85,6 @@ def init():
 	use_icons = True
 	global preview_collections
 	preview_collections = {}
-
-	global obj_header
-	obj_header = ObjHeaderOptions()
 
 	# -----------------------------------------------
 	# For initializing the custom icons

--- a/MCprep_addon/conf.py
+++ b/MCprep_addon/conf.py
@@ -32,6 +32,44 @@ except:
 # -----------------------------------------------------------------------------
 
 
+class ObjHeaderOptions:
+	def __init__(self):
+		self._exporter = None
+		self._file_type = None
+	
+	"""
+	Wrapper functions to avoid typos causing issues
+	"""
+	def set_mineways(self):
+		self._exporter = "Mineways"
+	def set_jmc2obj(self):
+		self._exporter = "jmc2obj"
+
+	def set_atlas(self):
+		self._file_type = "ATLAS"
+	def set_seperated(self):
+		self._file_type = "INDIVIDUAL_TILES"
+
+	"""
+	Determines if the OBJ is compatible with textureswap
+	"""
+	def texture_swap_compatible(self):
+		if self._file_type == "INDIVIDUAL_TILES":
+			return True
+		return False
+
+	"""
+	Returns the exporter used
+	"""
+	def exporter(self):
+		return self._exporter if self._exporter is not None else "(choose)"
+
+	"""
+	Returns the type of textures
+	"""
+	def texture_type(self):
+		return self._file_type if self._file_type is not None else "NONE"
+
 def init():
 
 	# -----------------------------------------------
@@ -86,6 +124,9 @@ def init():
 	use_icons = True
 	global preview_collections
 	preview_collections = {}
+
+	global obj_header
+	obj_header = ObjHeaderOptions()
 
 	# -----------------------------------------------
 	# For initializing the custom icons

--- a/MCprep_addon/materials/prep.py
+++ b/MCprep_addon/materials/prep.py
@@ -130,25 +130,11 @@ def draw_mats_common(self, context):
 		col.prop(self, "usePrincipledShader")
 	col.prop(self, "useReflections")
 	col.prop(self, "makeSolid")
-	if len(context.selected_objects):
-		file_types = {
-			"ATLAS" : 0,
-			"INDIVIDUAL" : 0
-		}
-		for obj in context.selected_objects:
-			# If the header exists then we should be fine
-			if obj["MCPREP_OBJ_HEADER"] is not None:
-				if obj["MCPREP_OBJ_FILE_TYPE"] == "ATLAS":
-					file_types["ATLAS"] += 1
-				else:
-					file_types["INDIVIDUAL"] += 1
-			else:
-				# Perform early return, though this causes undefined behavior in edge cases where one object may have the header property and another may not
-				col.prop(self, "animateTextures")
-		if file_types["ATLAS"] == 0:
-			col.prop(self, "animateTextures")
+		
+	if util.isTextureSwapCompatible(context):
+		col.prop(self, "animateTextures")
 
-		col.prop(self, "autoFindMissingTextures")
+	col.prop(self, "autoFindMissingTextures")
 
 	row = self.layout.row()
 	row.prop(self, "useExtraMaps")
@@ -409,23 +395,7 @@ class MCPREP_OT_swap_texture_pack(
 	def poll(cls, context):
 		addon_prefs = util.get_user_preferences(context)
 		if addon_prefs.MCprep_exporter_type != "(choose)":
-			if len(context.selected_objects):
-				file_types = {
-					"ATLAS" : 0,
-					"INDIVIDUAL" : 0
-				}
-				for obj in context.selected_objects:
-					# If the header exists then we should be fine
-					if obj["MCPREP_OBJ_HEADER"] is not None:
-						if obj["MCPREP_OBJ_FILE_TYPE"] == "ATLAS":
-							file_types["ATLAS"] += 1
-						else:
-							file_types["INDIVIDUAL"] += 1
-					else:
-						# Perform early return, though this causes undefined behavior in edge cases where one object may have the header property and another may not
-						return True 
-				if file_types["ATLAS"] == 0:
-					return True
+			return util.isTextureSwapCompatible(context)
 		return False
 
 	def draw(self, context):

--- a/MCprep_addon/materials/prep.py
+++ b/MCprep_addon/materials/prep.py
@@ -133,7 +133,6 @@ def draw_mats_common(self, context):
 		
 	if util.isTextureSwapCompatible(context):
 		col.prop(self, "animateTextures")
-
 	col.prop(self, "autoFindMissingTextures")
 
 	row = self.layout.row()

--- a/MCprep_addon/materials/prep.py
+++ b/MCprep_addon/materials/prep.py
@@ -391,7 +391,9 @@ class MCPREP_OT_swap_texture_pack(
 	@classmethod
 	def poll(cls, context):
 		addon_prefs = util.get_user_preferences(context)
-		return addon_prefs.MCprep_exporter_type != "(choose)"
+		if addon_prefs.MCprep_exporter_type != "(choose)":
+			return conf.obj_header.texture_swap_compatible()
+		return False
 
 	def draw(self, context):
 		row = self.layout.row()

--- a/MCprep_addon/materials/prep.py
+++ b/MCprep_addon/materials/prep.py
@@ -130,9 +130,14 @@ def draw_mats_common(self, context):
 		col.prop(self, "usePrincipledShader")
 	col.prop(self, "useReflections")
 	col.prop(self, "makeSolid")
-		
-	if util.isTextureSwapCompatible(context):
-		col.prop(self, "animateTextures")
+
+	anim_row = col.row()
+	can_swap_text = util.is_atlas_export(context)
+	anim_row.enabled = can_swap_text
+	if can_swap_text:
+		anim_row.prop(self, "animateTextures")
+	else:
+		anim_row.prop(self, "animateTextures", text="Animate textures (disabled due to import settings)")
 	col.prop(self, "autoFindMissingTextures")
 
 	row = self.layout.row()
@@ -394,7 +399,7 @@ class MCPREP_OT_swap_texture_pack(
 	def poll(cls, context):
 		addon_prefs = util.get_user_preferences(context)
 		if addon_prefs.MCprep_exporter_type != "(choose)":
-			return util.isTextureSwapCompatible(context)
+			return util.is_atlas_export(context)
 		return False
 
 	def draw(self, context):

--- a/MCprep_addon/mcprep_ui.py
+++ b/MCprep_addon/mcprep_ui.py
@@ -723,12 +723,12 @@ class MCPREP_PT_world_imports(bpy.types.Panel):
 		col.label(text="MCprep tools")
 		col.operator("mcprep.prep_materials", text="Prep Materials")
 
-		if not util.isTextureSwapCompatible(context):
+		if not util.is_atlas_export(context):
 			row = col.row()
 			row.operator(
 				"mcprep.open_help", text="", icon="QUESTION", emboss=False
 			).url = "https://github.com/StandingPadAnimations/MCprep-Kaion/blob/obj-metadata/docs/common_errors.md#obj-not-exported-with-the-correct-settings-for-textureswap"
-			row.label(text="OBJ not exported with the correct settings for textureswap")
+			row.label(text="OBJ incompatible with textureswap")
 		p = col.operator("mcprep.swap_texture_pack")
 		p.filepath = context.scene.mcprep_texturepack_path
 		if context.mode == "OBJECT":

--- a/MCprep_addon/mcprep_ui.py
+++ b/MCprep_addon/mcprep_ui.py
@@ -722,6 +722,8 @@ class MCPREP_PT_world_imports(bpy.types.Panel):
 		col = split.column(align=True)
 		col.label(text="MCprep tools")
 		col.operator("mcprep.prep_materials", text="Prep Materials")
+		if not conf.obj_header.texture_swap_compatible():
+			col.label(text="OBJ not exported with the correct settings for textureswap")
 		p = col.operator("mcprep.swap_texture_pack")
 		p.filepath = context.scene.mcprep_texturepack_path
 		if context.mode == "OBJECT":

--- a/MCprep_addon/mcprep_ui.py
+++ b/MCprep_addon/mcprep_ui.py
@@ -722,8 +722,13 @@ class MCPREP_PT_world_imports(bpy.types.Panel):
 		col = split.column(align=True)
 		col.label(text="MCprep tools")
 		col.operator("mcprep.prep_materials", text="Prep Materials")
-		if not conf.obj_header.texture_swap_compatible():
-			col.label(text="OBJ not exported with the correct settings for textureswap")
+
+		if len(context.selected_objects):
+			for obj in context.selected_objects:
+				if obj["MCPREP_OBJ_HEADER"] == 1:
+					if obj["MCPREP_OBJ_FILE_TYPE"] == "ATLAS":
+						col.label(text="OBJ not exported with the correct settings for textureswap")
+						break
 		p = col.operator("mcprep.swap_texture_pack")
 		p.filepath = context.scene.mcprep_texturepack_path
 		if context.mode == "OBJECT":

--- a/MCprep_addon/mcprep_ui.py
+++ b/MCprep_addon/mcprep_ui.py
@@ -723,12 +723,8 @@ class MCPREP_PT_world_imports(bpy.types.Panel):
 		col.label(text="MCprep tools")
 		col.operator("mcprep.prep_materials", text="Prep Materials")
 
-		if len(context.selected_objects):
-			for obj in context.selected_objects:
-				if obj["MCPREP_OBJ_HEADER"] == 1:
-					if obj["MCPREP_OBJ_FILE_TYPE"] == "ATLAS":
-						col.label(text="OBJ not exported with the correct settings for textureswap")
-						break
+		if util.isTextureSwapCompatible(context):
+			col.label(text="OBJ not exported with the correct settings for textureswap")
 		p = col.operator("mcprep.swap_texture_pack")
 		p.filepath = context.scene.mcprep_texturepack_path
 		if context.mode == "OBJECT":

--- a/MCprep_addon/mcprep_ui.py
+++ b/MCprep_addon/mcprep_ui.py
@@ -724,7 +724,11 @@ class MCPREP_PT_world_imports(bpy.types.Panel):
 		col.operator("mcprep.prep_materials", text="Prep Materials")
 
 		if not util.isTextureSwapCompatible(context):
-			col.label(text="OBJ not exported with the correct settings for textureswap")
+			row = col.row()
+			row.operator(
+				"mcprep.open_help", text="", icon="QUESTION", emboss=False
+			).url = "https://github.com/StandingPadAnimations/MCprep-Kaion/blob/obj-metadata/docs/common_errors.md#obj-not-exported-with-the-correct-settings-for-textureswap"
+			row.label(text="OBJ not exported with the correct settings for textureswap")
 		p = col.operator("mcprep.swap_texture_pack")
 		p.filepath = context.scene.mcprep_texturepack_path
 		if context.mode == "OBJECT":

--- a/MCprep_addon/mcprep_ui.py
+++ b/MCprep_addon/mcprep_ui.py
@@ -723,7 +723,7 @@ class MCPREP_PT_world_imports(bpy.types.Panel):
 		col.label(text="MCprep tools")
 		col.operator("mcprep.prep_materials", text="Prep Materials")
 
-		if util.isTextureSwapCompatible(context):
+		if not util.isTextureSwapCompatible(context):
 			col.label(text="OBJ not exported with the correct settings for textureswap")
 		p = col.operator("mcprep.swap_texture_pack")
 		p.filepath = context.scene.mcprep_texturepack_path

--- a/MCprep_addon/util.py
+++ b/MCprep_addon/util.py
@@ -220,6 +220,27 @@ def bv30():
 	return min_bv((3, 00))
 
 
+def isTextureSwapCompatible(context):
+	"""Check if the selected objects are textureswap compatible"""
+	if len(context.selected_objects):
+		file_types = {
+			"ATLAS" : 0,
+			"INDIVIDUAL" : 0
+		}
+		for obj in context.selected_objects:
+			# If the header exists then we should be fine
+			if obj["MCPREP_OBJ_HEADER"] is not None:
+				if obj["MCPREP_OBJ_FILE_TYPE"] == "ATLAS":
+					file_types["ATLAS"] += 1
+				else:
+					file_types["INDIVIDUAL"] += 1
+			else:
+				# Perform early return, though this causes undefined behavior in edge cases where one object may have the header property and another may not
+				return True
+		if file_types["ATLAS"] == 0:
+			return True
+		return False
+
 def face_on_edge(faceLoc):
 	"""Check if a face is on the boundary between two blocks (local coordinates)."""
 	face_decimals = [loc - loc // 1 for loc in faceLoc]

--- a/MCprep_addon/util.py
+++ b/MCprep_addon/util.py
@@ -220,26 +220,35 @@ def bv30():
 	return min_bv((3, 00))
 
 
-def isTextureSwapCompatible(context):
-	"""Check if the selected objects are textureswap compatible"""
-	if len(context.selected_objects):
-		file_types = {
-			"ATLAS" : 0,
-			"INDIVIDUAL" : 0
-		}
-		for obj in context.selected_objects:
-			# If the header exists then we should be fine
-			if "MCPREP_OBJ_HEADER" in obj:
-				if obj["MCPREP_OBJ_FILE_TYPE"] == "ATLAS":
-					file_types["ATLAS"] += 1
-				else:
-					file_types["INDIVIDUAL"] += 1
+def is_atlas_export(context):
+	"""Check if the selected objects are textureswap/animate tex compatible.
+
+	Atlas textures are ones where all textures are combined into a single file,
+	while individual textures is where there is one image file per block type.
+
+	Returns a bool. If false, the UI will show a warning and link to doc
+	about using the right settings.
+	"""
+	if not context.selected_objects:
+		# Don't trigger the UI warning just because nothing is selected
+		return True
+
+	file_types = {
+		"ATLAS": 0,
+		"INDIVIDUAL": 0
+	}
+	for obj in context.selected_objects:
+		# If the header exists then we should be fine
+		if "MCPREP_OBJ_HEADER" in obj:
+			if obj["MCPREP_OBJ_FILE_TYPE"] == "ATLAS":
+				file_types["ATLAS"] += 1
 			else:
-				# Perform early return, though this causes undefined behavior in edge cases where one object may have the header property and another may not
-				return True
-		if file_types["ATLAS"] == 0:
-			return True
-	return False
+				file_types["INDIVIDUAL"] += 1
+		else:
+			continue
+
+	return file_types["ATLAS"] == 0
+
 
 def face_on_edge(faceLoc):
 	"""Check if a face is on the boundary between two blocks (local coordinates)."""

--- a/MCprep_addon/util.py
+++ b/MCprep_addon/util.py
@@ -239,7 +239,8 @@ def isTextureSwapCompatible(context):
 				return True
 		if file_types["ATLAS"] == 0:
 			return True
-		return False
+	
+	return False
 
 def face_on_edge(faceLoc):
 	"""Check if a face is on the boundary between two blocks (local coordinates)."""

--- a/MCprep_addon/util.py
+++ b/MCprep_addon/util.py
@@ -229,7 +229,7 @@ def isTextureSwapCompatible(context):
 		}
 		for obj in context.selected_objects:
 			# If the header exists then we should be fine
-			if obj["MCPREP_OBJ_HEADER"] is not None:
+			if "MCPREP_OBJ_HEADER" in obj:
 				if obj["MCPREP_OBJ_FILE_TYPE"] == "ATLAS":
 					file_types["ATLAS"] += 1
 				else:
@@ -239,7 +239,6 @@ def isTextureSwapCompatible(context):
 				return True
 		if file_types["ATLAS"] == 0:
 			return True
-	
 	return False
 
 def face_on_edge(faceLoc):

--- a/MCprep_addon/world_tools.py
+++ b/MCprep_addon/world_tools.py
@@ -394,8 +394,11 @@ class MCPREP_OT_import_world_split(bpy.types.Operator, ImportHelper):
 
 		prefs = util.get_user_preferences(context)
 		detect_world_exporter(self.filepath)
-		print(conf.obj_header.exporter())
 		prefs.MCprep_exporter_type = conf.obj_header.exporter()
+		
+		for obj in context.selected_objects:
+			obj["MCPREP_OBJ_HEADER"] = True
+			obj["MCPREP_OBJ_FILE_TYPE"] = conf.obj_header.texture_type()
 
 		if util.bv28():
 			self.split_world_by_material(context)
@@ -403,7 +406,7 @@ class MCPREP_OT_import_world_split(bpy.types.Operator, ImportHelper):
 		addon_prefs = util.get_user_preferences(context)
 		self.track_exporter = addon_prefs.MCprep_exporter_type  # Soft detect.
 		return {'FINISHED'}
-
+	
 	def obj_name_to_material(self, obj):
 		"""Update an objects name based on its first material"""
 		if not obj:

--- a/MCprep_addon/world_tools.py
+++ b/MCprep_addon/world_tools.py
@@ -18,6 +18,7 @@
 
 import os
 import math
+from pathlib import Path
 
 import bpy
 from bpy_extras.io_utils import ExportHelper, ImportHelper
@@ -316,14 +317,15 @@ class MCPREP_OT_import_world_split(bpy.types.Operator, ImportHelper):
 	@tracking.report_error
 	def execute(self, context):
 		# for consistency with the built in one, only import the active path
+		if self.filepath.lower().endswith(".mtl"):
+			filename = Path(self.filepath)
+			new_filename = filename.with_suffix(".obj")
+			self.filepath = str(new_filename) # Change it from MTL to OBJ, this will be checked with the rest of the if clauses
 		if not self.filepath:
 			self.report({"ERROR"}, "File not found, could not import obj")
 			return {'CANCELLED'}
 		if not os.path.isfile(self.filepath):
 			self.report({"ERROR"}, "File not found, could not import obj")
-			return {'CANCELLED'}
-		if self.filepath.lower().endswith(".mtl"):
-			self.report({"ERROR"}, "Select the .obj file, NOT the .mtl!")
 			return {'CANCELLED'}
 		if not self.filepath.lower().endswith(".obj"):
 			self.report({"ERROR"}, "You must select a .obj file to import")

--- a/MCprep_addon/world_tools.py
+++ b/MCprep_addon/world_tools.py
@@ -62,6 +62,37 @@ def get_time_object():
 
 	return time_obj_cache
 
+class ObjHeaderOptions:
+	def __init__(self):
+		self._exporter = None
+		self._file_type = None
+	
+	"""
+	Wrapper functions to avoid typos causing issues
+	"""
+	def set_mineways(self):
+		self._exporter = "Mineways"
+	def set_jmc2obj(self):
+		self._exporter = "jmc2obj"
+
+	def set_atlas(self):
+		self._file_type = "ATLAS"
+	def set_seperated(self):
+		self._file_type = "INDIVIDUAL_TILES"
+
+	"""
+	Returns the exporter used
+	"""
+	def exporter(self):
+		return self._exporter if self._exporter is not None else "(choose)"
+
+	"""
+	Returns the type of textures
+	"""
+	def texture_type(self):
+		return self._file_type if self._file_type is not None else "NONE"
+
+obj_header = ObjHeaderOptions()
 def detect_world_exporter(filepath):
 	"""Detect whether Mineways or jmc2obj was used, based on prefix info.
 
@@ -83,14 +114,14 @@ def detect_world_exporter(filepath):
 				atlas = re.compile(r'\btextures to three large images|full color texture patterns\b')
 				tiles = re.compile(r'\bexport individual textures|tiles for textures\b')
 				if re.search(atlas, header.lower()) is not None: # If a texture atlas is used
-					conf.obj_header.set_atlas()
+					obj_header.set_atlas()
 				elif re.search(tiles, header.lower()) is not None: # If the OBJ uses individual textures
-					conf.obj_header.set_seperated()
+					obj_header.set_seperated()
 				return
 		except UnicodeDecodeError:
 			print("failed to read first line of obj: " + filepath)
 			return
-		conf.obj_header.set_jmc2obj()
+		obj_header.set_jmc2obj()
 
 # -----------------------------------------------------------------------------
 # open mineways/jmc2obj related
@@ -394,11 +425,11 @@ class MCPREP_OT_import_world_split(bpy.types.Operator, ImportHelper):
 
 		prefs = util.get_user_preferences(context)
 		detect_world_exporter(self.filepath)
-		prefs.MCprep_exporter_type = conf.obj_header.exporter()
+		prefs.MCprep_exporter_type = obj_header.exporter()
 		
 		for obj in context.selected_objects:
 			obj["MCPREP_OBJ_HEADER"] = True
-			obj["MCPREP_OBJ_FILE_TYPE"] = conf.obj_header.texture_type()
+			obj["MCPREP_OBJ_FILE_TYPE"] = obj_header.texture_type()
 
 		if util.bv28():
 			self.split_world_by_material(context)

--- a/MCprep_addon/world_tools.py
+++ b/MCprep_addon/world_tools.py
@@ -18,7 +18,6 @@
 
 import os
 import math
-import re
 
 import bpy
 from bpy_extras.io_utils import ExportHelper, ImportHelper
@@ -104,18 +103,25 @@ def detect_world_exporter(filepath):
 		try:
 			header = obj_fd.readline()
 			if 'mineways' in header.lower():
-				conf.obj_header.set_mineways()
+				obj_header.set_mineways()
 				# form of: # Wavefront OBJ file made by Mineways version 5.10...
 				for line in obj_fd:
 					if line.startswith("# File type:"):
-						header = line
+						header = line.rstrip() # Remove trailing newline
 				
 				# The issue here is that Mineways has changed how the header is generated. As such, we're limited with only a couple of OBJs, some from 2020 and some from 2023, so we'll assume people are using an up to date version.
-				atlas = re.compile(r'\btextures to three large images|full color texture patterns\b')
-				tiles = re.compile(r'\bexport individual textures|tiles for textures\b')
-				if re.search(atlas, header.lower()) is not None: # If a texture atlas is used
+				atlas = (
+					"# File type: Export all textures to three large images",
+					"# File type: Export full color texture patterns"
+				)
+				tiles = (
+					"# File type: Export tiles for textures to directory textures",
+					"# File type: Export individual textures to directory tex"
+				)
+				print(f"\"{header}\"")
+				if header in atlas: # If a texture atlas is used
 					obj_header.set_atlas()
-				elif re.search(tiles, header.lower()) is not None: # If the OBJ uses individual textures
+				elif header in tiles: # If the OBJ uses individual textures
 					obj_header.set_seperated()
 				return
 		except UnicodeDecodeError:

--- a/MCprep_addon/world_tools.py
+++ b/MCprep_addon/world_tools.py
@@ -122,6 +122,7 @@ def detect_world_exporter(filepath):
 			print("failed to read first line of obj: " + filepath)
 			return
 		obj_header.set_jmc2obj()
+		obj_header.set_seperated() # Since this is the default for Jmc2Obj, we'll assume this is what the OBJ is using
 
 # -----------------------------------------------------------------------------
 # open mineways/jmc2obj related

--- a/docs/common_errors.md
+++ b/docs/common_errors.md
@@ -1,0 +1,6 @@
+# Common Error messages and what they mean
+## OBJ not exported with the correct settings for textureswap
+This means the OBJ was exported with incorrect UVs, most commonly UVs for a texture atlas (a giant image with all textures) rather than individual textures. In Mineways, this can be solved by selecting the "Export tiles for textures to directory textures"/"Export individual textures to directory tex" option when exporting, depending on the version. In later versions of Mineways, this should be the default option.
+
+### Why not simply fix the UVs?
+That's a massive pain in the butt to program, not to mention it causes more issues


### PR DESCRIPTION
This PR adds basic Mineways OBJ header parsing to determine feature compatibility for animate texture and textureswap. The header info (at least the info used) is stored as properties on the OBJ, to A. as a form of storage and B. to determine compatibility on a per OBJ basis

If the OBJ is not compatible, then:
* Textureswap is greyed out and a warning is added alerting the user that the OBJ isn't compatible
* Animate textures is removed from the UI