### PR TITLE
Set default particle planes folder and fixed emitter material

### DIFF
--- a/MCprep_addon/materials/generate.py
+++ b/MCprep_addon/materials/generate.py
@@ -35,6 +35,10 @@ def update_mcprep_texturepack_path(self, context):
 	bpy.ops.mcprep.reload_models()
 	conf.material_sync_cache = None
 
+	# Forces particle plane emitter to now use the newly set resource pack
+	# the first time, but the value gets saved again after.
+	context.scene.mcprep_particle_plane_file = ''
+
 
 def get_mc_canonical_name(name):
 	"""Convert a material name to standard MC name.

--- a/MCprep_addon/mcprep_ui.py
+++ b/MCprep_addon/mcprep_ui.py
@@ -1546,18 +1546,23 @@ def effects_spawner(self, context):
 	ops.location = util.get_cuser_location(context)
 	ops.frame = context.scene.frame_current
 
-	initial_sel = os.path.join(
-		context.scene.mcprep_texturepack_path,
-		"assets", "minecraft", "textures", "block", "dirt.png")
-	alt_sel = os.path.join(
-		context.scene.mcprep_texturepack_path,
-		"assets", "minecraft", "textures", "block")
-	if os.path.isfile(initial_sel):
-		ops.filepath = initial_sel
-	elif os.path.isdir(alt_sel):
-		ops.filepath = alt_sel
+	# If particle planes has not been changed yet this session,
+	# use the texture pack location in
+	if not context.scene.mcprep_particle_plane_file:
+		initial_sel = os.path.join(
+			context.scene.mcprep_texturepack_path,
+			"assets", "minecraft", "textures", "block", "dirt.png")
+		alt_sel = os.path.join(
+			context.scene.mcprep_texturepack_path,
+			"assets", "minecraft", "textures", "block")
+		if os.path.isfile(initial_sel):
+			ops.filepath = initial_sel
+		elif os.path.isdir(alt_sel):
+			ops.filepath = alt_sel
+		else:
+			ops.filepath = context.scene.mcprep_texturepack_path
 	else:
-		ops.filepath = context.scene.mcprep_texturepack_path
+		ops.filepath = context.scene.mcprep_particle_plane_file
 
 	col = layout.column()
 	if not scn_props.show_settings_effect:
@@ -1575,6 +1580,11 @@ def effects_spawner(self, context):
 		subrow = b_col.row(align=True)
 		subrow.prop(context.scene, "mcprep_effects_path", text="")
 		subrow.operator("mcprep.effects_path_reset", icon=LOAD_FACTORY, text="")
+
+		box.label(text="Texture pack folder")
+		row = box.row(align=True)
+		row.prop(context.scene, "mcprep_texturepack_path", text="")
+		row.operator("mcprep.reset_texture_path", text="", icon=LOAD_FACTORY)
 
 		base = bpy.path.abspath(context.scene.mcprep_effects_path)
 		if not os.path.isdir(base):
@@ -1953,6 +1963,11 @@ def register():
 		subtype='DIR_PATH',
 		update=effects.update_effects_path,
 		default=addon_prefs.effects_path)
+	bpy.types.Scene.mcprep_particle_plane_file = bpy.props.StringProperty(
+		name="Particle planes file set",
+		description="Has the particle planes file been changed",
+		subtype='FILE_PATH',
+		default='')
 	bpy.types.Scene.entity_path = bpy.props.StringProperty(
 		name="Entity file",
 		description="File for entity library",

--- a/MCprep_addon/mcprep_ui.py
+++ b/MCprep_addon/mcprep_ui.py
@@ -1546,6 +1546,19 @@ def effects_spawner(self, context):
 	ops.location = util.get_cuser_location(context)
 	ops.frame = context.scene.frame_current
 
+	initial_sel = os.path.join(
+		context.scene.mcprep_texturepack_path,
+		"assets", "minecraft", "textures", "block", "dirt.png")
+	alt_sel = os.path.join(
+		context.scene.mcprep_texturepack_path,
+		"assets", "minecraft", "textures", "block")
+	if os.path.isfile(initial_sel):
+		ops.filepath = initial_sel
+	elif os.path.isdir(alt_sel):
+		ops.filepath = alt_sel
+	else:
+		ops.filepath = context.scene.mcprep_texturepack_path
+
 	col = layout.column()
 	if not scn_props.show_settings_effect:
 		col.prop(

--- a/MCprep_addon/spawner/effects.py
+++ b/MCprep_addon/spawner/effects.py
@@ -1196,6 +1196,8 @@ class MCPREP_OT_spawn_particle_planes(bpy.types.Operator, ImportHelper):
 			bpy.ops.mcprep.prompt_reset_spawners('INVOKE_DEFAULT')
 			return {'CANCELLED'}
 
+		context.scene.mcprep_particle_plane_file = self.filepath
+
 		self.track_param = name
 		return {'FINISHED'}
 

--- a/MCprep_addon/spawner/effects.py
+++ b/MCprep_addon/spawner/effects.py
@@ -372,6 +372,22 @@ def add_particle_planes_effect(context, image_path, location, frame):
 	pcoll = get_or_create_particle_meshes_coll(
 		context, f_name, img)
 
+	# Set the material for the emitter object. Though not actually rendered,
+	# this helps clarify which particle is being emitted from this object.
+	mat = None
+	for ob in pcoll.objects:
+		if ob.material_slots and ob.material_slots[0].material:
+			mat = ob.material_slots[0].material
+			break
+	if mat:
+		if not obj.material_slots:
+			obj.data.materials.append(mat)
+		# Must use 'OBEJCT' instead of mesh data, otherwise all particle
+		# emitters will have the same material (how it was initially working)
+		obj.material_slots[0].link = 'OBJECT'
+		obj.material_slots[0].material = mat
+		print("Linked {} with {}".format(obj.name, mat.name))
+
 	apply_particle_settings(obj, frame, base_name, pcoll)
 
 
@@ -600,7 +616,7 @@ def apply_particle_settings(obj, frame, base_name, pcoll):
 	psystem.settings.lifetime_random = 0.2
 	psystem.settings.emit_from = 'FACE'
 	psystem.settings.distribution = 'RAND'
-	psystem.settings.normal_factor = -1.5
+	psystem.settings.normal_factor = 1.5
 	psystem.settings.use_rotations = True
 	psystem.settings.rotation_factor_random = 1
 	psystem.settings.particle_size = 0.2


### PR DESCRIPTION
Set default particle planes folder, fixed emitter material, and now updated folder for particle planes is remembered.

Added scene variable `mcprep_particle_plane_file` which is initially unset, only assigned after a confirmed, non-cancelled particle plane effect placement.