### PR TITLE
Code compatibility cleanup

### DIFF
--- a/MCprep_addon/mcprep_ui.py
+++ b/MCprep_addon/mcprep_ui.py
@@ -768,15 +768,16 @@ class MCPREP_PT_world_imports(bpy.types.Panel):
 			col.operator(
 				"mcprep.improve_ui", text="Improve UI", icon='SETTINGS')
 
-		# Optimizer Panel.
-		row = col.row(align=True)
-		icon = "TRIA_DOWN" if scn_props.show_settings_optimizer else "TRIA_RIGHT"
-		row.prop(
-			scn_props, "show_settings_optimizer",
-			text="Cycles Optimizer", icon=icon)
-		if scn_props.show_settings_optimizer:
+		# Optimizer Panel (only for blender 2.80+)
+		if util.min_bv((2, 80)):
 			row = col.row(align=True)
-			optimize_scene.panel_draw(context, row)
+			icon = "TRIA_DOWN" if scn_props.show_settings_optimizer else "TRIA_RIGHT"
+			row.prop(
+				scn_props, "show_settings_optimizer",
+				text="Cycles Optimizer", icon=icon)
+			if scn_props.show_settings_optimizer:
+				row = col.row(align=True)
+				optimize_scene.panel_draw(context, row)
 
 		# Advanced settings.
 		row = col.row(align=True)

--- a/MCprep_addon/world_tools.py
+++ b/MCprep_addon/world_tools.py
@@ -36,6 +36,7 @@ from .materials import generate
 
 time_obj_cache = None
 
+
 def get_time_object():
 	"""Returns the time object if present in the file"""
 	global time_obj_cache  # to avoid re parsing every time
@@ -62,21 +63,23 @@ def get_time_object():
 
 	return time_obj_cache
 
+
 class ObjHeaderOptions:
+	"""Wrapper functions to avoid typos causing issues."""
+
 	def __init__(self):
 		self._exporter = None
 		self._file_type = None
-	
-	"""
-	Wrapper functions to avoid typos causing issues
-	"""
+
 	def set_mineways(self):
 		self._exporter = "Mineways"
+
 	def set_jmc2obj(self):
 		self._exporter = "jmc2obj"
 
 	def set_atlas(self):
 		self._file_type = "ATLAS"
+
 	def set_seperated(self):
 		self._file_type = "INDIVIDUAL_TILES"
 
@@ -92,7 +95,10 @@ class ObjHeaderOptions:
 	def texture_type(self):
 		return self._file_type if self._file_type is not None else "NONE"
 
+
 obj_header = ObjHeaderOptions()
+
+
 def detect_world_exporter(filepath):
 	"""Detect whether Mineways or jmc2obj was used, based on prefix info.
 
@@ -108,9 +114,12 @@ def detect_world_exporter(filepath):
 				# form of: # Wavefront OBJ file made by Mineways version 5.10...
 				for line in obj_fd:
 					if line.startswith("# File type:"):
-						header = line.rstrip() # Remove trailing newline
-				
-				# The issue here is that Mineways has changed how the header is generated. As such, we're limited with only a couple of OBJs, some from 2020 and some from 2023, so we'll assume people are using an up to date version.
+						header = line.rstrip()  # Remove trailing newline
+
+				# The issue here is that Mineways has changed how the header is generated.
+				# As such, we're limited with only a couple of OBJs, some from
+				# 2020 and some from 2023, so we'll assume people are using
+				# an up to date version.
 				atlas = (
 					"# File type: Export all textures to three large images",
 					"# File type: Export full color texture patterns"
@@ -119,17 +128,19 @@ def detect_world_exporter(filepath):
 					"# File type: Export tiles for textures to directory textures",
 					"# File type: Export individual textures to directory tex"
 				)
-				print(f"\"{header}\"")
-				if header in atlas: # If a texture atlas is used
+				print('"{}"'.format(header))
+				if header in atlas:  # If a texture atlas is used
 					obj_header.set_atlas()
-				elif header in tiles: # If the OBJ uses individual textures
+				elif header in tiles:  # If the OBJ uses individual textures
 					obj_header.set_seperated()
 				return
 		except UnicodeDecodeError:
 			print("failed to read first line of obj: " + filepath)
 			return
 		obj_header.set_jmc2obj()
-		obj_header.set_seperated() # Since this is the default for Jmc2Obj, we'll assume this is what the OBJ is using
+		# Since this is the default for Jmc2Obj,
+		# we'll assume this is what the OBJ is using
+		obj_header.set_seperated()
 
 # -----------------------------------------------------------------------------
 # open mineways/jmc2obj related
@@ -320,7 +331,8 @@ class MCPREP_OT_import_world_split(bpy.types.Operator, ImportHelper):
 		if self.filepath.lower().endswith(".mtl"):
 			filename = Path(self.filepath)
 			new_filename = filename.with_suffix(".obj")
-			self.filepath = str(new_filename) # Change it from MTL to OBJ, this will be checked with the rest of the if clauses
+			# Auto change from MTL to OBJ, latet if's will check if existing.
+			self.filepath = str(new_filename)
 		if not self.filepath:
 			self.report({"ERROR"}, "File not found, could not import obj")
 			return {'CANCELLED'}
@@ -359,10 +371,10 @@ class MCPREP_OT_import_world_split(bpy.types.Operator, ImportHelper):
 			res = None
 			if util.min_bv((3, 5)):
 				res = bpy.ops.wm.obj_import(
-					filepath=self.filepath, use_split_groups=True) 
+					filepath=self.filepath, use_split_groups=True)
 			else:
 				res = bpy.ops.import_scene.obj(
-					filepath=self.filepath, use_split_groups=True)	
+					filepath=self.filepath, use_split_groups=True)
 		except MemoryError as err:
 			print("Memory error during import OBJ:")
 			print(err)
@@ -440,7 +452,7 @@ class MCPREP_OT_import_world_split(bpy.types.Operator, ImportHelper):
 		prefs = util.get_user_preferences(context)
 		detect_world_exporter(self.filepath)
 		prefs.MCprep_exporter_type = obj_header.exporter()
-		
+
 		for obj in context.selected_objects:
 			obj["MCPREP_OBJ_HEADER"] = True
 			obj["MCPREP_OBJ_FILE_TYPE"] = obj_header.texture_type()
@@ -451,7 +463,7 @@ class MCPREP_OT_import_world_split(bpy.types.Operator, ImportHelper):
 		addon_prefs = util.get_user_preferences(context)
 		self.track_exporter = addon_prefs.MCprep_exporter_type  # Soft detect.
 		return {'FINISHED'}
-	
+
 	def obj_name_to_material(self, obj):
 		"""Update an objects name based on its first material"""
 		if not obj:
@@ -527,9 +539,12 @@ class MCPREP_OT_prep_world(bpy.types.Operator):
 
 		if "mcprep_world" not in context.scene.world:
 			world_nodes.clear()
-			skynode = generate.create_node(world_nodes, "ShaderNodeTexSky", location = (-280, 300))
-			background = generate.create_node(world_nodes, "ShaderNodeBackground", location = (10, 300))
-			output = generate.create_node(world_nodes, "ShaderNodeOutputWorld", location = (300, 300))
+			skynode = generate.create_node(
+				world_nodes, "ShaderNodeTexSky", location=(-280, 300))
+			background = generate.create_node(
+				world_nodes, "ShaderNodeBackground", location=(10, 300))
+			output = generate.create_node(
+				world_nodes, "ShaderNodeOutputWorld", location=(300, 300))
 			world_links.new(skynode.outputs["Color"], background.inputs[0])
 			world_links.new(background.outputs["Background"], output.inputs[0])
 
@@ -559,11 +574,16 @@ class MCPREP_OT_prep_world(bpy.types.Operator):
 
 		if "mcprep_world" not in context.scene.world:
 			world_nodes.clear()
-			light_paths = generate.create_node(world_nodes, "ShaderNodeLightPath", location = (-150, 400))
-			background_camera = generate.create_node(world_nodes, "ShaderNodeBackground", location = (10, 150))
-			background_others = generate.create_node(world_nodes, "ShaderNodeBackground", location = (10, 300))
-			mix_shader =generate.create_node(world_nodes, "ShaderNodeMixShader", location = (300, 300))
-			output = generate.create_node(world_nodes, "ShaderNodeOutputWorld", location = (500, 300))
+			light_paths = generate.create_node(
+				world_nodes, "ShaderNodeLightPath", location=(-150, 400))
+			background_camera = generate.create_node(
+				world_nodes, "ShaderNodeBackground", location=(10, 150))
+			background_others = generate.create_node(
+				world_nodes, "ShaderNodeBackground", location=(10, 300))
+			mix_shader = generate.create_node(
+				world_nodes, "ShaderNodeMixShader", location=(300, 300))
+			output = generate.create_node(
+				world_nodes, "ShaderNodeOutputWorld", location=(500, 300))
 			background_others.inputs["Color"].default_value = (0.14965, 0.425823, 1, 1)
 			background_others.inputs["Strength"].default_value = 0.1
 			background_camera.inputs["Color"].default_value = (0.14965, 0.425823, 1, 1)
@@ -890,8 +910,9 @@ class MCPREP_OT_add_mc_sky(bpy.types.Operator):
 		if time_obj_cache:
 			try:
 				util.obj_unlink_remove(time_obj_cache, True, context)
-			except:
+			except Exception as e:
 				print("Error, could not unlink time_obj_cache " + str(time_obj_cache))
+				print(e)
 
 		time_obj_cache = None  # force reset to use newer cache object
 

--- a/MCprep_addon/world_tools.py
+++ b/MCprep_addon/world_tools.py
@@ -1026,24 +1026,6 @@ class MCPREP_OT_time_set(bpy.types.Operator):
 		return {'FINISHED'}
 
 
-def world_time_update(self, context):
-	"""Handler which updates the current world time on a frame change.
-
-	Maybe don't need this in favor of using a driver for simplicity
-	"""
-
-	time = context.scene.mcprep_props.world_time
-
-	# translate time into rotation of sun/moon rig
-	# see: http://minecraft.gamepedia.com/Day-night_cycle
-	# set to the armature.... would be even better if it was somehow driver-set.
-
-	# if real python code requried to set this up, generate and auto-run python
-	# script, though more ideally just set drivers based on the time param
-
-	return
-
-
 class MCPREP_OT_render_helper():
 	render_queue = []
 	render_queue_cleanup = []


### PR DESCRIPTION
Addressed a few things to improve:

- Removed an f-string reference (invalid syntax in blender 2.7's version of python)
- Disabled the cycles optimizer for blender 2.7 (the draw function wasn't working even due to missing icon names, so nobody could have been using it so far there anyways; I did not address an issue where it doesn't seem to work in Blender 2.80, but is fine in 2.90)
- General style improvements in the files touched, mostly whitespaces.