### PR TITLE
Desaturation fix

### DIFF
--- a/MCprep_addon/materials/generate.py
+++ b/MCprep_addon/materials/generate.py
@@ -955,10 +955,8 @@ def set_saturation_material(mat):
 		if len(desat_color) == 3:
 			desat_color += [1]  # add in alpha
 
-		if util.min_bv((3, 4)):
-			sat_node.inputs[6].default_value = desat_color
-		else:
-			sat_node.inputs[2].default_value = desat_color
+		sat_node_in = get_node_socket(node, is_input=True) # Get the node sockets in a version agnostic way	
+		sat_node.inputs[sat_node_in[2]].default_value = desat_color
 		sat_node.mute = not bool(saturate)
 		sat_node.hide = not bool(saturate)
 

--- a/MCprep_addon/materials/generate.py
+++ b/MCprep_addon/materials/generate.py
@@ -954,7 +954,7 @@ def set_saturation_material(mat):
 			return  # requires regenerating material to add back
 		if len(desat_color) == 3:
 			desat_color += [1]  # add in alpha
-		sat_node.inputs[2].default_value = desat_color
+		sat_node.inputs[6].default_value = desat_color
 		sat_node.mute = not bool(saturate)
 		sat_node.hide = not bool(saturate)
 

--- a/MCprep_addon/materials/generate.py
+++ b/MCprep_addon/materials/generate.py
@@ -954,7 +954,11 @@ def set_saturation_material(mat):
 			return  # requires regenerating material to add back
 		if len(desat_color) == 3:
 			desat_color += [1]  # add in alpha
-		sat_node.inputs[6].default_value = desat_color
+
+		if util.min_bv((3, 4)):
+			sat_node.inputs[6].default_value = desat_color
+		else:
+			sat_node.inputs[2].default_value = desat_color
 		sat_node.mute = not bool(saturate)
 		sat_node.hide = not bool(saturate)
 


### PR DESCRIPTION
As mentioned in https://github.com/TheDuckCow/MCprep/issues/368#issuecomment-1438924696, the desaturation bug that's been recently plaguing MCprep for a while is caused by using an incorrect index. This PR should hopefully fix it (fingers crossed, I haven't tested it yet)