### PR TITLE
Moving to use more generic texture importing for models.

### DIFF
--- a/MCprep_addon/materials/prep.py
+++ b/MCprep_addon/materials/prep.py
@@ -595,7 +595,7 @@ class MCPREP_OT_load_material(bpy.types.Operator, McprepMaterialProps):
 			# need to create at least one texture node first, then the rest works
 			mat.use_nodes = True
 			nodes = mat.node_tree.nodes
-			node_diff = generate.create_node(nodes, 'ShaderNodeTexImage', image = image)
+			node_diff = generate.create_node(nodes, 'ShaderNodeTexImage', image=image)
 			node_diff["MCPREP_diffuse"] = True
 
 			# Initialize extra passes as well

--- a/test_files/addon_tests.py
+++ b/test_files/addon_tests.py
@@ -1567,15 +1567,23 @@ class mcprep_testing():
 			return "Too few models loaded, missing texturepack?"
 
 		# spawn with whatever default index
-		pre_objs = len(bpy.data.objects)
+		pre_objs = list(bpy.data.objects)
 		bpy.ops.mcprep.spawn_model(
 			filepath=scn_props.model_list[scn_props.model_list_index].filepath)
-		post_objs = len(bpy.data.objects)
+		post_objs = bpy.data.objects
 
-		if post_objs == pre_objs:
+		if len(post_objs) == len(pre_objs):
 			return "No models spawned"
-		elif post_objs > pre_objs + 1:
+		elif len(post_objs) > len(pre_objs) + 1:
 			return "More than one model spawned"
+
+		# Test that materials were properly added.
+		new_objs = list(set(post_objs) - set(pre_objs))
+		model = new_objs[0]
+		if not model.active_material:
+			return "No material on model"
+
+		# TODO: fetch/check there being a texture.
 
 		# Test collection/group added
 		# Test loading from file.


### PR DESCRIPTION
Reusing the general purpose operator for generating materials. It does not expose the setting values for all of the ways to load the material, we can think more about that in a future release where there is texture pack stacking and potentially scene-level settings for the prep settings (as opposed to forcing a popup per each use ahead of time).


All tests pass, reran for just the model importing tests:

```
blender	failed_test	short_err
(3, 5, 0)	ALL PASSED	-
(3, 4, 0)	ALL PASSED	-
(3, 2, 1)	ALL PASSED	-
(3, 3, 1)	ALL PASSED	-
(3, 1, 0)	ALL PASSED	-
(3, 0, 0)	ALL PASSED	-
(2, 93, 0)	ALL PASSED	-
(2, 90, 1)	ALL PASSED	-
(2, 80, 75)	ALL PASSED	-
```