### PR TITLE
Edit sync file button and using json lookup for sync mats.

### DIFF
--- a/MCprep_addon/mcprep_ui.py
+++ b/MCprep_addon/mcprep_ui.py
@@ -805,7 +805,10 @@ class MCPREP_PT_world_imports(bpy.types.Panel):
 
 			b_row = box.row()
 			b_col = b_row.column(align=True)
-			b_col.operator("mcprep.sync_materials")
+			sync_row = b_col.row(align=True)
+			sync_row.operator("mcprep.sync_materials")
+			sync_row.operator(
+				"mcprep.edit_sync_materials_file", text="", icon="FILE_TICK") # or TOOL_SETTINGS.
 			b_col.operator("mcprep.replace_missing_textures")
 			b_col.operator("mcprep.animate_textures")
 			# TODO: operator to make all local, all packed, or set to other location


### PR DESCRIPTION
This greatly improves the usability of the sync materials function, as users can now easily open to edit the sync file (matching their resource pack), as well as use the MCprep built in generate materials function and still have the material lookups match from their imported OBJs.

Before this change, materials had to be exact matches, and there was no easy way to get to the sync material file or to create your own sync file for a custom resource pack without very manual steps.