### PR TITLE
Fix MTL conversion bug with Mineways MTLs

### DIFF
--- a/MCprep_addon/world_tools.py
+++ b/MCprep_addon/world_tools.py
@@ -170,8 +170,13 @@ def convert_mtl(filepath):
 	mtl = filepath.rsplit(".", 1)[0] + '.mtl'
 	lines = None
 	copied_file = None
-	with open(mtl, 'r') as mtl_file:
-		lines = mtl_file.readlines()
+
+	try:
+		with open(mtl, 'r') as mtl_file:
+			lines = mtl_file.readlines()
+	except Exception as e:
+		print(e)
+		return False
 
 	if bpy.context.scene.view_settings.view_transform in BUILTIN_SPACES:
 		return None


### PR DESCRIPTION
There's been a issue recently where Mineways will name MTLs weirdly. For
instance:
	- "Beach Town.obj" : "Beach_Town.mtl"
	- "hello there.obj" : "hello_there.mtl"

The MTL conversion function simply replaces the extension of
self.filepath, assuming that the MTL has the same name. However, since
Mineways adds underscores, convert_mtl would throw an exception when
attempting to read the file. The current workarounds are to:
	- Remove the underscores
	- Don't add spaces to OBJ names (ideally no one should be adding
	  spaces to any filename because of issues like this)
	- Use jmc2OBJ, which as far as I know doesn't have this weird
	  behavior

This is more of a band-aid, and ideally we should check for underscores
in the MTL name (we can take advantage of pathlib for this), but for now
if an exception occurs due to a weirdly named MTL, we'll just print the
error, return False, and call it a day.