### PR TITLE
MCprep 3.5 Rewritten Core

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@ MCprep_addon/mcprep_addon_updater/MCprep_addon_updater_status.json
 blender_execs.txt
 blender_installs.txt
 build
-mcprep_venv
 test_results.tsv
 debug_save_state.blend1
 MCprep_addon/MCprep_resources/resourcepacks/mcprep_default/materials.blend1
+mcprep_venv_*

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ MCprep_addon/mcprep_addon_updater/MCprep_addon_updater_status.json
 blender_execs.txt
 blender_installs.txt
 build
+mcprep_venv
 test_results.tsv
 debug_save_state.blend1
 MCprep_addon/MCprep_resources/resourcepacks/mcprep_default/materials.blend1

--- a/MCprep_addon/__init__.py
+++ b/MCprep_addon/__init__.py
@@ -60,7 +60,6 @@ else:
 
 import bpy
 
-
 def register():
 	load_modules.register(bl_info)
 

--- a/MCprep_addon/addon_updater_ops.py
+++ b/MCprep_addon/addon_updater_ops.py
@@ -1357,7 +1357,8 @@ classes = (
 def register(bl_info):
 	"""Registering the operators in this module"""
 	from . import conf
-	updater.verbose = conf.v
+	env = conf.MCprepEnv()
+	updater.verbose = conf.env
 
 	# safer failure in case of issue loading module
 	if updater.error != None:

--- a/MCprep_addon/addon_updater_ops.py
+++ b/MCprep_addon/addon_updater_ops.py
@@ -1357,8 +1357,8 @@ classes = (
 def register(bl_info):
 	"""Registering the operators in this module"""
 	from . import conf
-	env = conf.MCprepEnv()
-	updater.verbose = conf.env
+	from .conf import ENV
+	updater.verbose = ENV.verbose
 
 	# safer failure in case of issue loading module
 	if updater.error != None:

--- a/MCprep_addon/conf.py
+++ b/MCprep_addon/conf.py
@@ -141,12 +141,18 @@ class MCprepEnv:
 				os.path.join(icons_dir, "model_icon.png"),
 				'IMAGE')
 		except Exception as e:
-			log("Old verison of blender, no custom icons available")
-			log("\t" + str(e))
+			self.log("Old verison of blender, no custom icons available")
+			self.log("\t" + str(e))
 			global use_icons
 			self.use_icons = False
 			for iconset in collection_sets:
 				self.preview_collections[iconset] = ""
+    
+	def log(self, statement, vv_only=False):
+		if self.verbose and vv_only and self.very_verbose:
+			print(statement)
+		elif self.verbose:
+			print(statement)
 
 ENV = MCprepEnv(dev_build=True, verbose=True)
 
@@ -310,6 +316,7 @@ def icons_init():
 		for iconset in collection_sets:
 			preview_collections[iconset] = ""
 
+# ! Deprecated as of MCprep 3.4.2
 def log(statement, vv_only=False):
     if ENV.verbose and vv_only and ENV.very_verbose:
         print(statement)

--- a/MCprep_addon/conf.py
+++ b/MCprep_addon/conf.py
@@ -44,6 +44,7 @@ class MCprepEnv:
 		self.verbose = verbose
 		self.very_verbose = dev_build
 
+		self.data = None
 		self.json_data = None
 		self.json_path = os.path.join(
 						os.path.dirname(__file__),
@@ -157,7 +158,7 @@ class MCprepEnv:
 def init():
 
 	# -----------------------------------------------
-	# Verbose, use as conf.v
+	# Verbose, use as env.verbose
 	# Used to print out extra information, set false with distribution
 	# -----------------------------------------------
 	# ! Deprecated as of MCprep 3.4.2

--- a/MCprep_addon/conf.py
+++ b/MCprep_addon/conf.py
@@ -57,9 +57,9 @@ class MCprepEnv:
 
 		# if new update file found from install, replace old one with new
 		if os.path.isfile(self.json_path_update):
-			if os.path.isfile(json_path) is True:
-				os.remove(json_path)
-			os.rename(self.json_path_update, json_path)
+			if os.path.isfile(self.json_path) is True:
+				os.remove(self.json_path)
+			os.rename(self.json_path_update, self.json_path)
 
 		# lazy load json, ie only load it when needed (util function defined)
 
@@ -317,7 +317,7 @@ def log(statement, vv_only=False):
     env = MCprepEnv()
     if env.verbose and vv_only and env.very_verbose:
         print(statement)
-    elif v:
+    elif env.verbose:
         print(statement)
 
 def updater_select_link_function(self, tag):

--- a/MCprep_addon/conf.py
+++ b/MCprep_addon/conf.py
@@ -17,7 +17,7 @@
 # ##### END GPL LICENSE BLOCK #####
 
 import os
-
+from pathlib import Path
 import bpy
 
 # check if custom preview icons available
@@ -33,27 +33,18 @@ except:
 
 class MCprepEnv:
 	def __init__(self, dev_build=False, verbose=False):
-		self.dev_build = dev_build
-		self.verbose = verbose
-		self.very_verbose = dev_build
+		self.dev_build: bool = dev_build
+		self.verbose: bool = verbose
+		self.very_verbose: bool = dev_build
 
 		self.data = None
 		self.json_data = None
-		self.json_path = os.path.join(
-						os.path.dirname(__file__),
-						"MCprep_resources",
-						"mcprep_data.json")
-
-		self.json_path_update = os.path.join(
-							os.path.dirname(__file__),
-							"MCprep_resources",
-							"mcprep_data_update.json")
+		self.json_path: Path = Path(os.path.dirname(__file__), "MCprep_resources", "mcprep_data.json")
+		self.json_path_update: Path = Path(os.path.dirname(__file__), "MCprep_resources", "mcprep_data_update.json")
 
 		# if new update file found from install, replace old one with new
-		if os.path.isfile(self.json_path_update):
-			if os.path.isfile(self.json_path) is True:
-				os.remove(self.json_path)
-			os.rename(self.json_path_update, self.json_path)
+		if self.json_path_update.exists():
+			self.json_path_update.replace(self.json_path)
 
 		# lazy load json, ie only load it when needed (util function defined)
 
@@ -61,8 +52,8 @@ class MCprepEnv:
 		# For preview icons
 		# -----------------------------------------------
 
-		self.use_icons = True
-		self.preview_collections = {}
+		self.use_icons: bool = True
+		self.preview_collections: dict = {}
 
 		# -----------------------------------------------
 		# For initializing the custom icons
@@ -76,11 +67,11 @@ class MCprepEnv:
 		# To ensure shift-A starts drawing sub menus after pressing load all spawns
 		# as without this, if any one of the spawners loads nothing (invalid folder,
 		# no blend files etc), then it would continue to ask to reload spanwers.
-		self.loaded_all_spawners = False
+		self.loaded_all_spawners: bool = False
 
-		self.skin_list = []  # each is: [ basename, path ]
-		self.rig_categories = []  # simple list of directory names
-		self.entity_list = []
+		self.skin_list: list = []  # each is: [ basename, path ]
+		self.rig_categories: list = []  # simple list of directory names
+		self.entity_list: list = []
 
 		# -----------------------------------------------
 		# Matieral sync cahce, to avoid repeat lib reads
@@ -97,16 +88,12 @@ class MCprepEnv:
 
 
 	def icons_init(self):
-		# start with custom icons
-		# put into a try statement in case older blender version!
-		global preview_collections
-
 		collection_sets = [
 			"main", "skins", "mobs", "entities", "blocks", "items", "effects", "materials"]
 
 		try:
 			for iconset in collection_sets:
-				preview_collections[iconset] = bpy.utils.previews.new()
+				self.preview_collections[iconset] = bpy.utils.previews.new()
 
 			script_path = bpy.path.abspath(os.path.dirname(__file__))
 			icons_dir = os.path.join(script_path, 'icons')
@@ -156,7 +143,6 @@ env = MCprepEnv(dev_build=True, verbose=True)
 
 # ! Deprecated as of MCprep 3.4.2
 def init():
-
 	# -----------------------------------------------
 	# Verbose, use as env.verbose
 	# Used to print out extra information, set false with distribution
@@ -349,7 +335,7 @@ def unregister():
 			try:
 				bpy.utils.previews.remove(pcoll)
 			except:
-				log('Issue clearing preview set ' + str(pcoll))
+				env.log('Issue clearing preview set ' + str(pcoll))
 	env.preview_collections.clear()
 
 	env.json_data = None  # actively clearing out json data for next open

--- a/MCprep_addon/conf.py
+++ b/MCprep_addon/conf.py
@@ -33,13 +33,7 @@ except:
 
 
 class MCprepEnv:
-	_instance = None
-	def __new__(cls, *args, **kwargs):
-		if cls._instance is None:
-			cls._instance = super().__new__(cls, *args, **kwargs)
-		return cls._instance
-
-	def set_env(self, dev_build=False, verbose=False):
+	def __init__(self, dev_build=False, verbose=False):
 		self.dev_build = dev_build
 		self.verbose = verbose
 		self.very_verbose = dev_build
@@ -153,6 +147,8 @@ class MCprepEnv:
 			self.use_icons = False
 			for iconset in collection_sets:
 				self.preview_collections[iconset] = ""
+
+ENV = MCprepEnv(dev_build=True, verbose=True)
 
 # ! Deprecated as of MCprep 3.4.2
 def init():
@@ -315,10 +311,9 @@ def icons_init():
 			preview_collections[iconset] = ""
 
 def log(statement, vv_only=False):
-    env = MCprepEnv()
-    if env.verbose and vv_only and env.very_verbose:
+    if ENV.verbose and vv_only and ENV.very_verbose:
         print(statement)
-    elif env.verbose:
+    elif ENV.verbose:
         print(statement)
 
 def updater_select_link_function(self, tag):
@@ -344,18 +339,17 @@ def register():
 
 
 def unregister():
-	env = MCprepEnv()
-	if env.use_icons:
-		for pcoll in env.preview_collections.values():
+	if ENV.use_icons:
+		for pcoll in ENV.preview_collections.values():
 			try:
 				bpy.utils.previews.remove(pcoll)
 			except:
 				log('Issue clearing preview set ' + str(pcoll))
-	env.preview_collections.clear()
+	ENV.preview_collections.clear()
 
-	env.json_data = None  # actively clearing out json data for next open
+	ENV.json_data = None  # actively clearing out json data for next open
 
-	env.loaded_all_spawners = False
-	env.skin_list = []
-	env.rig_categories = []
-	env.material_sync_cache = []
+	ENV.loaded_all_spawners = False
+	ENV.skin_list = []
+	ENV.rig_categories = []
+	ENV.material_sync_cache = []

--- a/MCprep_addon/conf.py
+++ b/MCprep_addon/conf.py
@@ -101,7 +101,6 @@ class MCprepEnv:
 		# start with custom icons
 		# put into a try statement in case older blender version!
 		global preview_collections
-		global v
 
 		collection_sets = [
 			"main", "skins", "mobs", "entities", "blocks", "items", "effects", "materials"]
@@ -154,7 +153,7 @@ class MCprepEnv:
 		elif self.verbose:
 			print(statement)
 
-ENV = MCprepEnv(dev_build=True, verbose=True)
+env = MCprepEnv(dev_build=True, verbose=True)
 
 # ! Deprecated as of MCprep 3.4.2
 def init():
@@ -318,9 +317,9 @@ def icons_init():
 
 # ! Deprecated as of MCprep 3.4.2
 def log(statement, vv_only=False):
-    if ENV.verbose and vv_only and ENV.very_verbose:
+    if env.verbose and vv_only and env.very_verbose:
         print(statement)
-    elif ENV.verbose:
+    elif env.verbose:
         print(statement)
 
 def updater_select_link_function(self, tag):
@@ -346,17 +345,17 @@ def register():
 
 
 def unregister():
-	if ENV.use_icons:
-		for pcoll in ENV.preview_collections.values():
+	if env.use_icons:
+		for pcoll in env.preview_collections.values():
 			try:
 				bpy.utils.previews.remove(pcoll)
 			except:
 				log('Issue clearing preview set ' + str(pcoll))
-	ENV.preview_collections.clear()
+	env.preview_collections.clear()
 
-	ENV.json_data = None  # actively clearing out json data for next open
+	env.json_data = None  # actively clearing out json data for next open
 
-	ENV.loaded_all_spawners = False
-	ENV.skin_list = []
-	ENV.rig_categories = []
-	ENV.material_sync_cache = []
+	env.loaded_all_spawners = False
+	env.skin_list = []
+	env.rig_categories = []
+	env.material_sync_cache = []

--- a/MCprep_addon/conf.py
+++ b/MCprep_addon/conf.py
@@ -32,7 +32,7 @@ except:
 # -----------------------------------------------------------------------------
 
 class MCprepEnv:
-	def __init__(self, dev_build=False, verbose=False):
+	def __init__(self, dev_build: bool=False, verbose: bool=False):
 		self.dev_build: bool = dev_build
 		self.verbose: bool = verbose
 		self.very_verbose: bool = dev_build
@@ -133,7 +133,7 @@ class MCprepEnv:
 			for iconset in collection_sets:
 				self.preview_collections[iconset] = ""
     
-	def log(self, statement, vv_only=False):
+	def log(self, statement: str, vv_only: bool=False):
 		if self.verbose and vv_only and self.very_verbose:
 			print(statement)
 		elif self.verbose:

--- a/MCprep_addon/import_bridge/bridge.py
+++ b/MCprep_addon/import_bridge/bridge.py
@@ -25,7 +25,7 @@ from bpy_extras.io_utils import ImportHelper
 
 from .mineways_connector import MinewaysConnector
 from .jmc_connector import JmcConnector
-from .. import conf
+from ..conf import env
 from .. import util
 from .. import tracking
 
@@ -286,7 +286,7 @@ class MCPREP_OT_import_new_world(bpy.types.Operator):
 			"_" + connector.world + "_exp.mtl"
 			)
 
-		conf.log("Running Mineways bridge to import world "+ connector.world)
+		env.log("Running Mineways bridge to import world "+ connector.world)
 		connector.run_export_single(
 			obj_path,
 			list(self.first_corner),
@@ -297,14 +297,14 @@ class MCPREP_OT_import_new_world(bpy.types.Operator):
 		# TODO: Implement check/connector class check for success, not just file existing
 		if not os.path.isfile(obj_path):
 			self.report({"ERROR"}, "OBJ file not exported, try using Mineways on its own to export OBJ")
-			conf.log("OBJ file not found to import: "+obj_path)
+			env.log("OBJ file not found to import: "+obj_path)
 			return {"CANCELLED"}
-		conf.log("Now importing the exported obj into blender")
+		env.log("Now importing the exported obj into blender")
 		bpy.ops.import_scene.obj(filepath=obj_path)
 		# consider removing old world obj's?
 
 		t2 = time.time()
-		conf.log("Mineways bridge completed in: {}s (Mineways: {}s, obj import: {}s".format(
+		env.log("Mineways bridge completed in: {}s (Mineways: {}s, obj import: {}s".format(
 			int(t2-t0), int(t1-t0), int(t2-t1)))
 
 		self.report({'INFO'}, "Bridge completed finished")

--- a/MCprep_addon/import_bridge/bridge.py
+++ b/MCprep_addon/import_bridge/bridge.py
@@ -361,7 +361,6 @@ classes = (
 
 def register():
 	for cls in classes:
-		util.make_annotations(cls)
 		bpy.utils.register_class(cls)
 
 

--- a/MCprep_addon/load_modules.py
+++ b/MCprep_addon/load_modules.py
@@ -21,8 +21,6 @@ import importlib
 
 import bpy
 
-from MCprep_addon.conf import MCprepEnv
-
 # Per module loading for stable, in-session updates, even if new files are added
 if "conf" in locals():
 	importlib.reload(conf)
@@ -174,8 +172,7 @@ module_list = (
 
 
 def register(bl_info):
-	first_instance = MCprepEnv()
-	first_instance.set_env(dev_build=True, verbose=True)
+	conf.register()
 	tracking.register(bl_info)
 	for mod in module_list:
 		mod.register()

--- a/MCprep_addon/load_modules.py
+++ b/MCprep_addon/load_modules.py
@@ -183,8 +183,8 @@ def register(bl_info):
 	# Inject the custom updater function, to use release zip instead src.
 	addon_updater_ops.updater.select_link = conf.updater_select_link_function
 
-	conf.log("MCprep: Verbose is enabled")
-	conf.log("MCprep: Very Verbose is enabled", vv_only=True)
+	conf.env.log("MCprep: Verbose is enabled")
+	conf.env.log("MCprep: Very Verbose is enabled", vv_only=True)
 
 
 def unregister(bl_info):

--- a/MCprep_addon/load_modules.py
+++ b/MCprep_addon/load_modules.py
@@ -21,6 +21,8 @@ import importlib
 
 import bpy
 
+from MCprep_addon.conf import MCprepEnv
+
 # Per module loading for stable, in-session updates, even if new files are added
 if "conf" in locals():
 	importlib.reload(conf)
@@ -172,7 +174,8 @@ module_list = (
 
 
 def register(bl_info):
-	conf.register()
+	first_instance = MCprepEnv()
+	first_instance.set_env(dev_build=True, verbose=True)
 	tracking.register(bl_info)
 	for mod in module_list:
 		mod.register()

--- a/MCprep_addon/materials/default_materials.py
+++ b/MCprep_addon/materials/default_materials.py
@@ -26,23 +26,25 @@ from .. import tracking
 from .. import util
 from . import sync
 
+from ..conf import ENV
+
 
 def default_material_in_sync_library(default_material, context):
 	"""Returns true if the material is in the sync mat library blend file."""
-	if conf.material_sync_cache is None:
+	if ENV.material_sync_cache is None:
 		sync.reload_material_sync_library(context)
-	if util.nameGeneralize(default_material) in conf.material_sync_cache:
+	if util.nameGeneralize(default_material) in ENV.material_sync_cache:
 		return True
-	elif default_material in conf.material_sync_cache:
+	elif default_material in ENV.material_sync_cache:
 		return True
 	return False
 
 
 def sync_default_material(context, material, default_material, engine):
 	"""Normal sync material method but with duplication and name change."""
-	if default_material in conf.material_sync_cache:
+	if default_material in ENV.material_sync_cache:
 		import_name = default_material
-	elif util.nameGeneralize(default_material) in conf.material_sync_cache:
+	elif util.nameGeneralize(default_material) in ENV.material_sync_cache:
 		import_name = util.nameGeneralize(default_material)
 
 	# If link is true, check library material not already linked.

--- a/MCprep_addon/materials/default_materials.py
+++ b/MCprep_addon/materials/default_materials.py
@@ -26,25 +26,25 @@ from .. import tracking
 from .. import util
 from . import sync
 
-from ..conf import ENV
+from ..conf import env
 
 
 def default_material_in_sync_library(default_material, context):
 	"""Returns true if the material is in the sync mat library blend file."""
-	if ENV.material_sync_cache is None:
+	if env.material_sync_cache is None:
 		sync.reload_material_sync_library(context)
-	if util.nameGeneralize(default_material) in ENV.material_sync_cache:
+	if util.nameGeneralize(default_material) in env.material_sync_cache:
 		return True
-	elif default_material in ENV.material_sync_cache:
+	elif default_material in env.material_sync_cache:
 		return True
 	return False
 
 
 def sync_default_material(context, material, default_material, engine):
 	"""Normal sync material method but with duplication and name change."""
-	if default_material in ENV.material_sync_cache:
+	if default_material in env.material_sync_cache:
 		import_name = default_material
-	elif util.nameGeneralize(default_material) in ENV.material_sync_cache:
+	elif util.nameGeneralize(default_material) in env.material_sync_cache:
 		import_name = util.nameGeneralize(default_material)
 
 	# If link is true, check library material not already linked.

--- a/MCprep_addon/materials/default_materials.py
+++ b/MCprep_addon/materials/default_materials.py
@@ -21,7 +21,6 @@ import os
 
 import bpy
 
-from .. import conf
 from .. import tracking
 from .. import util
 from . import sync
@@ -139,7 +138,7 @@ class MCPREP_OT_default_material(bpy.types.Operator):
 			try:
 				err = sync_default_material(context, mat, material_name, self.engine) # no linking
 				if err:
-					conf.log(err)
+					env.log(err)
 			except Exception as e:
 				print(e)
 

--- a/MCprep_addon/materials/default_materials.py
+++ b/MCprep_addon/materials/default_materials.py
@@ -211,7 +211,6 @@ classes = (
 
 def register():
 	for cls in classes:
-		util.make_annotations(cls)
 		bpy.utils.register_class(cls)
 	bpy.app.handlers.load_post.append(sync.clear_sync_cache)
 

--- a/MCprep_addon/materials/generate.py
+++ b/MCprep_addon/materials/generate.py
@@ -22,7 +22,7 @@ import bpy
 from .. import conf
 from .. import util
 
-from ..conf import ENV
+from ..conf import env
 
 
 # -----------------------------------------------------------------------------
@@ -35,7 +35,7 @@ def update_mcprep_texturepack_path(self, context):
 	bpy.ops.mcprep.reload_items()
 	bpy.ops.mcprep.reload_materials()
 	bpy.ops.mcprep.reload_models()
-	ENV.material_sync_cache = None
+	env.material_sync_cache = None
 
 
 def get_mc_canonical_name(name):
@@ -46,7 +46,7 @@ def get_mc_canonical_name(name):
 		form (mc, jmc, or mineways)
 	"""
 	general_name = util.nameGeneralize(name)
-	if not ENV.json_data:
+	if not env.json_data:
 		res = util.load_mcprep_json()
 		if not res:
 			return general_name, None
@@ -57,10 +57,10 @@ def get_mc_canonical_name(name):
 	if ".emit" in general_name and general_name != ".emit":
 		general_name = general_name.replace(".emit", "")
 
-	no_missing = "blocks" in ENV.json_data
-	no_missing &= "block_mapping_mc" in ENV.json_data["blocks"]
-	no_missing &= "block_mapping_jmc" in ENV.json_data["blocks"]
-	no_missing &= "block_mapping_mineways" in ENV.json_data["blocks"]
+	no_missing = "blocks" in env.json_data
+	no_missing &= "block_mapping_mc" in env.json_data["blocks"]
+	no_missing &= "block_mapping_jmc" in env.json_data["blocks"]
+	no_missing &= "block_mapping_mineways" in env.json_data["blocks"]
 
 	if no_missing is False:
 		conf.log("Missing key values in json")
@@ -76,21 +76,21 @@ def get_mc_canonical_name(name):
 	else:
 		jmc_prefix = False
 
-	if general_name in ENV.json_data["blocks"]["block_mapping_mc"]:
-		canon = ENV.json_data["blocks"]["block_mapping_mc"][general_name]
+	if general_name in env.json_data["blocks"]["block_mapping_mc"]:
+		canon = env.json_data["blocks"]["block_mapping_mc"][general_name]
 		form = "mc" if not jmc_prefix else "jmc2obj"
-	elif general_name in ENV.json_data["blocks"]["block_mapping_jmc"]:
-		canon = ENV.json_data["blocks"]["block_mapping_jmc"][general_name]
+	elif general_name in env.json_data["blocks"]["block_mapping_jmc"]:
+		canon = env.json_data["blocks"]["block_mapping_jmc"][general_name]
 		form = "jmc2obj"
-	elif general_name in ENV.json_data["blocks"]["block_mapping_mineways"]:
-		canon = ENV.json_data["blocks"]["block_mapping_mineways"][general_name]
+	elif general_name in env.json_data["blocks"]["block_mapping_mineways"]:
+		canon = env.json_data["blocks"]["block_mapping_mineways"][general_name]
 		form = "mineways"
-	elif general_name.lower() in ENV.json_data["blocks"]["block_mapping_jmc"]:
-		canon = ENV.json_data["blocks"]["block_mapping_jmc"][
+	elif general_name.lower() in env.json_data["blocks"]["block_mapping_jmc"]:
+		canon = env.json_data["blocks"]["block_mapping_jmc"][
 			general_name.lower()]
 		form = "jmc2obj"
-	elif general_name.lower() in ENV.json_data["blocks"]["block_mapping_mineways"]:
-		canon = ENV.json_data["blocks"]["block_mapping_mineways"][
+	elif general_name.lower() in env.json_data["blocks"]["block_mapping_mineways"]:
+		canon = env.json_data["blocks"]["block_mapping_mineways"][
 			general_name.lower()]
 		form = "mineways"
 	else:
@@ -219,15 +219,15 @@ def detect_form(materials):
 
 def checklist(matName, listName):
 	"""Helper to expand single wildcard within generalized material names"""
-	if not ENV.json_data:
+	if not env.json_data:
 		conf.log("No json_data for checklist to call from!")
-	if "blocks" not in ENV.json_data or listName not in ENV.json_data["blocks"]:
+	if "blocks" not in env.json_data or listName not in ENV.json_data["blocks"]:
 		conf.log(
-			"ENV.json_data is missing blocks or listName " + str(listName))
+			"env.json_data is missing blocks or listName " + str(listName))
 		return False
-	if matName in ENV.json_data["blocks"][listName]:
+	if matName in env.json_data["blocks"][listName]:
 		return True
-	for name in ENV.json_data["blocks"][listName]:
+	for name in env.json_data["blocks"][listName]:
 		if '*' not in name:
 			continue
 		x = name.split('*')
@@ -242,7 +242,7 @@ def matprep_internal(mat, passes, use_reflections, only_solid):
 	"""Update existing internal materials with improved settings.
 	Will not necessarily properly convert cycles materials into internal."""
 
-	if not ENV.json_data:
+	if not env.json_data:
 		_ = util.load_mcprep_json()
 
 	newName = mat.name + '_tex'
@@ -350,7 +350,7 @@ def matprep_internal(mat, passes, use_reflections, only_solid):
 		new_tex.use_color_ramp = True
 		for _ in range(len(new_tex.color_ramp.elements) - 1):
 			new_tex.color_ramp.elements.remove(new_tex.color_ramp.elements[0])
-		desat_color = ENV.json_data['blocks']['desaturated'][canon]
+		desat_color = env.json_data['blocks']['desaturated'][canon]
 		if len(desat_color) < len(new_tex.color_ramp.elements[0].color):
 			desat_color.append(1.0)
 		new_tex.color_ramp.elements[0].color = desat_color
@@ -637,7 +637,7 @@ def set_internal_texture(image, material, extra_passes=False):
 			new_tex.use_color_ramp = True
 			for _ in range(len(new_tex.color_ramp.elements) - 1):
 				new_tex.color_ramp.elements.remove(new_tex.color_ramp.elements[0])
-			desat_color = ENV.json_data['blocks']['desaturated'][canon]
+			desat_color = env.json_data['blocks']['desaturated'][canon]
 			if len(desat_color) < len(new_tex.color_ramp.elements[0].color):
 				desat_color.append(1.0)
 			new_tex.color_ramp.elements[0].color = desat_color
@@ -923,7 +923,7 @@ def set_saturation_material(mat):
 
 	saturate = is_image_grayscale(diff_img)
 
-	desat_color = ENV.json_data['blocks']['desaturated'][canon]
+	desat_color = env.json_data['blocks']['desaturated'][canon]
 	engine = bpy.context.scene.render.engine
 
 	if engine == 'BLENDER_RENDER' or engine == 'BLENDER_GAME':
@@ -1131,7 +1131,7 @@ def texgen_specular(mat, passes, nodeInputs, use_reflections):
 		pass
 	else:
 		conf.log("Texture desaturated: " + canon, vv_only=True)
-		desat_color = ENV.json_data['blocks']['desaturated'][canon]
+		desat_color = env.json_data['blocks']['desaturated'][canon]
 		if len(desat_color) < len(nodeSaturateMix.inputs[2].default_value):
 			desat_color.append(1.0)
 		nodeSaturateMix.inputs[2].default_value = desat_color
@@ -1265,7 +1265,7 @@ def texgen_seus(mat, passes, nodeInputs, use_reflections):
 		pass
 	else:
 		conf.log("Texture desaturated: " + canon, vv_only=True)
-		desat_color = ENV.json_data['blocks']['desaturated'][canon]
+		desat_color = env.json_data['blocks']['desaturated'][canon]
 		if len(desat_color) < len(nodeSaturateMix.inputs[2].default_value):
 			desat_color.append(1.0)
 		nodeSaturateMix.inputs[2].default_value = desat_color
@@ -1383,7 +1383,7 @@ def matgen_cycles_simple(
 		pass
 	else:
 		conf.log("Texture desaturated: " + canon, vv_only=True)
-		desat_color = ENV.json_data['blocks']['desaturated'][canon]
+		desat_color = env.json_data['blocks']['desaturated'][canon]
 		if len(desat_color) < len(nodeSaturateMix.inputs[2].default_value):
 			desat_color.append(1.0)
 		nodeSaturateMix.inputs[2].default_value = desat_color
@@ -1896,7 +1896,7 @@ def matgen_special_water(mat, passes):
 		pass
 	else:
 		conf.log("Texture desaturated: " + canon, vv_only=True)
-		desat_color = ENV.json_data['blocks']['desaturated'][canon]
+		desat_color = env.json_data['blocks']['desaturated'][canon]
 		if len(desat_color) < len(nodeSaturateMix.inputs[2].default_value):
 			desat_color.append(1.0)
 		nodeSaturateMix.inputs[2].default_value = desat_color

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -27,7 +27,7 @@ from . import sequences
 from .. import tracking
 from .. import util
 
-from ..conf import ENV
+from ..conf import env
 
 
 # -----------------------------------------------------------------------------
@@ -42,9 +42,9 @@ def reload_materials(context):
 	extensions = [".png", ".jpg", ".jpeg"]
 
 	mcprep_props.material_list.clear()
-	if ENV.use_icons and ENV.preview_collections["materials"]:
+	if env.use_icons and ENV.preview_collections["materials"]:
 		try:
-			bpy.utils.previews.remove(ENV.preview_collections["materials"])
+			bpy.utils.previews.remove(env.preview_collections["materials"])
 		except:
 			conf.log("Failed to remove icon set, materials")
 
@@ -90,9 +90,9 @@ def reload_materials(context):
 		asset.index = i
 
 		# if available, load the custom icon too
-		if not ENV.use_icons or ENV.preview_collections["materials"] == "":
+		if not env.use_icons or ENV.preview_collections["materials"] == "":
 			continue
-		ENV.preview_collections["materials"].load(
+		env.preview_collections["materials"].load(
 			"material-{}".format(i), image_file, 'IMAGE')
 
 	if mcprep_props.material_list_index >= len(mcprep_props.material_list):

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -27,6 +27,8 @@ from . import sequences
 from .. import tracking
 from .. import util
 
+from ..conf import ENV
+
 
 # -----------------------------------------------------------------------------
 # UI and utility functions
@@ -40,9 +42,9 @@ def reload_materials(context):
 	extensions = [".png", ".jpg", ".jpeg"]
 
 	mcprep_props.material_list.clear()
-	if conf.use_icons and conf.preview_collections["materials"]:
+	if ENV.use_icons and ENV.preview_collections["materials"]:
 		try:
-			bpy.utils.previews.remove(conf.preview_collections["materials"])
+			bpy.utils.previews.remove(ENV.preview_collections["materials"])
 		except:
 			conf.log("Failed to remove icon set, materials")
 
@@ -88,9 +90,9 @@ def reload_materials(context):
 		asset.index = i
 
 		# if available, load the custom icon too
-		if not conf.use_icons or conf.preview_collections["materials"] == "":
+		if not ENV.use_icons or ENV.preview_collections["materials"] == "":
 			continue
-		conf.preview_collections["materials"].load(
+		ENV.preview_collections["materials"].load(
 			"material-{}".format(i), image_file, 'IMAGE')
 
 	if mcprep_props.material_list_index >= len(mcprep_props.material_list):

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -21,7 +21,6 @@ import os
 
 import bpy
 
-from .. import conf
 from . import generate
 from . import sequences
 from .. import tracking
@@ -46,10 +45,10 @@ def reload_materials(context):
 		try:
 			bpy.utils.previews.remove(env.preview_collections["materials"])
 		except:
-			conf.log("Failed to remove icon set, materials")
+			env.log("Failed to remove icon set, materials")
 
 	if not os.path.isdir(resource_folder):
-		conf.log("Error, resource folder does not exist")
+		env.log("Error, resource folder does not exist")
 		return
 
 	# Check multiple paths, picking the first match (order is important),
@@ -198,7 +197,7 @@ class MCPREP_OT_combine_materials(bpy.types.Operator):
 			elif mat.name not in name_cat[base]:
 				name_cat[base].append(mat.name)
 			else:
-				conf.log("Skipping, already added material", True)
+				env.log("Skipping, already added material", True)
 
 		# Pre 2.78 solution, deep loop.
 		if bpy.app.version < (2, 78):
@@ -228,7 +227,7 @@ class MCPREP_OT_combine_materials(bpy.types.Operator):
 			name_cat[base].sort()  # in-place sorting
 			baseMat = bpy.data.materials[name_cat[base][0]]
 
-			conf.log([name_cat[base], " ## ", baseMat], vv_only=True)
+			env.log([name_cat[base], " ## ", baseMat], vv_only=True)
 
 			for matname in name_cat[base][1:]:
 				# skip if fake user set
@@ -240,9 +239,9 @@ class MCPREP_OT_combine_materials(bpy.types.Operator):
 					self.report({'ERROR'}, str(res))
 					return {'CANCELLED'}
 				old = bpy.data.materials[matname]
-				conf.log("removing old? " + matname, vv_only=True)
+				env.log("removing old? " + matname, vv_only=True)
 				if removeold is True and old.users == 0:
-					conf.log("removing old:" + matname, vv_only=True)
+					env.log("removing old:" + matname, vv_only=True)
 					try:
 						data.remove(old)
 					except ReferenceError as err:
@@ -263,7 +262,7 @@ class MCPREP_OT_combine_materials(bpy.types.Operator):
 					baseMat.name = gen_base
 			else:
 				baseMat.name = gen_base
-			conf.log(["Final: ", baseMat], vv_only=True)
+			env.log(["Final: ", baseMat], vv_only=True)
 
 		postcount = len(["x" for x in getMaterials(self, context) if x.users > 0])
 		self.report({"INFO"}, "Consolidated {x} materials down to {y}".format(
@@ -325,7 +324,7 @@ class MCPREP_OT_combine_images(bpy.types.Operator):
 			elif im.name not in name_cat[base]:
 				name_cat[base].append(im.name)
 			else:
-				conf.log("Skipping, already added image", vv_only=True)
+				env.log("Skipping, already added image", vv_only=True)
 
 		# pre 2.78 solution, deep loop
 		if bpy.app.version < (2, 78):
@@ -419,7 +418,7 @@ class MCPREP_OT_replace_missing_textures(bpy.types.Operator):
 			updated = False
 			passes = generate.get_textures(mat)
 			if not passes:
-				conf.log("No images found within material")
+				env.log("No images found within material")
 			for pass_name in passes:
 				if pass_name == 'diffuse' and passes[pass_name] is None:
 					res = self.load_from_texturepack(mat)
@@ -429,7 +428,7 @@ class MCPREP_OT_replace_missing_textures(bpy.types.Operator):
 					updated = True
 			if updated:
 				count += 1
-				conf.log("Updated " + mat.name)
+				env.log("Updated " + mat.name)
 				if self.animateTextures:
 					sequences.animate_single_material(
 						mat, context.scene.render.engine)
@@ -447,15 +446,15 @@ class MCPREP_OT_replace_missing_textures(bpy.types.Operator):
 
 	def load_from_texturepack(self, mat):
 		"""If image datablock not found in passes, try to directly load and assign"""
-		conf.log("Loading from texpack for " + mat.name, vv_only=True)
+		env.log("Loading from texpack for " + mat.name, vv_only=True)
 		canon, _ = generate.get_mc_canonical_name(mat.name)
 		image_path = generate.find_from_texturepack(canon)
 		if not image_path or not os.path.isfile(image_path):
-			conf.log("Find missing images: No source file found for " + mat.name)
+			env.log("Find missing images: No source file found for " + mat.name)
 			return False
 
 		# even if images of same name already exist, load new block
-		conf.log("Find missing images: Creating new image datablock for " + mat.name)
+		env.log("Find missing images: Creating new image datablock for " + mat.name)
 		# do not use 'check_existing=False' to keep compatibility pre 2.79
 		image = bpy.data.images.load(image_path, check_existing=True)
 

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -41,7 +41,7 @@ def reload_materials(context):
 	extensions = [".png", ".jpg", ".jpeg"]
 
 	mcprep_props.material_list.clear()
-	if env.use_icons and ENV.preview_collections["materials"]:
+	if env.use_icons and env.preview_collections["materials"]:
 		try:
 			bpy.utils.previews.remove(env.preview_collections["materials"])
 		except:
@@ -89,7 +89,7 @@ def reload_materials(context):
 		asset.index = i
 
 		# if available, load the custom icon too
-		if not env.use_icons or ENV.preview_collections["materials"] == "":
+		if not env.use_icons or env.preview_collections["materials"] == "":
 			continue
 		env.preview_collections["materials"].load(
 			"material-{}".format(i), image_file, 'IMAGE')
@@ -101,9 +101,9 @@ def reload_materials(context):
 class ListMaterials(bpy.types.PropertyGroup):
 	"""For UI drawing of item assets and holding data"""
 	# inherited: name
-	description = bpy.props.StringProperty()
-	path = bpy.props.StringProperty(subtype='FILE_PATH')
-	index = bpy.props.IntProperty(min=0, default=0)  # for icon drawing
+	description: bpy.props.StringProperty()
+	path: bpy.props.StringProperty(subtype='FILE_PATH')
+	index: bpy.props.IntProperty(min=0, default=0)  # for icon drawing
 
 
 # -----------------------------------------------------------------------------
@@ -484,7 +484,6 @@ classes = (
 
 def register():
 	for cls in classes:
-		util.make_annotations(cls)
 		bpy.utils.register_class(cls)
 
 

--- a/MCprep_addon/materials/prep.py
+++ b/MCprep_addon/materials/prep.py
@@ -245,12 +245,7 @@ class MCPREP_OT_prep_materials(bpy.types.Operator, McprepMaterialProps):
 					if res > 0:
 						mat["texture_swapped"] = True  # used to apply saturation
 
-			if engine == 'BLENDER_RENDER' or engine == 'BLENDER_GAME':
-				res = generate.matprep_internal(
-					mat, passes, self.useReflections, self.makeSolid)
-				if res == 0:
-					count += 1
-			elif engine == 'CYCLES' or engine == 'BLENDER_EEVEE':
+			if engine == 'CYCLES' or engine == 'BLENDER_EEVEE':
 				res = generate.matprep_cycles(
 					mat=mat,
 					passes=passes,
@@ -264,7 +259,7 @@ class MCPREP_OT_prep_materials(bpy.types.Operator, McprepMaterialProps):
 			else:
 				self.report(
 					{'ERROR'},
-					"Only Blender Internal, Cycles, and Eevee are supported")
+					"Only Cycles and Eevee are supported")
 				return {'CANCELLED'}
 
 			if self.animateTextures:
@@ -590,9 +585,7 @@ class MCPREP_OT_load_material(bpy.types.Operator, McprepMaterialProps):
 		mat = bpy.data.materials.new(name=name)
 
 		engine = context.scene.render.engine
-		if engine == 'BLENDER_RENDER' or engine == 'BLENDER_GAME':
-			generate.set_internal_texture(image, mat, self.useExtraMaps)
-		elif engine == 'CYCLES' or engine == 'BLENDER_EEVEE':
+		if engine == 'CYCLES' or engine == 'BLENDER_EEVEE':
 			# need to create at least one texture node first, then the rest works
 			mat.use_nodes = True
 			nodes = mat.node_tree.nodes
@@ -610,7 +603,7 @@ class MCPREP_OT_load_material(bpy.types.Operator, McprepMaterialProps):
 			# now use standard method to update textures
 			generate.set_cycles_texture(image, mat, self.useExtraMaps)
 		else:
-			return None, "Only Blender Internal, Cycles, or Eevee supported"
+			return None, "Only Cycles and Eevee supported"
 
 		return mat, None
 
@@ -636,10 +629,7 @@ class MCPREP_OT_load_material(bpy.types.Operator, McprepMaterialProps):
 				if res > 0:
 					mat["texture_swapped"] = True  # used to apply saturation
 
-		if engine == 'BLENDER_RENDER' or engine == 'BLENDER_GAME':
-			res = generate.matprep_internal(
-				mat, passes, self.useReflections, self.makeSolid)
-		elif engine == 'CYCLES' or engine == 'BLENDER_EEVEE':
+		if engine == 'CYCLES' or engine == 'BLENDER_EEVEE':
 			res = generate.matprep_cycles(
 				mat=mat,
 				passes=passes,
@@ -649,7 +639,7 @@ class MCPREP_OT_load_material(bpy.types.Operator, McprepMaterialProps):
 				pack_format=self.packFormat,
 				use_emission_nodes=self.useEmission)
 		else:
-			return False, "Only Blender Internal, Cycles, or Eevee supported"
+			return False, "Only Cycles and Eevee supported"
 
 		success = res == 0
 

--- a/MCprep_addon/materials/prep.py
+++ b/MCprep_addon/materials/prep.py
@@ -299,9 +299,10 @@ class MCPREP_OT_materials_help(bpy.types.Operator):
 
 	def update_supress_help(self, context):
 		"""Update trigger for supressing help popups."""
-		if conf.v and self.suppress_help:
+		env = conf.MCprepEnv()
+		if env.verbose and self.suppress_help:
 			print("Supressing future help popups")
-		elif conf.v and not self.suppress_help:
+		elif env.verbose and not self.suppress_help:
 			print("Re-enabling popup warnings")
 
 	help_num = bpy.props.IntProperty(

--- a/MCprep_addon/materials/prep.py
+++ b/MCprep_addon/materials/prep.py
@@ -53,47 +53,47 @@ class McprepMaterialProps():
 		itms.append(("seus", "SEUS", "Sets the pack format to SEUS."))
 		return itms
 	
-	animateTextures = bpy.props.BoolProperty(
+	animateTextures: bpy.props.BoolProperty(
 		name="Animate textures (may be slow first time)",
 		description=(
 			"Swap still images for the animated sequenced found in "
 			"the active or default texture pack."),
 		default=False)
-	autoFindMissingTextures = bpy.props.BoolProperty(
+	autoFindMissingTextures: bpy.props.BoolProperty(
 		name="Find missing images",
 		description=(
 			"If the texture for an existing material is missing, try "
 			"to load from the default texture pack instead"),
 		default=True)
-	combineMaterials = bpy.props.BoolProperty(
+	combineMaterials: bpy.props.BoolProperty(
 		name="Combine materials",
 		description="Consolidate duplciate materials & textures",
 		default=False)
-	improveUiSettings = bpy.props.BoolProperty(
+	improveUiSettings: bpy.props.BoolProperty(
 		name="Improve UI",
 		description="Automatically improve relevant UI settings",
 		default=True)
-	optimizeScene = bpy.props.BoolProperty(
+	optimizeScene: bpy.props.BoolProperty(
 		name="Optimize scene (cycles)",
 		description="Optimize the scene for faster cycles rendering",
 		default=False)
-	usePrincipledShader = bpy.props.BoolProperty(
+	usePrincipledShader: bpy.props.BoolProperty(
 		name="Use Principled Shader (if available)",
 		description=(
 			"If available and using cycles, build materials using the "
 			"principled shader"),
 		default=True)
-	useReflections = bpy.props.BoolProperty(
+	useReflections: bpy.props.BoolProperty(
 		name="Use reflections",
 		description="Allow appropriate materials to be rendered reflective",
 		default=True)
-	useExtraMaps = bpy.props.BoolProperty(
+	useExtraMaps: bpy.props.BoolProperty(
 		name="Use extra maps",
 		description=(
 			"load other image passes like normal and "
 			"spec maps if available"),
 		default=True)
-	normalIntensity = bpy.props.FloatProperty(
+	normalIntensity: bpy.props.FloatProperty(
 		name="Normal map intensity",
 		description=(
 			"Set normal map intensity, if normal maps are found in "
@@ -101,11 +101,11 @@ class McprepMaterialProps():
 		default=1.0,
 		max=1,
 		min=0)
-	makeSolid = bpy.props.BoolProperty(
+	makeSolid: bpy.props.BoolProperty(
 		name="Make all materials solid",
 		description="Make all materials solid only, for shadows and rendering",
 		default=False)
-	syncMaterials = bpy.props.BoolProperty(
+	syncMaterials: bpy.props.BoolProperty(
 		name="Sync materials",
 		description=(
 			"Synchronize materials with those in the active "
@@ -115,12 +115,12 @@ class McprepMaterialProps():
 	#	name="Use custom default material",
 	#	description="Use a custom default material if you have one set up",
 	#	default=False)
-	packFormat = bpy.props.EnumProperty(
+	packFormat: bpy.props.EnumProperty(
 		name="Pack Format",
 		description="Change the pack format when using a PBR resource pack.",
 		items=pack_formats
 	)
-	useEmission = bpy.props.BoolProperty(
+	useEmission: bpy.props.BoolProperty(
 		name="Use Emission",
 		description="Make emmisive materials emit light",
 		default=True
@@ -674,9 +674,7 @@ classes = (
 
 
 def register():
-	util.make_annotations(McprepMaterialProps)
 	for cls in classes:
-		util.make_annotations(cls)
 		bpy.utils.register_class(cls)
 
 

--- a/MCprep_addon/materials/prep.py
+++ b/MCprep_addon/materials/prep.py
@@ -29,6 +29,8 @@ from .. import tracking
 from .. import util
 from . import uv_tools
 
+from ..conf import ENV
+
 # -----------------------------------------------------------------------------
 # Material class functions
 # -----------------------------------------------------------------------------
@@ -299,10 +301,9 @@ class MCPREP_OT_materials_help(bpy.types.Operator):
 
 	def update_supress_help(self, context):
 		"""Update trigger for supressing help popups."""
-		env = conf.MCprepEnv()
-		if env.verbose and self.suppress_help:
+		if ENV.verbose and self.suppress_help:
 			print("Supressing future help popups")
-		elif env.verbose and not self.suppress_help:
+		elif ENV.verbose and not self.suppress_help:
 			print("Re-enabling popup warnings")
 
 	help_num = bpy.props.IntProperty(

--- a/MCprep_addon/materials/prep.py
+++ b/MCprep_addon/materials/prep.py
@@ -29,7 +29,7 @@ from .. import tracking
 from .. import util
 from . import uv_tools
 
-from ..conf import ENV
+from ..conf import env
 
 # -----------------------------------------------------------------------------
 # Material class functions
@@ -301,9 +301,9 @@ class MCPREP_OT_materials_help(bpy.types.Operator):
 
 	def update_supress_help(self, context):
 		"""Update trigger for supressing help popups."""
-		if ENV.verbose and self.suppress_help:
+		if env.verbose and self.suppress_help:
 			print("Supressing future help popups")
-		elif ENV.verbose and not self.suppress_help:
+		elif env.verbose and not self.suppress_help:
 			print("Re-enabling popup warnings")
 
 	help_num = bpy.props.IntProperty(

--- a/MCprep_addon/materials/prep.py
+++ b/MCprep_addon/materials/prep.py
@@ -22,7 +22,6 @@ import os
 import bpy
 from bpy_extras.io_utils import ImportHelper
 
-from .. import conf
 from . import generate
 from . import sequences
 from .. import tracking
@@ -197,7 +196,7 @@ class MCPREP_OT_prep_materials(bpy.types.Operator, McprepMaterialProps):
 
 		for mat in mat_list:
 			if not mat:
-				conf.log(
+				env.log(
 					"During prep, found null material:" + str(mat), vv_only=True)
 				continue
 
@@ -428,7 +427,7 @@ class MCPREP_OT_swap_texture_pack(
 		folder = self.filepath
 		if os.path.isfile(bpy.path.abspath(folder)):
 			folder = os.path.dirname(folder)
-		conf.log("Folder: " + folder)
+		env.log("Folder: " + folder)
 
 		if not os.path.isdir(bpy.path.abspath(folder)):
 			self.report({'ERROR'}, "Selected folder does not exist")
@@ -453,7 +452,7 @@ class MCPREP_OT_swap_texture_pack(
 		# set the scene's folder for the texturepack being swapped
 		context.scene.mcprep_texturepack_path = folder
 
-		conf.log("Materials detected: " + str(len(mat_list)))
+		env.log("Materials detected: " + str(len(mat_list)))
 		res = 0
 		for mat in mat_list:
 			self.preprocess_material(mat)
@@ -483,8 +482,8 @@ class MCPREP_OT_swap_texture_pack(
 			self.report({'ERROR'}, (
 				"Detected scaled UV's (all in one texture), be sure to use "
 				"Mineway's 'Export Individual Textures To..'' feature"))
-			conf.log("Detected scaledd UV's, incompatible with swap textures")
-			conf.log([ob.name for ob in affected_objs], vv_only=True)
+			env.log("Detected scaledd UV's, incompatible with swap textures")
+			env.log([ob.name for ob in affected_objs], vv_only=True)
 		else:
 			self.report({'INFO'}, "{} materials affected".format(res))
 		self.track_param = context.scene.render.engine
@@ -497,7 +496,7 @@ class MCPREP_OT_swap_texture_pack(
 		# but in Mineways export, this is the flattened grass/drit block side
 		if material.name == "grass_block_side_overlay":
 			material.name = "grass_block_side"
-			conf.log("Renamed material: grass_block_side_overlay to grass_block_side")
+			env.log("Renamed material: grass_block_side_overlay to grass_block_side")
 
 
 class MCPREP_OT_load_material(bpy.types.Operator, McprepMaterialProps):
@@ -586,7 +585,7 @@ class MCPREP_OT_load_material(bpy.types.Operator, McprepMaterialProps):
 			node_nrm = mat.node_tree.nodes.new('ShaderNodeTexImage')
 			node_nrm["MCPREP_normal"] = True
 
-			conf.log("Added blank texture node")
+			env.log("Added blank texture node")
 
 			# now use standard method to update textures
 			generate.set_cycles_texture(image, mat, self.useExtraMaps)
@@ -598,14 +597,14 @@ class MCPREP_OT_load_material(bpy.types.Operator, McprepMaterialProps):
 	def update_material(self, context, mat):
 		"""Update the initially created material"""
 		if not mat:
-			conf.log("During prep, found null material:" + str(mat), vv_only=True)
+			env.log("During prep, found null material:" + str(mat), vv_only=True)
 			return
 		elif mat.library:
 			return
 
 		engine = context.scene.render.engine
 		passes = generate.get_textures(mat)
-		conf.log("Load Mat Passes:" + str(passes), vv_only=True)
+		env.log("Load Mat Passes:" + str(passes), vv_only=True)
 		if not self.useExtraMaps:
 			for pass_name in passes:
 				if pass_name != "diffuse":

--- a/MCprep_addon/materials/sequences.py
+++ b/MCprep_addon/materials/sequences.py
@@ -30,6 +30,7 @@ from .. import tracking
 from .. import util
 from . import uv_tools
 
+from ..conf import ENV
 
 # -----------------------------------------------------------------------------
 # Supporting functions
@@ -186,8 +187,7 @@ def generate_material_sequence(
 		# export to save frames in currently selected texturepack (could be addon)
 		seq_path_base = os.path.dirname(bpy.path.abspath(image_path))
 
-	env = conf.MCprepEnv()
-	if env.very_verbose:
+	if ENV.very_verbose:
 		conf.log("Pre-sequence details")
 		conf.log(image_path)
 		conf.log(image_dict)

--- a/MCprep_addon/materials/sequences.py
+++ b/MCprep_addon/materials/sequences.py
@@ -24,7 +24,6 @@ import re
 
 import bpy
 
-from .. import conf
 from . import generate
 from .. import tracking
 from .. import util
@@ -64,12 +63,12 @@ def animate_single_material(
 	# get the base image from the texturepack (cycles/BI general)
 	image_path_canon = generate.find_from_texturepack(canon)
 	if not image_path_canon:
-		conf.log("Canon path not found for {}:{}, form {}, path: {}".format(
+		env.log("Canon path not found for {}:{}, form {}, path: {}".format(
 			mat_gen, canon, form, image_path_canon), vv_only=True)
 		return affectable, False, None
 
 	if not os.path.isfile(image_path_canon + ".mcmeta"):
-		conf.log(".mcmeta not found for " + mat_gen, vv_only=True)
+		env.log(".mcmeta not found for " + mat_gen, vv_only=True)
 		affectable = False
 		return affectable, False, None
 	affectable = True
@@ -79,7 +78,7 @@ def animate_single_material(
 			mcmeta = json.load(mcf)
 		except json.JSONDecodeError:
 			print("Failed to parse the mcmeta data")
-	conf.log("MCmeta for {}: {}".format(diffuse_block, mcmeta))
+	env.log("MCmeta for {}: {}".format(diffuse_block, mcmeta))
 
 	# apply the sequence if any found, will be empty dict if not
 	if diffuse_block and hasattr(diffuse_block, "filepath"):
@@ -88,12 +87,12 @@ def animate_single_material(
 		source_path = None
 	if not source_path:
 		source_path = image_path_canon
-		conf.log("Fallback to using image canon path instead of source path")
+		env.log("Fallback to using image canon path instead of source path")
 	tile_path_dict, err = generate_material_sequence(
 		source_path, image_path_canon, form, export_location, clear_cache)
 	if err:
-		conf.log("Error occured during sequence generation:")
-		conf.log(err)
+		env.log("Error occured during sequence generation:")
+		env.log(err)
 		return affectable, False, err
 	if tile_path_dict == {}:
 		return affectable, False, None
@@ -101,7 +100,7 @@ def animate_single_material(
 	affected_materials = 0
 	for pass_name in tile_path_dict:
 		if not tile_path_dict[pass_name]:  # ie ''
-			conf.log("Skipping passname: " + pass_name)
+			env.log("Skipping passname: " + pass_name)
 			continue
 		if engine == 'CYCLES' or engine == 'BLENDER_EEVEE':
 			node = generate.get_node_for_pass(mat, pass_name)
@@ -188,19 +187,19 @@ def generate_material_sequence(
 		seq_path_base = os.path.dirname(bpy.path.abspath(image_path))
 
 	if env.very_verbose:
-		conf.log("Pre-sequence details")
-		conf.log(image_path)
-		conf.log(image_dict)
-		conf.log(img_pass_dict)
-		conf.log(seq_path_base)
-		conf.log("---")
+		env.log("Pre-sequence details")
+		env.log(image_path)
+		env.log(image_dict)
+		env.log(img_pass_dict)
+		env.log(seq_path_base)
+		env.log("---")
 
 	if form == "jmc2obj":
-		conf.log("DEBUG - jmc2obj aniamted texture detected")
+		env.log("DEBUG - jmc2obj aniamted texture detected")
 	elif form == "mineways":
-		conf.log("DEBUG - mineways aniamted texture detected")
+		env.log("DEBUG - mineways aniamted texture detected")
 	else:
-		conf.log("DEBUG - other form of animated texture detected")
+		env.log("DEBUG - other form of animated texture detected")
 
 	perm_denied = (
 		"Permission denied, could not make folder - "
@@ -208,8 +207,8 @@ def generate_material_sequence(
 
 	for img_pass in img_pass_dict:
 		passfile = img_pass_dict[img_pass]
-		conf.log("Running on file:")
-		conf.log(bpy.path.abspath(passfile))
+		env.log("Running on file:")
+		env.log(bpy.path.abspath(passfile))
 
 		# Create the sequence subdir (without race condition)
 		pass_name = os.path.splitext(os.path.basename(passfile))[0]
@@ -217,7 +216,7 @@ def generate_material_sequence(
 			seq_path = os.path.join(os.path.dirname(passfile), pass_name)
 		else:
 			seq_path = os.path.join(seq_path_base, pass_name)
-		conf.log("Using sequence directory: " + seq_path)
+		env.log("Using sequence directory: " + seq_path)
 
 		try:  # check parent folder exists/create if needed
 			os.mkdir(os.path.dirname(seq_path))
@@ -243,7 +242,7 @@ def generate_material_sequence(
 			if os.path.isfile(os.path.join(seq_path, tile))
 			and tile.startswith(pass_name)]
 		if cached:
-			conf.log("Cached detected")
+			env.log("Cached detected")
 
 		if clear_cache and cached:
 			for tile in cached:
@@ -284,12 +283,12 @@ def export_image_to_sequence(image_path, params, output_folder=None, form=None):
 	image = bpy.data.images.load(image_path)
 	tiles = image.size[1] / image.size[0]
 	if int(tiles) != tiles:
-		conf.log("Not perfectly tiled image - " + image_path)
+		env.log("Not perfectly tiled image - " + image_path)
 		image.user_clear()
 		if image.users == 0:
 			bpy.data.images.remove(image)
 		else:
-			conf.log("Couldn't remove image, shouldn't keep: " + image.name)
+			env.log("Couldn't remove image, shouldn't keep: " + image.name)
 		return None  # any non-titled materials will exit here
 	else:
 		tiles = int(tiles)
@@ -311,7 +310,7 @@ def export_image_to_sequence(image_path, params, output_folder=None, form=None):
 	pxlen = len(image.pixels)
 	first_img = None
 	for i in range(tiles):
-		conf.log("Exporting sequence tile " + str(i))
+		env.log("Exporting sequence tile " + str(i))
 		tile_name = basename + "_" + str(i + 1).zfill(4)
 		out_path = os.path.join(output_folder, tile_name + ext)
 		if not first_img:
@@ -342,17 +341,17 @@ def export_image_to_sequence(image_path, params, output_folder=None, form=None):
 			if img_tile.users == 0:
 				bpy.data.images.remove(img_tile)
 			else:
-				conf.log("Couldn't remove tile, shouldn't keep: " + img_tile.name)
+				env.log("Couldn't remove tile, shouldn't keep: " + img_tile.name)
 		else:
 			img_tile = None
 			raise Exception("No Animate Textures Mineways support yet")
 
-	conf.log("Finished exporting frame sequence: " + basename)
+	env.log("Finished exporting frame sequence: " + basename)
 	image.user_clear()
 	if image.users == 0:
 		bpy.data.images.remove(image)
 	else:
-		conf.log("Couldn't remove image block, shouldn't keep: " + image.name)
+		env.log("Couldn't remove image block, shouldn't keep: " + image.name)
 
 	return bpy.path.abspath(first_img)
 
@@ -373,11 +372,11 @@ def set_sequence_to_texnode(node, image_path):
 
 	Note: this also works as-is where "node" is actually a texture block
 	"""
-	conf.log("Sequence exporting " + os.path.basename(image_path), vv_only=True)
+	env.log("Sequence exporting " + os.path.basename(image_path), vv_only=True)
 	image_path = bpy.path.abspath(image_path)
 	base_dir = os.path.dirname(image_path)
 	first_img = os.path.splitext(os.path.basename(image_path))[0]
-	conf.log("IMAGE path to apply: {}, node/tex: {}".format(
+	env.log("IMAGE path to apply: {}, node/tex: {}".format(
 		image_path, node.name))
 
 	ind = get_sequence_int_index(first_img)
@@ -387,7 +386,7 @@ def set_sequence_to_texnode(node, image_path):
 	img_count = len(img_sets)
 
 	image_data = bpy.data.images.load(image_path)
-	conf.log("Loaded in " + str(image_data))
+	env.log("Loaded in " + str(image_data))
 	image_data.source = 'SEQUENCE'
 	node.image = image_data
 	node.image_user.frame_duration = img_count
@@ -500,7 +499,7 @@ class MCPREP_OT_prep_animated_textures(bpy.types.Operator):
 				{'ERROR'},
 				("Detected scaled UV's (all in one texture), be sure to use "
 					"Mineway's 'Export Individual Textures To..' feature"))
-			conf.log("Detected scaled UV's, incompatible with animate textures")
+			env.log("Detected scaled UV's, incompatible with animate textures")
 			return {'FINISHED'}
 		else:
 			self.report({'INFO'}, "Modified {} material(s)".format(

--- a/MCprep_addon/materials/sequences.py
+++ b/MCprep_addon/materials/sequences.py
@@ -186,7 +186,8 @@ def generate_material_sequence(
 		# export to save frames in currently selected texturepack (could be addon)
 		seq_path_base = os.path.dirname(bpy.path.abspath(image_path))
 
-	if conf.vv:
+	env = conf.MCprepEnv()
+	if env.very_verbose:
 		conf.log("Pre-sequence details")
 		conf.log(image_path)
 		conf.log(image_dict)

--- a/MCprep_addon/materials/sequences.py
+++ b/MCprep_addon/materials/sequences.py
@@ -30,7 +30,7 @@ from .. import tracking
 from .. import util
 from . import uv_tools
 
-from ..conf import ENV
+from ..conf import env
 
 # -----------------------------------------------------------------------------
 # Supporting functions
@@ -187,7 +187,7 @@ def generate_material_sequence(
 		# export to save frames in currently selected texturepack (could be addon)
 		seq_path_base = os.path.dirname(bpy.path.abspath(image_path))
 
-	if ENV.very_verbose:
+	if env.very_verbose:
 		conf.log("Pre-sequence details")
 		conf.log(image_path)
 		conf.log(image_dict)

--- a/MCprep_addon/materials/sequences.py
+++ b/MCprep_addon/materials/sequences.py
@@ -533,7 +533,6 @@ classes = (
 
 def register():
 	for cls in classes:
-		util.make_annotations(cls)
 		bpy.utils.register_class(cls)
 
 

--- a/MCprep_addon/materials/skin.py
+++ b/MCprep_addon/materials/skin.py
@@ -297,6 +297,7 @@ def download_user(self, context, username):
 	Reusable function from within two common operators for downloading skin.
 	Example link: http://minotar.net/skin/theduckcow
 	"""
+	env = conf.MCprepEnv()
 	conf.log("Downloading skin: " + username)
 
 	src_link = "http://minotar.net/skin/"
@@ -305,7 +306,7 @@ def download_user(self, context, username):
 		username.lower() + ".png")
 
 	try:
-		if conf.vv:
+		if env.very_verbose:
 			print("Download starting with url: " + src_link + username.lower())
 			print("to save location: " + saveloc)
 		urllib.request.urlretrieve(src_link + username.lower(), saveloc)

--- a/MCprep_addon/materials/skin.py
+++ b/MCprep_addon/materials/skin.py
@@ -29,6 +29,7 @@ from . import generate
 from .. import tracking
 from .. import util
 
+from ..conf import ENV
 
 # -----------------------------------------------------------------------------
 # Support functions
@@ -57,12 +58,12 @@ def reloadSkinList(context):
 
 	# clear lists
 	context.scene.mcprep_skins_list.clear()
-	conf.skin_list = []
+	ENV.skin_list = []
 
 	# recreate
 	for i, (skin, description) in enumerate(skinlist, 1):
 		item = context.scene.mcprep_skins_list.add()
-		conf.skin_list.append(
+		ENV.skin_list.append(
 			(skin, os.path.join(skinfolder, skin))
 		)
 		item.label = description
@@ -297,7 +298,6 @@ def download_user(self, context, username):
 	Reusable function from within two common operators for downloading skin.
 	Example link: http://minotar.net/skin/theduckcow
 	"""
-	env = conf.MCprepEnv()
 	conf.log("Downloading skin: " + username)
 
 	src_link = "http://minotar.net/skin/"
@@ -306,7 +306,7 @@ def download_user(self, context, username):
 		username.lower() + ".png")
 
 	try:
-		if env.very_verbose:
+		if ENV.very_verbose:
 			print("Download starting with url: " + src_link + username.lower())
 			print("to save location: " + saveloc)
 		urllib.request.urlretrieve(src_link + username.lower(), saveloc)
@@ -465,8 +465,8 @@ class MCPREP_OT_apply_username_skin(bpy.types.Operator):
 			self.report({"ERROR"}, "Invalid username")
 			return {'CANCELLED'}
 
-		skins = [str(skin[0]).lower() for skin in conf.skin_list]
-		paths = [skin[1] for skin in conf.skin_list]
+		skins = [str(skin[0]).lower() for skin in ENV.skin_list]
+		paths = [skin[1] for skin in ENV.skin_list]
 		if self.username.lower() not in skins or not self.skip_redownload:
 			# Do the download
 			saveloc = download_user(self, context, self.username)
@@ -572,7 +572,7 @@ class MCPREP_OT_remove_skin(bpy.types.Operator):
 			self, width=400 * util.ui_scale())
 
 	def draw(self, context):
-		skin_path = conf.skin_list[context.scene.mcprep_skins_list_index]
+		skin_path = ENV.skin_list[context.scene.mcprep_skins_list_index]
 		col = self.layout.column()
 		col.scale_y = 0.7
 		col.label(text="Warning, will delete file {} from".format(
@@ -582,14 +582,14 @@ class MCPREP_OT_remove_skin(bpy.types.Operator):
 	@tracking.report_error
 	def execute(self, context):
 
-		if not conf.skin_list:
+		if not ENV.skin_list:
 			self.report({"ERROR"}, "No skins loaded in memory, try reloading")
 			return {'CANCELLED'}
-		if context.scene.mcprep_skins_list_index >= len(conf.skin_list):
+		if context.scene.mcprep_skins_list_index >= len(ENV.skin_list):
 			self.report({"ERROR"}, "Indexing error")
 			return {'CANCELLED'}
 
-		file = conf.skin_list[context.scene.mcprep_skins_list_index][-1]
+		file = ENV.skin_list[context.scene.mcprep_skins_list_index][-1]
 
 		if os.path.isfile(file) is False:
 			self.report({"ERROR"}, "Skin not found to delete")
@@ -598,8 +598,8 @@ class MCPREP_OT_remove_skin(bpy.types.Operator):
 
 		# refresh the folder
 		bpy.ops.mcprep.reload_skins()
-		if context.scene.mcprep_skins_list_index >= len(conf.skin_list):
-			context.scene.mcprep_skins_list_index = len(conf.skin_list) - 1
+		if context.scene.mcprep_skins_list_index >= len(ENV.skin_list):
+			context.scene.mcprep_skins_list_index = len(ENV.skin_list) - 1
 
 		# in future, select multiple
 		self.report({"INFO"}, "Removed " + bpy.path.basename(file))
@@ -663,7 +663,7 @@ class MCPREP_OT_spawn_mob_with_skin(bpy.types.Operator):
 	@tracking.report_error
 	def execute(self, context):
 		scn_props = context.scene.mcprep_props
-		if not conf.skin_list:
+		if not ENV.skin_list:
 			self.report({'ERROR'}, "No skins found")
 			return {'CANCELLED'}
 
@@ -679,7 +679,7 @@ class MCPREP_OT_spawn_mob_with_skin(bpy.types.Operator):
 
 		# bpy.ops.mcprep.spawn_with_skin() spawn based on active mob
 		ind = context.scene.mcprep_skins_list_index
-		_ = loadSkinFile(self, context, conf.skin_list[ind][1])
+		_ = loadSkinFile(self, context, ENV.skin_list[ind][1])
 
 		return {'FINISHED'}
 
@@ -736,7 +736,7 @@ class MCPREP_OT_download_username_list(bpy.types.Operator):
 		user_list = list(set(user_list))  # Make list unique.
 
 		# Currently loaded
-		skins = [str(skin[0]).lower() for skin in conf.skin_list]
+		skins = [str(skin[0]).lower() for skin in ENV.skin_list]
 		issue_skins = []
 		for username in user_list:
 			if username.lower() not in skins or not self.skip_redownload:

--- a/MCprep_addon/materials/skin.py
+++ b/MCprep_addon/materials/skin.py
@@ -29,7 +29,7 @@ from . import generate
 from .. import tracking
 from .. import util
 
-from ..conf import ENV
+from ..conf import env
 
 # -----------------------------------------------------------------------------
 # Support functions
@@ -58,12 +58,12 @@ def reloadSkinList(context):
 
 	# clear lists
 	context.scene.mcprep_skins_list.clear()
-	ENV.skin_list = []
+	env.skin_list = []
 
 	# recreate
 	for i, (skin, description) in enumerate(skinlist, 1):
 		item = context.scene.mcprep_skins_list.add()
-		ENV.skin_list.append(
+		env.skin_list.append(
 			(skin, os.path.join(skinfolder, skin))
 		)
 		item.label = description
@@ -306,7 +306,7 @@ def download_user(self, context, username):
 		username.lower() + ".png")
 
 	try:
-		if ENV.very_verbose:
+		if env.very_verbose:
 			print("Download starting with url: " + src_link + username.lower())
 			print("to save location: " + saveloc)
 		urllib.request.urlretrieve(src_link + username.lower(), saveloc)
@@ -465,8 +465,8 @@ class MCPREP_OT_apply_username_skin(bpy.types.Operator):
 			self.report({"ERROR"}, "Invalid username")
 			return {'CANCELLED'}
 
-		skins = [str(skin[0]).lower() for skin in ENV.skin_list]
-		paths = [skin[1] for skin in ENV.skin_list]
+		skins = [str(skin[0]).lower() for skin in env.skin_list]
+		paths = [skin[1] for skin in env.skin_list]
 		if self.username.lower() not in skins or not self.skip_redownload:
 			# Do the download
 			saveloc = download_user(self, context, self.username)
@@ -572,7 +572,7 @@ class MCPREP_OT_remove_skin(bpy.types.Operator):
 			self, width=400 * util.ui_scale())
 
 	def draw(self, context):
-		skin_path = ENV.skin_list[context.scene.mcprep_skins_list_index]
+		skin_path = env.skin_list[context.scene.mcprep_skins_list_index]
 		col = self.layout.column()
 		col.scale_y = 0.7
 		col.label(text="Warning, will delete file {} from".format(
@@ -582,14 +582,14 @@ class MCPREP_OT_remove_skin(bpy.types.Operator):
 	@tracking.report_error
 	def execute(self, context):
 
-		if not ENV.skin_list:
+		if not env.skin_list:
 			self.report({"ERROR"}, "No skins loaded in memory, try reloading")
 			return {'CANCELLED'}
-		if context.scene.mcprep_skins_list_index >= len(ENV.skin_list):
+		if context.scene.mcprep_skins_list_index >= len(env.skin_list):
 			self.report({"ERROR"}, "Indexing error")
 			return {'CANCELLED'}
 
-		file = ENV.skin_list[context.scene.mcprep_skins_list_index][-1]
+		file = env.skin_list[context.scene.mcprep_skins_list_index][-1]
 
 		if os.path.isfile(file) is False:
 			self.report({"ERROR"}, "Skin not found to delete")
@@ -598,8 +598,8 @@ class MCPREP_OT_remove_skin(bpy.types.Operator):
 
 		# refresh the folder
 		bpy.ops.mcprep.reload_skins()
-		if context.scene.mcprep_skins_list_index >= len(ENV.skin_list):
-			context.scene.mcprep_skins_list_index = len(ENV.skin_list) - 1
+		if context.scene.mcprep_skins_list_index >= len(env.skin_list):
+			context.scene.mcprep_skins_list_index = len(env.skin_list) - 1
 
 		# in future, select multiple
 		self.report({"INFO"}, "Removed " + bpy.path.basename(file))
@@ -663,7 +663,7 @@ class MCPREP_OT_spawn_mob_with_skin(bpy.types.Operator):
 	@tracking.report_error
 	def execute(self, context):
 		scn_props = context.scene.mcprep_props
-		if not ENV.skin_list:
+		if not env.skin_list:
 			self.report({'ERROR'}, "No skins found")
 			return {'CANCELLED'}
 
@@ -679,7 +679,7 @@ class MCPREP_OT_spawn_mob_with_skin(bpy.types.Operator):
 
 		# bpy.ops.mcprep.spawn_with_skin() spawn based on active mob
 		ind = context.scene.mcprep_skins_list_index
-		_ = loadSkinFile(self, context, ENV.skin_list[ind][1])
+		_ = loadSkinFile(self, context, env.skin_list[ind][1])
 
 		return {'FINISHED'}
 
@@ -736,7 +736,7 @@ class MCPREP_OT_download_username_list(bpy.types.Operator):
 		user_list = list(set(user_list))  # Make list unique.
 
 		# Currently loaded
-		skins = [str(skin[0]).lower() for skin in ENV.skin_list]
+		skins = [str(skin[0]).lower() for skin in env.skin_list]
 		issue_skins = []
 		for username in user_list:
 			if username.lower() not in skins or not self.skip_redownload:

--- a/MCprep_addon/materials/skin.py
+++ b/MCprep_addon/materials/skin.py
@@ -351,8 +351,8 @@ class MCPREP_UL_skins(bpy.types.UIList):
 
 class ListColl(bpy.types.PropertyGroup):
 	"""For asset listing"""
-	label = bpy.props.StringProperty()
-	description = bpy.props.StringProperty()
+	label: bpy.props.StringProperty()
+	description: bpy.props.StringProperty()
 
 
 class MCPREP_OT_swap_skin_from_file(bpy.types.Operator, ImportHelper):

--- a/MCprep_addon/materials/skin.py
+++ b/MCprep_addon/materials/skin.py
@@ -24,7 +24,6 @@ import shutil
 import urllib.request
 from bpy.app.handlers import persistent
 
-from .. import conf
 from . import generate
 from .. import tracking
 from .. import util
@@ -73,7 +72,7 @@ def reloadSkinList(context):
 
 def update_skin_path(self, context):
 	"""For UI list path callback"""
-	conf.log("Updating rig path", vv_only=True)
+	env.log("Updating rig path", vv_only=True)
 	reloadSkinList(context)
 
 
@@ -83,17 +82,17 @@ def handler_skins_enablehack(scene):
 		bpy.app.handlers.scene_update_pre.remove(handler_skins_enablehack)
 	except:
 		pass
-	conf.log("Triggering Handler_skins_load from first enable", vv_only=True)
+	env.log("Triggering Handler_skins_load from first enable", vv_only=True)
 	handler_skins_load(scene)
 
 
 @persistent
 def handler_skins_load(scene):
 	try:
-		conf.log("Reloading skins", vv_only=True)
+		env.log("Reloading skins", vv_only=True)
 		reloadSkinList(bpy.context)
 	except:
-		conf.log("Didn't run skin reloading callback", vv_only=True)
+		env.log("Didn't run skin reloading callback", vv_only=True)
 
 
 def loadSkinFile(self, context, filepath, new_material=False):
@@ -142,7 +141,7 @@ def convert_skin_layout(image_file):
 	"""
 
 	if not os.path.isfile(image_file):
-		conf.log("Error! Image file does not exist: " + image_file)
+		env.log("Error! Image file does not exist: " + image_file)
 		return False
 
 	img = bpy.data.images.load(image_file)
@@ -150,13 +149,13 @@ def convert_skin_layout(image_file):
 		return False
 	elif img.size[0] != img.size[1] * 2:
 		# some image that isn't the normal 64x32 of old skin formats
-		conf.log("Unknown skin image format, not converting layout")
+		env.log("Unknown skin image format, not converting layout")
 		return False
 	elif img.size[0] / 64 != int(img.size[0] / 64):
-		conf.log("Non-regular scaling of skin image, can't process")
+		env.log("Non-regular scaling of skin image, can't process")
 		return False
 
-	conf.log("Old image format detected, converting to post 1.8 layout")
+	env.log("Old image format detected, converting to post 1.8 layout")
 
 	scale = int(img.size[0] / 64)
 	has_alpha = img.channels == 4
@@ -196,7 +195,7 @@ def convert_skin_layout(image_file):
 			end = (row * block_width * 4) + block_width + (block_width * 2.5)
 			lower_half += upper_half[int(start):int(end)]
 		else:
-			conf.log("Bad math! Should never go above 4 blocks")
+			env.log("Bad math! Should never go above 4 blocks")
 			failout = True
 			break
 
@@ -207,7 +206,7 @@ def convert_skin_layout(image_file):
 		new_image.pixels = new_pixels
 		new_image.filepath_raw = image_file
 		new_image.save()
-		conf.log("Saved out post 1.8 converted skin file")
+		env.log("Saved out post 1.8 converted skin file")
 
 	# cleanup files
 	img.user_clear()
@@ -244,7 +243,7 @@ def getMatsFromSelected(selected, new_material=False):
 
 	for ob in obj_list:
 		if ob.data.library:
-			conf.log("Library object, skipping")
+			env.log("Library object, skipping")
 			linked_objs += 1
 			continue
 		elif new_material is False:
@@ -284,7 +283,7 @@ def setUVimage(objs, image):
 		if obj.type != "MESH":
 			continue
 		if not hasattr(obj.data, "uv_textures"):
-			conf.log("Called setUVimage on object with no uv_textures, 2.8?")
+			env.log("Called setUVimage on object with no uv_textures, 2.8?")
 			return
 		if obj.data.uv_textures.active is None:
 			continue
@@ -298,7 +297,7 @@ def download_user(self, context, username):
 	Reusable function from within two common operators for downloading skin.
 	Example link: http://minotar.net/skin/theduckcow
 	"""
-	conf.log("Downloading skin: " + username)
+	env.log("Downloading skin: " + username)
 
 	src_link = "http://minotar.net/skin/"
 	saveloc = os.path.join(
@@ -480,7 +479,7 @@ class MCPREP_OT_apply_username_skin(bpy.types.Operator):
 			bpy.ops.mcprep.reload_skins()
 			return {'FINISHED'}
 		else:
-			conf.log("Reusing downloaded skin")
+			env.log("Reusing downloaded skin")
 			ind = skins.index(self.username.lower())
 			res = loadSkinFile(self, context, paths[ind][1], self.new_material)
 			if res != 0:
@@ -791,7 +790,7 @@ def register():
 	bpy.types.Scene.mcprep_skins_list_index = bpy.props.IntProperty(default=0)
 
 	# to auto-load the skins
-	conf.log("Adding reload skin handler to scene", vv_only=True)
+	env.log("Adding reload skin handler to scene", vv_only=True)
 	try:
 		bpy.app.handlers.scene_update_pre.append(handler_skins_enablehack)
 	except:

--- a/MCprep_addon/materials/sync.py
+++ b/MCprep_addon/materials/sync.py
@@ -22,7 +22,7 @@ import os
 import bpy
 from bpy.app.handlers import persistent
 
-from .. import conf
+from ..conf import env 
 from .. import tracking
 from .. import util
 
@@ -34,7 +34,7 @@ from ..conf import env
 
 @persistent
 def clear_sync_cache(scene):
-	conf.log("Resetting sync mat cache", vv_only=True)
+	env.log("Resetting sync mat cache", vv_only=True)
 	env.material_sync_cache = None
 
 
@@ -179,7 +179,7 @@ class MCPREP_OT_sync_materials(bpy.types.Operator):
 				last_err = err
 
 		if last_err:
-			conf.log("Most recent error during sync:" + str(last_err))
+			env.log("Most recent error during sync:" + str(last_err))
 
 		# Re-establish initial state, as append material clears selections
 		for obj in inital_selection:

--- a/MCprep_addon/materials/sync.py
+++ b/MCprep_addon/materials/sync.py
@@ -26,6 +26,7 @@ from .. import conf
 from .. import tracking
 from .. import util
 
+from ..conf import ENV
 
 # -----------------------------------------------------------------------------
 # Utilities
@@ -34,7 +35,7 @@ from .. import util
 @persistent
 def clear_sync_cache(scene):
 	conf.log("Resetting sync mat cache", vv_only=True)
-	conf.material_sync_cache = None
+	ENV.material_sync_cache = None
 
 
 def get_sync_blend(context):
@@ -47,21 +48,21 @@ def reload_material_sync_library(context):
 	"""Reloads the library and cache"""
 	sync_file = get_sync_blend(context)
 	if not os.path.isfile(sync_file):
-		conf.material_sync_cache = []
+		ENV.material_sync_cache = []
 		return
 
 	with bpy.data.libraries.load(sync_file) as (data_from, _):
-		conf.material_sync_cache = list(data_from.materials)
-	conf.log("Updated sync cache", vv_only=True)
+		ENV.material_sync_cache = list(data_from.materials)
+	ENV.log("Updated sync cache", vv_only=True)
 
 
 def material_in_sync_library(material, context):
 	"""Returns true if the material is in the sync mat library blend file"""
-	if conf.material_sync_cache is None:
+	if ENV.material_sync_cache is None:
 		reload_material_sync_library(context)
-	if util.nameGeneralize(material.name) in conf.material_sync_cache:
+	if util.nameGeneralize(material.name) in ENV.material_sync_cache:
 		return True
-	elif material.name in conf.material_sync_cache:
+	elif material.name in ENV.material_sync_cache:
 		return True
 	return False
 
@@ -73,9 +74,9 @@ def sync_material(context, material, link, replace):
 		0 if nothing modified, 1 if modified
 		None if no error or string if error
 	"""
-	if material.name in conf.material_sync_cache:
+	if material.name in ENV.material_sync_cache:
 		import_name = material.name
-	elif util.nameGeneralize(material.name) in conf.material_sync_cache:
+	elif util.nameGeneralize(material.name) in ENV.material_sync_cache:
 		import_name = util.nameGeneralize(material.name)
 
 	# if link is true, check library material not already linked

--- a/MCprep_addon/materials/sync.py
+++ b/MCprep_addon/materials/sync.py
@@ -26,7 +26,7 @@ from .. import conf
 from .. import tracking
 from .. import util
 
-from ..conf import ENV
+from ..conf import env
 
 # -----------------------------------------------------------------------------
 # Utilities
@@ -35,7 +35,7 @@ from ..conf import ENV
 @persistent
 def clear_sync_cache(scene):
 	conf.log("Resetting sync mat cache", vv_only=True)
-	ENV.material_sync_cache = None
+	env.material_sync_cache = None
 
 
 def get_sync_blend(context):
@@ -48,21 +48,21 @@ def reload_material_sync_library(context):
 	"""Reloads the library and cache"""
 	sync_file = get_sync_blend(context)
 	if not os.path.isfile(sync_file):
-		ENV.material_sync_cache = []
+		env.material_sync_cache = []
 		return
 
 	with bpy.data.libraries.load(sync_file) as (data_from, _):
-		ENV.material_sync_cache = list(data_from.materials)
-	ENV.log("Updated sync cache", vv_only=True)
+		env.material_sync_cache = list(data_from.materials)
+	env.log("Updated sync cache", vv_only=True)
 
 
 def material_in_sync_library(material, context):
 	"""Returns true if the material is in the sync mat library blend file"""
-	if ENV.material_sync_cache is None:
+	if env.material_sync_cache is None:
 		reload_material_sync_library(context)
-	if util.nameGeneralize(material.name) in ENV.material_sync_cache:
+	if util.nameGeneralize(material.name) in env.material_sync_cache:
 		return True
-	elif material.name in ENV.material_sync_cache:
+	elif material.name in env.material_sync_cache:
 		return True
 	return False
 
@@ -74,9 +74,9 @@ def sync_material(context, material, link, replace):
 		0 if nothing modified, 1 if modified
 		None if no error or string if error
 	"""
-	if material.name in ENV.material_sync_cache:
+	if material.name in env.material_sync_cache:
 		import_name = material.name
-	elif util.nameGeneralize(material.name) in ENV.material_sync_cache:
+	elif util.nameGeneralize(material.name) in env.material_sync_cache:
 		import_name = util.nameGeneralize(material.name)
 
 	# if link is true, check library material not already linked

--- a/MCprep_addon/materials/sync.py
+++ b/MCprep_addon/materials/sync.py
@@ -215,7 +215,6 @@ classes = (
 
 def register():
 	for cls in classes:
-		util.make_annotations(cls)
 		bpy.utils.register_class(cls)
 	bpy.app.handlers.load_post.append(clear_sync_cache)
 

--- a/MCprep_addon/materials/uv_tools.py
+++ b/MCprep_addon/materials/uv_tools.py
@@ -21,7 +21,7 @@ import bpy
 
 import time
 
-from .. import conf
+from ..conf import env
 from . import generate
 from .. import tracking
 from .. import util
@@ -98,7 +98,7 @@ def detect_invalid_uvs_from_objs(obj_list):
 	# rightfully not up against bounds of image. But generally, for combined
 	# images the area covered is closer to 0.05
 	thresh = 0.25
-	conf.log("Doing check for invalid UV faces", vv_only=True)
+	env.log("Doing check for invalid UV faces", vv_only=True)
 	t0 = time.time()
 
 	for obj in obj_list:
@@ -122,7 +122,7 @@ def detect_invalid_uvs_from_objs(obj_list):
 			invalid_objects.append(obj)
 	t1 = time.time()
 	t_diff = t1 - t0  # round to .1s
-	conf.log("UV check took {}s".format(t_diff), vv_only=True)
+	env.log("UV check took {}s".format(t_diff), vv_only=True)
 	return invalid, invalid_objects
 
 
@@ -187,7 +187,7 @@ class MCPREP_OT_scale_uv(bpy.types.Operator):
 
 		if ret is not None:
 			self.report({'ERROR'}, ret)
-			conf.log("Error, " + ret)
+			env.log("Error, " + ret)
 			return {'CANCELLED'}
 
 		return {'FINISHED'}
@@ -285,7 +285,7 @@ class MCPREP_OT_select_alpha_faces(bpy.types.Operator):
 			return {"CANCELLED"}
 
 		if not ret and self.delete:
-			conf.log("Delet faces")
+			env.log("Delet faces")
 			bpy.ops.mesh.delete(type='FACE')
 
 		return {"FINISHED"}
@@ -293,7 +293,7 @@ class MCPREP_OT_select_alpha_faces(bpy.types.Operator):
 	def select_alpha(self, ob, threshold):
 		"""Core function to select alpha faces based on active material/image."""
 		if not ob.material_slots:
-			conf.log("No materials, skipping.")
+			env.log("No materials, skipping.")
 			return "No materials"
 
 		# pre-cache the materials and their respective images for comparing
@@ -309,7 +309,7 @@ class MCPREP_OT_select_alpha_faces(bpy.types.Operator):
 				continue
 			elif image.channels != 4:
 				textures.append(None)  # no alpha channel anyways
-				conf.log("No alpha channel for: " + image.name)
+				env.log("No alpha channel for: " + image.name)
 				continue
 			textures.append(image)
 		data = [None for tex in textures]
@@ -321,7 +321,7 @@ class MCPREP_OT_select_alpha_faces(bpy.types.Operator):
 			fnd = f.material_index
 			image = textures[fnd]
 			if not image:
-				conf.log("Could not get image from face's material")
+				env.log("Could not get image from face's material")
 				return "Could not get image from face's material"
 
 			# lazy load alpha part of image to memory, hold for whole operator
@@ -348,7 +348,7 @@ class MCPREP_OT_select_alpha_faces(bpy.types.Operator):
 			xmax = round(max(xlist) * image.size[0]) - 0.5
 			ymin = round(min(ylist) * image.size[1]) - 0.5
 			ymax = round(max(ylist) * image.size[1]) - 0.5
-			conf.log(["\tSet size:", xmin, xmax, ymin, ymax], vv_only=True)
+			env.log(["\tSet size:", xmin, xmax, ymin, ymax], vv_only=True)
 
 			# assuming faces are roughly rectangular, sum pixels a face covers
 			asum = 0

--- a/MCprep_addon/materials/uv_tools.py
+++ b/MCprep_addon/materials/uv_tools.py
@@ -390,7 +390,6 @@ classes = (
 
 def register():
 	for cls in classes:
-		util.make_annotations(cls)
 		bpy.utils.register_class(cls)
 
 

--- a/MCprep_addon/mcprep_ui.py
+++ b/MCprep_addon/mcprep_ui.py
@@ -37,6 +37,7 @@ from .spawner import mcmodel
 from .spawner import meshswap
 from .spawner import mobs
 from .spawner import spawn_util
+from .conf import ENV
 # from .import_bridge import bridge
 
 # blender 2.7 vs 2.8 icon selections
@@ -49,7 +50,6 @@ OPT_IN = 'URL' if util.bv28() else 'HAND'
 # Above for class functions/operators
 # Below for UI
 # -----------------------------------------------------------------------------
-
 
 class MCPREP_MT_mob_spawner(bpy.types.Menu):
 	"""Shift-A menu in the 3D view"""
@@ -75,12 +75,12 @@ class MCPREP_MT_mob_spawner(bpy.types.Menu):
 			# show icon if available
 			mob = scn_props.mob_list_all[mobkey]
 			icn = "mob-{}".format(mob.index)
-			if conf.use_icons and icn in conf.preview_collections["mobs"]:
+			if ENV.use_icons and icn in ENV.preview_collections["mobs"]:
 				ops = layout.operator(
 					"mcprep.mob_spawner",
 					text=mob.name,
-					icon_value=conf.preview_collections["mobs"][icn].icon_id)
-			elif conf.use_icons:
+					icon_value=ENV.preview_collections["mobs"][icn].icon_id)
+			elif ENV.use_icons:
 				ops = layout.operator(
 					"mcprep.mob_spawner", text=mob.name, icon="BLANK1")
 			else:
@@ -88,7 +88,7 @@ class MCPREP_MT_mob_spawner(bpy.types.Menu):
 			ops.mcmob_type = mob.mcmob_type
 
 			# Skip prep materials in case of unique shader.
-			if conf.json_data and mob.name in conf.json_data.get("mob_skip_prep", []):
+			if ENV.json_data and mob.name in ENV.json_data.get("mob_skip_prep", []):
 				ops.prep_materials = False
 
 
@@ -117,7 +117,7 @@ class MCPREP_MT_meshswap_place(bpy.types.Menu):
 			opr.location = util.get_cuser_location(context)
 
 			# Ensure meshswap with rigs is made real, so the rigs can be used.
-			if conf.json_data and blockset[1] in conf.json_data.get("make_real", []):
+			if ENV.json_data and blockset[1] in ENV.json_data.get("make_real", []):
 				opr.make_real = True
 
 
@@ -132,11 +132,11 @@ class MCPREP_MT_item_spawn(bpy.types.Menu):
 			layout.label(text="No items found!")
 		for item in context.scene.mcprep_props.item_list:
 			icn = "item-{}".format(item.index)
-			if conf.use_icons and icn in conf.preview_collections["items"]:
+			if ENV.use_icons and icn in ENV.preview_collections["items"]:
 				ops = layout.operator(
 					"mcprep.spawn_item", text=item.name,
-					icon_value=conf.preview_collections["items"][icn].icon_id)
-			elif conf.use_icons:
+					icon_value=ENV.preview_collections["items"][icn].icon_id)
+			elif ENV.use_icons:
 				ops = layout.operator(
 					"mcprep.spawn_item", text=item.name, icon="BLANK1")
 			else:
@@ -172,11 +172,11 @@ class MCPREP_MT_effect_spawn(bpy.types.Menu):
 				ops.frame = context.scene.frame_current
 			elif effect.effect_type == effects.IMG_SEQ:
 				icon = "effects-{}".format(effect.index)
-				if conf.use_icons and icon in conf.preview_collections["effects"]:
+				if ENV.use_icons and icon in ENV.preview_collections["effects"]:
 					ops = col.operator(
 						"mcprep.spawn_instant_effect",
 						text=effect.name,
-						icon_value=conf.preview_collections["effects"][icon].icon_id)
+						icon_value=ENV.preview_collections["effects"][icon].icon_id)
 				else:
 					ops = col.operator(
 						"mcprep.spawn_instant_effect",
@@ -239,13 +239,13 @@ class MCPREP_MT_3dview_add(bpy.types.Menu):
 		layout = self.layout
 		props = context.scene.mcprep_props
 
-		if conf.preview_collections["main"] != "":
-			spawner_icon = conf.preview_collections["main"].get("spawner_icon")
-			meshswap_icon = conf.preview_collections["main"].get("meshswap_icon")
-			sword_icon = conf.preview_collections["main"].get("sword_icon")
-			effects_icon = conf.preview_collections["main"].get("effects_icon")
-			entity_icon = conf.preview_collections["main"].get("entity_icon")
-			model_icon = conf.preview_collections["main"].get("model_icon")
+		if ENV.preview_collections["main"] != "":
+			spawner_icon = ENV.preview_collections["main"].get("spawner_icon")
+			meshswap_icon = ENV.preview_collections["main"].get("meshswap_icon")
+			sword_icon = ENV.preview_collections["main"].get("sword_icon")
+			effects_icon = ENV.preview_collections["main"].get("effects_icon")
+			entity_icon = ENV.preview_collections["main"].get("entity_icon")
+			model_icon = ENV.preview_collections["main"].get("model_icon")
 		else:
 			spawner_icon = None
 			meshswap_icon = None
@@ -255,7 +255,7 @@ class MCPREP_MT_3dview_add(bpy.types.Menu):
 			model_icon = None
 
 		all_loaded = props.mob_list and props.meshswap_list and props.item_list
-		if not conf.loaded_all_spawners and not all_loaded:
+		if not ENV.loaded_all_spawners and not all_loaded:
 			row = layout.row()
 			row.operator(
 				"mcprep.reload_spawners", text="Load spawners", icon=HAND_ICON)
@@ -320,8 +320,7 @@ class McprepPreference(bpy.types.AddonPreferences):
 	scriptdir = bpy.path.abspath(os.path.dirname(__file__))
 
 	def change_verbose(self, context):
-		env = conf.MCprepEnv()
-		env.verbose = self.verbose
+		ENV.verbose = self.verbose
 
 	meshswap_path = bpy.props.StringProperty(
 		name="Meshswap path",
@@ -899,18 +898,18 @@ class MCPREP_PT_skins(bpy.types.Panel):
 		row = layout.row()
 		col = row.column()
 
-		is_sortable = len(conf.skin_list) > 1
+		is_sortable = len(ENV.skin_list) > 1
 		rows = 1
 		if (is_sortable):
 			rows = 4
 
 		# any other conditions for needing reloading?
-		if not conf.skin_list:
+		if not ENV.skin_list:
 			col = layout.column()
 			col.label(text="No skins found/loaded")
 			p = col.operator(
 				"mcprep.reload_skins", text="Press to reload", icon="ERROR")
-		elif conf.skin_list and len(conf.skin_list) <= sind:
+		elif ENV.skin_list and len(ENV.skin_list) <= sind:
 			col = layout.column()
 			col.label(text="Reload skins")
 			p = col.operator(
@@ -926,10 +925,10 @@ class MCPREP_PT_skins(bpy.types.Panel):
 
 			row = col.row(align=True)
 			row.scale_y = 1.5
-			if conf.skin_list:
-				skinname = bpy.path.basename(conf.skin_list[sind][0])
+			if ENV.skin_list:
+				skinname = bpy.path.basename(ENV.skin_list[sind][0])
 				p = row.operator("mcprep.applyskin", text="Apply " + skinname)
-				p.filepath = conf.skin_list[sind][1]
+				p.filepath = ENV.skin_list[sind][1]
 			else:
 				row.enabled = False
 				p = row.operator("mcprep.skin_swapper", text="No skins found")
@@ -972,7 +971,7 @@ class MCPREP_PT_skins(bpy.types.Panel):
 					row.enabled = False
 					row.operator(
 						"mcprep.spawn_with_skin", text="Reload mobs below")
-				elif not conf.skin_list:
+				elif not ENV.skin_list:
 					row.enabled = False
 					row.operator(
 						"mcprep.spawn_with_skin", text="Reload skins above")
@@ -1113,7 +1112,7 @@ def mob_spawner(self, context):
 		p.mcmob_type = mcmob_type
 
 	# Skip prep materials in case of unique shader.
-	if conf.json_data and name in conf.json_data.get("mob_skip_prep", []):
+	if ENV.json_data and name in ENV.json_data.get("mob_skip_prep", []):
 		p.prep_materials = False
 
 	p = col.operator("mcprep.mob_install_menu")
@@ -1153,7 +1152,7 @@ def mob_spawner(self, context):
 			b_col.operator("mcprep.mob_install_icon")
 		else:
 			icon_index = scn_props.mob_list[scn_props.mob_list_index].index
-			if "mob-{}".format(icon_index) in conf.preview_collections["mobs"]:
+			if "mob-{}".format(icon_index) in ENV.preview_collections["mobs"]:
 				b_col.operator(
 					"mcprep.mob_install_icon", text="Change mob icon")
 			else:
@@ -1219,7 +1218,7 @@ def meshswap_spawner(self, context):
 		p.method = method
 		p.location = util.get_cuser_location(context)
 		# Ensure meshswap with rigs is made real, so the rigs can be used.
-		if conf.json_data and block in conf.json_data.get("make_real", []):
+		if ENV.json_data and block in ENV.json_data.get("make_real", []):
 			p.make_real = True
 
 	else:
@@ -1259,7 +1258,7 @@ def meshswap_spawner(self, context):
 def item_spawner(self, context):
 	"""Code for drawing the item spawner"""
 	scn_props = context.scene.mcprep_props
-
+	
 	layout = self.layout
 	layout.label(text="Generate items from textures")
 	split = layout.split()
@@ -1595,9 +1594,9 @@ class MCPREP_PT_mob_spawner(bpy.types.Panel):
 		mob_spawner(self, context)
 
 	def draw_header(self, context):
-		if not conf.use_icons or conf.preview_collections["main"] == "":
+		if not ENV.use_icons or ENV.preview_collections["main"] == "":
 			return
-		icon = conf.preview_collections["main"].get("spawner_icon")
+		icon = ENV.preview_collections["main"].get("spawner_icon")
 		if not icon:
 			return
 		self.layout.label(text="", icon_value=icon.icon_id)
@@ -1620,9 +1619,9 @@ class MCPREP_PT_model_spawner(bpy.types.Panel):
 		model_spawner(self, context)
 
 	def draw_header(self, context):
-		if not conf.use_icons or conf.preview_collections["main"] == "":
+		if not ENV.use_icons or ENV.preview_collections["main"] == "":
 			return
-		icon = conf.preview_collections["main"].get("model_icon")
+		icon = ENV.preview_collections["main"].get("model_icon")
 		if not icon:
 			return
 		self.layout.label(text="", icon_value=icon.icon_id)
@@ -1646,9 +1645,9 @@ class MCPREP_PT_item_spawner(bpy.types.Panel):
 		item_spawner(self, context)
 
 	def draw_header(self, context):
-		if not conf.use_icons or conf.preview_collections["main"] == "":
+		if not ENV.use_icons or ENV.preview_collections["main"] == "":
 			return
-		icon = conf.preview_collections["main"].get("sword_icon")
+		icon = ENV.preview_collections["main"].get("sword_icon")
 		if not icon:
 			return
 		self.layout.label(text="", icon_value=icon.icon_id)
@@ -1671,9 +1670,9 @@ class MCPREP_PT_effects_spawner(bpy.types.Panel):
 		effects_spawner(self, context)
 
 	def draw_header(self, context):
-		if not conf.use_icons or conf.preview_collections["main"] == "":
+		if not ENV.use_icons or ENV.preview_collections["main"] == "":
 			return
-		icon = conf.preview_collections["main"].get("effects_icon")
+		icon = ENV.preview_collections["main"].get("effects_icon")
 		if not icon:
 			return
 		self.layout.label(text="", icon_value=icon.icon_id)
@@ -1696,9 +1695,9 @@ class MCPREP_PT_entity_spawner(bpy.types.Panel):
 		entity_spawner(self, context)
 
 	def draw_header(self, context):
-		if not conf.use_icons or conf.preview_collections["main"] == "":
+		if not ENV.use_icons or ENV.preview_collections["main"] == "":
 			return
-		icon = conf.preview_collections["main"].get("entity_icon")
+		icon = ENV.preview_collections["main"].get("entity_icon")
 		if not icon:
 			return
 		self.layout.label(text="", icon_value=icon.icon_id)
@@ -1721,9 +1720,9 @@ class MCPREP_PT_meshswap_spawner(bpy.types.Panel):
 		meshswap_spawner(self, context)
 
 	def draw_header(self, context):
-		if not conf.use_icons or conf.preview_collections["main"] == "":
+		if not ENV.use_icons or ENV.preview_collections["main"] == "":
 			return
-		icon = conf.preview_collections["main"].get("meshswap_icon")
+		icon = ENV.preview_collections["main"].get("meshswap_icon")
 		if not icon:
 			return
 		self.layout.label(text="", icon_value=icon.icon_id)
@@ -1738,7 +1737,7 @@ class MCPREP_PT_meshswap_spawner(bpy.types.Panel):
 def draw_mcprepadd(self, context):
 	"""Append to Shift+A, icon for top-level MCprep section."""
 	layout = self.layout
-	pcoll = conf.preview_collections["main"]
+	pcoll = ENV.preview_collections["main"]
 	if pcoll != "":
 		my_icon = pcoll["crafting_icon"]
 		layout.menu(MCPREP_MT_3dview_add.bl_idname, icon_value=my_icon.icon_id)
@@ -1771,8 +1770,8 @@ def mcprep_image_tools(self, context):
 		txt = "Spawn as item"
 	if not img:
 		row.enabled = False
-	if conf.preview_collections["main"] != "":
-		sword_icon = conf.preview_collections["main"]["sword_icon"]
+	if ENV.preview_collections["main"] != "":
+		sword_icon = ENV.preview_collections["main"]["sword_icon"]
 	else:
 		sword_icon = None
 
@@ -1888,7 +1887,6 @@ classes = (
 
 
 def register():
-	env = conf.MCprepEnv()
 	for cls in classes:
 		util.make_annotations(cls)
 		bpy.utils.register_class(cls)
@@ -1937,7 +1935,7 @@ def register():
 		update=update_mcprep_texturepack_path,
 		default=addon_prefs.custom_texturepack_path)
 
-	env.verbose = addon_prefs.verbose
+	ENV.verbose = addon_prefs.verbose
 	if hasattr(bpy.types, "INFO_MT_add"):  # 2.7
 		bpy.types.INFO_MT_add.append(draw_mcprepadd)
 	elif hasattr(bpy.types, "VIEW3D_MT_add"):  # 2.8

--- a/MCprep_addon/mcprep_ui.py
+++ b/MCprep_addon/mcprep_ui.py
@@ -1841,35 +1841,35 @@ class McprepProps(bpy.types.PropertyGroup):
 	addon_prefs = util.get_user_preferences()
 
 	# depreciated, keeping to prevent re-registration errors
-	show_settings_material = bpy.props.BoolProperty(
+	show_settings_material: bpy.props.BoolProperty(
 		name="show material settings",
 		description="Show extra MCprep panel settings",
 		default=False)
-	show_settings_skin = bpy.props.BoolProperty(
+	show_settings_skin: bpy.props.BoolProperty(
 		name="show skin settings",
 		description="Show extra MCprep panel settings",
 		default=False)
-	show_settings_optimizer = bpy.props.BoolProperty(
+	show_settings_optimizer: bpy.props.BoolProperty(
 		name="show optimizer settings",
 		description="Show extra MCprep panel settings",
 		default=False)
-	show_settings_spawner = bpy.props.BoolProperty(
+	show_settings_spawner: bpy.props.BoolProperty(
 		name="show spawner settings",
 		description="Show extra MCprep panel settings",
 		default=False)
-	show_settings_effect = bpy.props.BoolProperty(
+	show_settings_effect: bpy.props.BoolProperty(
 		name="show effect settings",
 		description="Show extra MCprep panel settings",
 		default=False)
 
 	# Rig settings
-	spawn_rig_category = bpy.props.EnumProperty(
+	spawn_rig_category: bpy.props.EnumProperty(
 		name="Mob category",
 		description="Category of mobs & character rigs to spawn",
 		update=mobs.spawn_rigs_category_load,
 		items=mobs.spawn_rigs_categories
 	)
-	spawn_mode = bpy.props.EnumProperty(
+	spawn_mode: bpy.props.EnumProperty(
 		name="Spawn Mode",
 		description="Set mode for rig/object spawner",
 		items=[
@@ -1881,28 +1881,28 @@ class McprepProps(bpy.types.PropertyGroup):
 	)
 
 	# spawn lists
-	mob_list = bpy.props.CollectionProperty(type=spawn_util.ListMobAssets)
-	mob_list_index = bpy.props.IntProperty(default=0)
-	mob_list_all = bpy.props.CollectionProperty(
+	mob_list: bpy.props.CollectionProperty(type=spawn_util.ListMobAssets)
+	mob_list_index: bpy.props.IntProperty(default=0)
+	mob_list_all: bpy.props.CollectionProperty(
 		type=spawn_util.ListMobAssetsAll)
-	meshswap_list = bpy.props.CollectionProperty(
+	meshswap_list: bpy.props.CollectionProperty(
 		type=spawn_util.ListMeshswapAssets)
-	meshswap_list_index = bpy.props.IntProperty(default=0)
-	item_list = bpy.props.CollectionProperty(type=spawn_util.ListItemAssets)
-	item_list_index = bpy.props.IntProperty(default=0)
-	material_list = bpy.props.CollectionProperty(
+	meshswap_list_index: bpy.props.IntProperty(default=0)
+	item_list: bpy.props.CollectionProperty(type=spawn_util.ListItemAssets)
+	item_list_index: bpy.props.IntProperty(default=0)
+	material_list: bpy.props.CollectionProperty(
 		type=material_manager.ListMaterials)
-	material_list_index = bpy.props.IntProperty(default=0)
-	entity_list = bpy.props.CollectionProperty(type=spawn_util.ListEntityAssets)
-	entity_list_index = bpy.props.IntProperty(default=0)
-	model_list = bpy.props.CollectionProperty(type=spawn_util.ListModelAssets)
-	model_list_index = bpy.props.IntProperty(default=0)
+	material_list_index: bpy.props.IntProperty(default=0)
+	entity_list: bpy.props.CollectionProperty(type=spawn_util.ListEntityAssets)
+	entity_list_index: bpy.props.IntProperty(default=0)
+	model_list: bpy.props.CollectionProperty(type=spawn_util.ListModelAssets)
+	model_list_index: bpy.props.IntProperty(default=0)
 
 	# Effects are uniqune in that they are loaded into a list structure,
 	# but the UI list itself is not directly displayed. Rather, dropdowns
 	# will iterate over this to populate based on type.
-	effects_list = bpy.props.CollectionProperty(type=spawn_util.ListEffectsAssets)
-	effects_list_index = bpy.props.IntProperty(default=0)
+	effects_list: bpy.props.CollectionProperty(type=spawn_util.ListEffectsAssets)
+	effects_list_index: bpy.props.IntProperty(default=0)
 
 
 # -----------------------------------------------------------------------------
@@ -1938,7 +1938,6 @@ classes = (
 
 def register():
 	for cls in classes:
-		util.make_annotations(cls)
 		bpy.utils.register_class(cls)
 
 	bpy.types.Scene.mcprep_props = bpy.props.PointerProperty(type=McprepProps)

--- a/MCprep_addon/mcprep_ui.py
+++ b/MCprep_addon/mcprep_ui.py
@@ -320,7 +320,8 @@ class McprepPreference(bpy.types.AddonPreferences):
 	scriptdir = bpy.path.abspath(os.path.dirname(__file__))
 
 	def change_verbose(self, context):
-		conf.v = self.verbose
+		env = conf.MCprepEnv()
+		env.verbose = self.verbose
 
 	meshswap_path = bpy.props.StringProperty(
 		name="Meshswap path",
@@ -1887,6 +1888,7 @@ classes = (
 
 
 def register():
+	env = conf.MCprepEnv()
 	for cls in classes:
 		util.make_annotations(cls)
 		bpy.utils.register_class(cls)
@@ -1935,7 +1937,7 @@ def register():
 		update=update_mcprep_texturepack_path,
 		default=addon_prefs.custom_texturepack_path)
 
-	conf.v = addon_prefs.verbose
+	env.verbose = addon_prefs.verbose
 	if hasattr(bpy.types, "INFO_MT_add"):  # 2.7
 		bpy.types.INFO_MT_add.append(draw_mcprepadd)
 	elif hasattr(bpy.types, "VIEW3D_MT_add"):  # 2.8

--- a/MCprep_addon/mcprep_ui.py
+++ b/MCprep_addon/mcprep_ui.py
@@ -37,7 +37,7 @@ from .spawner import mcmodel
 from .spawner import meshswap
 from .spawner import mobs
 from .spawner import spawn_util
-from .conf import ENV
+from .conf import env
 # from .import_bridge import bridge
 
 # blender 2.7 vs 2.8 icon selections
@@ -75,12 +75,12 @@ class MCPREP_MT_mob_spawner(bpy.types.Menu):
 			# show icon if available
 			mob = scn_props.mob_list_all[mobkey]
 			icn = "mob-{}".format(mob.index)
-			if ENV.use_icons and icn in ENV.preview_collections["mobs"]:
+			if env.use_icons and icn in ENV.preview_collections["mobs"]:
 				ops = layout.operator(
 					"mcprep.mob_spawner",
 					text=mob.name,
-					icon_value=ENV.preview_collections["mobs"][icn].icon_id)
-			elif ENV.use_icons:
+					icon_value=env.preview_collections["mobs"][icn].icon_id)
+			elif env.use_icons:
 				ops = layout.operator(
 					"mcprep.mob_spawner", text=mob.name, icon="BLANK1")
 			else:
@@ -88,7 +88,7 @@ class MCPREP_MT_mob_spawner(bpy.types.Menu):
 			ops.mcmob_type = mob.mcmob_type
 
 			# Skip prep materials in case of unique shader.
-			if ENV.json_data and mob.name in ENV.json_data.get("mob_skip_prep", []):
+			if env.json_data and mob.name in ENV.json_data.get("mob_skip_prep", []):
 				ops.prep_materials = False
 
 
@@ -117,7 +117,7 @@ class MCPREP_MT_meshswap_place(bpy.types.Menu):
 			opr.location = util.get_cuser_location(context)
 
 			# Ensure meshswap with rigs is made real, so the rigs can be used.
-			if ENV.json_data and blockset[1] in ENV.json_data.get("make_real", []):
+			if env.json_data and blockset[1] in ENV.json_data.get("make_real", []):
 				opr.make_real = True
 
 
@@ -132,11 +132,11 @@ class MCPREP_MT_item_spawn(bpy.types.Menu):
 			layout.label(text="No items found!")
 		for item in context.scene.mcprep_props.item_list:
 			icn = "item-{}".format(item.index)
-			if ENV.use_icons and icn in ENV.preview_collections["items"]:
+			if env.use_icons and icn in ENV.preview_collections["items"]:
 				ops = layout.operator(
 					"mcprep.spawn_item", text=item.name,
-					icon_value=ENV.preview_collections["items"][icn].icon_id)
-			elif ENV.use_icons:
+					icon_value=env.preview_collections["items"][icn].icon_id)
+			elif env.use_icons:
 				ops = layout.operator(
 					"mcprep.spawn_item", text=item.name, icon="BLANK1")
 			else:
@@ -172,11 +172,11 @@ class MCPREP_MT_effect_spawn(bpy.types.Menu):
 				ops.frame = context.scene.frame_current
 			elif effect.effect_type == effects.IMG_SEQ:
 				icon = "effects-{}".format(effect.index)
-				if ENV.use_icons and icon in ENV.preview_collections["effects"]:
+				if env.use_icons and icon in ENV.preview_collections["effects"]:
 					ops = col.operator(
 						"mcprep.spawn_instant_effect",
 						text=effect.name,
-						icon_value=ENV.preview_collections["effects"][icon].icon_id)
+						icon_value=env.preview_collections["effects"][icon].icon_id)
 				else:
 					ops = col.operator(
 						"mcprep.spawn_instant_effect",
@@ -239,13 +239,13 @@ class MCPREP_MT_3dview_add(bpy.types.Menu):
 		layout = self.layout
 		props = context.scene.mcprep_props
 
-		if ENV.preview_collections["main"] != "":
-			spawner_icon = ENV.preview_collections["main"].get("spawner_icon")
-			meshswap_icon = ENV.preview_collections["main"].get("meshswap_icon")
-			sword_icon = ENV.preview_collections["main"].get("sword_icon")
-			effects_icon = ENV.preview_collections["main"].get("effects_icon")
-			entity_icon = ENV.preview_collections["main"].get("entity_icon")
-			model_icon = ENV.preview_collections["main"].get("model_icon")
+		if env.preview_collections["main"] != "":
+			spawner_icon = env.preview_collections["main"].get("spawner_icon")
+			meshswap_icon = env.preview_collections["main"].get("meshswap_icon")
+			sword_icon = env.preview_collections["main"].get("sword_icon")
+			effects_icon = env.preview_collections["main"].get("effects_icon")
+			entity_icon = env.preview_collections["main"].get("entity_icon")
+			model_icon = env.preview_collections["main"].get("model_icon")
 		else:
 			spawner_icon = None
 			meshswap_icon = None
@@ -255,7 +255,7 @@ class MCPREP_MT_3dview_add(bpy.types.Menu):
 			model_icon = None
 
 		all_loaded = props.mob_list and props.meshswap_list and props.item_list
-		if not ENV.loaded_all_spawners and not all_loaded:
+		if not env.loaded_all_spawners and not all_loaded:
 			row = layout.row()
 			row.operator(
 				"mcprep.reload_spawners", text="Load spawners", icon=HAND_ICON)
@@ -320,7 +320,7 @@ class McprepPreference(bpy.types.AddonPreferences):
 	scriptdir = bpy.path.abspath(os.path.dirname(__file__))
 
 	def change_verbose(self, context):
-		ENV.verbose = self.verbose
+		env.verbose = self.verbose
 
 	meshswap_path = bpy.props.StringProperty(
 		name="Meshswap path",
@@ -898,18 +898,18 @@ class MCPREP_PT_skins(bpy.types.Panel):
 		row = layout.row()
 		col = row.column()
 
-		is_sortable = len(ENV.skin_list) > 1
+		is_sortable = len(env.skin_list) > 1
 		rows = 1
 		if (is_sortable):
 			rows = 4
 
 		# any other conditions for needing reloading?
-		if not ENV.skin_list:
+		if not env.skin_list:
 			col = layout.column()
 			col.label(text="No skins found/loaded")
 			p = col.operator(
 				"mcprep.reload_skins", text="Press to reload", icon="ERROR")
-		elif ENV.skin_list and len(ENV.skin_list) <= sind:
+		elif env.skin_list and len(ENV.skin_list) <= sind:
 			col = layout.column()
 			col.label(text="Reload skins")
 			p = col.operator(
@@ -925,10 +925,10 @@ class MCPREP_PT_skins(bpy.types.Panel):
 
 			row = col.row(align=True)
 			row.scale_y = 1.5
-			if ENV.skin_list:
-				skinname = bpy.path.basename(ENV.skin_list[sind][0])
+			if env.skin_list:
+				skinname = bpy.path.basename(env.skin_list[sind][0])
 				p = row.operator("mcprep.applyskin", text="Apply " + skinname)
-				p.filepath = ENV.skin_list[sind][1]
+				p.filepath = env.skin_list[sind][1]
 			else:
 				row.enabled = False
 				p = row.operator("mcprep.skin_swapper", text="No skins found")
@@ -971,7 +971,7 @@ class MCPREP_PT_skins(bpy.types.Panel):
 					row.enabled = False
 					row.operator(
 						"mcprep.spawn_with_skin", text="Reload mobs below")
-				elif not ENV.skin_list:
+				elif not env.skin_list:
 					row.enabled = False
 					row.operator(
 						"mcprep.spawn_with_skin", text="Reload skins above")
@@ -1112,7 +1112,7 @@ def mob_spawner(self, context):
 		p.mcmob_type = mcmob_type
 
 	# Skip prep materials in case of unique shader.
-	if ENV.json_data and name in ENV.json_data.get("mob_skip_prep", []):
+	if env.json_data and name in ENV.json_data.get("mob_skip_prep", []):
 		p.prep_materials = False
 
 	p = col.operator("mcprep.mob_install_menu")
@@ -1152,7 +1152,7 @@ def mob_spawner(self, context):
 			b_col.operator("mcprep.mob_install_icon")
 		else:
 			icon_index = scn_props.mob_list[scn_props.mob_list_index].index
-			if "mob-{}".format(icon_index) in ENV.preview_collections["mobs"]:
+			if "mob-{}".format(icon_index) in env.preview_collections["mobs"]:
 				b_col.operator(
 					"mcprep.mob_install_icon", text="Change mob icon")
 			else:
@@ -1218,7 +1218,7 @@ def meshswap_spawner(self, context):
 		p.method = method
 		p.location = util.get_cuser_location(context)
 		# Ensure meshswap with rigs is made real, so the rigs can be used.
-		if ENV.json_data and block in ENV.json_data.get("make_real", []):
+		if env.json_data and block in ENV.json_data.get("make_real", []):
 			p.make_real = True
 
 	else:
@@ -1594,9 +1594,9 @@ class MCPREP_PT_mob_spawner(bpy.types.Panel):
 		mob_spawner(self, context)
 
 	def draw_header(self, context):
-		if not ENV.use_icons or ENV.preview_collections["main"] == "":
+		if not env.use_icons or ENV.preview_collections["main"] == "":
 			return
-		icon = ENV.preview_collections["main"].get("spawner_icon")
+		icon = env.preview_collections["main"].get("spawner_icon")
 		if not icon:
 			return
 		self.layout.label(text="", icon_value=icon.icon_id)
@@ -1619,9 +1619,9 @@ class MCPREP_PT_model_spawner(bpy.types.Panel):
 		model_spawner(self, context)
 
 	def draw_header(self, context):
-		if not ENV.use_icons or ENV.preview_collections["main"] == "":
+		if not env.use_icons or ENV.preview_collections["main"] == "":
 			return
-		icon = ENV.preview_collections["main"].get("model_icon")
+		icon = env.preview_collections["main"].get("model_icon")
 		if not icon:
 			return
 		self.layout.label(text="", icon_value=icon.icon_id)
@@ -1645,9 +1645,9 @@ class MCPREP_PT_item_spawner(bpy.types.Panel):
 		item_spawner(self, context)
 
 	def draw_header(self, context):
-		if not ENV.use_icons or ENV.preview_collections["main"] == "":
+		if not env.use_icons or ENV.preview_collections["main"] == "":
 			return
-		icon = ENV.preview_collections["main"].get("sword_icon")
+		icon = env.preview_collections["main"].get("sword_icon")
 		if not icon:
 			return
 		self.layout.label(text="", icon_value=icon.icon_id)
@@ -1670,9 +1670,9 @@ class MCPREP_PT_effects_spawner(bpy.types.Panel):
 		effects_spawner(self, context)
 
 	def draw_header(self, context):
-		if not ENV.use_icons or ENV.preview_collections["main"] == "":
+		if not env.use_icons or ENV.preview_collections["main"] == "":
 			return
-		icon = ENV.preview_collections["main"].get("effects_icon")
+		icon = env.preview_collections["main"].get("effects_icon")
 		if not icon:
 			return
 		self.layout.label(text="", icon_value=icon.icon_id)
@@ -1695,9 +1695,9 @@ class MCPREP_PT_entity_spawner(bpy.types.Panel):
 		entity_spawner(self, context)
 
 	def draw_header(self, context):
-		if not ENV.use_icons or ENV.preview_collections["main"] == "":
+		if not env.use_icons or ENV.preview_collections["main"] == "":
 			return
-		icon = ENV.preview_collections["main"].get("entity_icon")
+		icon = env.preview_collections["main"].get("entity_icon")
 		if not icon:
 			return
 		self.layout.label(text="", icon_value=icon.icon_id)
@@ -1720,9 +1720,9 @@ class MCPREP_PT_meshswap_spawner(bpy.types.Panel):
 		meshswap_spawner(self, context)
 
 	def draw_header(self, context):
-		if not ENV.use_icons or ENV.preview_collections["main"] == "":
+		if not env.use_icons or ENV.preview_collections["main"] == "":
 			return
-		icon = ENV.preview_collections["main"].get("meshswap_icon")
+		icon = env.preview_collections["main"].get("meshswap_icon")
 		if not icon:
 			return
 		self.layout.label(text="", icon_value=icon.icon_id)
@@ -1737,7 +1737,7 @@ class MCPREP_PT_meshswap_spawner(bpy.types.Panel):
 def draw_mcprepadd(self, context):
 	"""Append to Shift+A, icon for top-level MCprep section."""
 	layout = self.layout
-	pcoll = ENV.preview_collections["main"]
+	pcoll = env.preview_collections["main"]
 	if pcoll != "":
 		my_icon = pcoll["crafting_icon"]
 		layout.menu(MCPREP_MT_3dview_add.bl_idname, icon_value=my_icon.icon_id)
@@ -1770,8 +1770,8 @@ def mcprep_image_tools(self, context):
 		txt = "Spawn as item"
 	if not img:
 		row.enabled = False
-	if ENV.preview_collections["main"] != "":
-		sword_icon = ENV.preview_collections["main"]["sword_icon"]
+	if env.preview_collections["main"] != "":
+		sword_icon = env.preview_collections["main"]["sword_icon"]
 	else:
 		sword_icon = None
 
@@ -1935,7 +1935,7 @@ def register():
 		update=update_mcprep_texturepack_path,
 		default=addon_prefs.custom_texturepack_path)
 
-	ENV.verbose = addon_prefs.verbose
+	env.verbose = addon_prefs.verbose
 	if hasattr(bpy.types, "INFO_MT_add"):  # 2.7
 		bpy.types.INFO_MT_add.append(draw_mcprepadd)
 	elif hasattr(bpy.types, "VIEW3D_MT_add"):  # 2.8

--- a/MCprep_addon/optimize_scene.py
+++ b/MCprep_addon/optimize_scene.py
@@ -46,34 +46,34 @@ class MCprepOptimizerProperties(bpy.types.PropertyGroup):
 		]
 		return itms
 
-	caustics_bool = bpy.props.BoolProperty(
+	caustics_bool: bpy.props.BoolProperty(
 		name="Caustics (slower)",
 		default=False,
 		description="If checked allows cautics to be enabled"
 	)
-	motion_blur_bool = bpy.props.BoolProperty(
+	motion_blur_bool: bpy.props.BoolProperty(
 		name="Motion Blur (slower)",
 		default=False,
 		description="If checked allows motion blur to be enabled"
 	)
-	scene_brightness = bpy.props.EnumProperty(
+	scene_brightness: bpy.props.EnumProperty(
 		name="",
 		description="Brightness of the scene: Affects how the optimizer adjusts sampling",
 		items=scene_brightness
 	)
-	quality_vs_speed = bpy.props.BoolProperty(
+	quality_vs_speed: bpy.props.BoolProperty(
 		name="Optimize scene for quality: Makes the optimizer adjust settings in a less \"destructive\" way",
 		default=True
 	)
-	simplify = bpy.props.BoolProperty(
+	simplify: bpy.props.BoolProperty(
 		name="Simplify the viewport: Reduces subdivisions to 0. Only disable if any assets will break when using this",
 		default=True
 	)
-	scrambling_unsafe = bpy.props.BoolProperty(
+	scrambling_unsafe: bpy.props.BoolProperty(
 		name="Automatic Scrambling Distance: Can cause artifacts when rendering",
 		default=False
 	)
-	preview_scrambling = bpy.props.BoolProperty(
+	preview_scrambling: bpy.props.BoolProperty(
 		name="Preview Scrambling in the viewport",
 		default=True
 	)
@@ -400,7 +400,6 @@ classes = (
 
 def register():
 	for cls in classes:
-		util.make_annotations(cls)
 		bpy.utils.register_class(cls)
 
 	bpy.types.Scene.optimizer_props = bpy.props.PointerProperty(

--- a/MCprep_addon/spawner/effects.py
+++ b/MCprep_addon/spawner/effects.py
@@ -31,7 +31,7 @@ from .. import tracking
 
 from . import spawn_util
 
-from ..conf import ENV
+from ..conf import env
 
 # -----------------------------------------------------------------------------
 # Global enum values
@@ -743,9 +743,9 @@ def update_effects_list(context):
 	mcprep_props = context.scene.mcprep_props
 	mcprep_props.effects_list.clear()
 
-	if ENV.use_icons and ENV.preview_collections["effects"]:
+	if env.use_icons and ENV.preview_collections["effects"]:
 		try:
-			bpy.utils.previews.remove(ENV.preview_collections["effects"])
+			bpy.utils.previews.remove(env.preview_collections["effects"])
 		except Exception as e:
 			print(e)
 			conf.log("MCPREP: Failed to remove icon set, effects")
@@ -948,7 +948,7 @@ def load_image_sequence_effects(context):
 		effect.index = len(mcprep_props.effects_list) - 1  # For icon index.
 
 		# Try to load a middle frame as the icon.
-		if not ENV.use_icons or ENV.preview_collections["effects"] == "":
+		if not env.use_icons or ENV.preview_collections["effects"] == "":
 			continue
 		effect_files = [
 			os.path.join(resource_folder, fname)
@@ -960,7 +960,7 @@ def load_image_sequence_effects(context):
 		if effect_files:
 			# 0 if 1 item, otherwise greater side of median.
 			e_index = int(len(effect_files) / 2)
-			ENV.preview_collections["effects"].load(
+			env.preview_collections["effects"].load(
 				"effects-{}".format(effect.index), effect_files[e_index], 'IMAGE')
 
 

--- a/MCprep_addon/spawner/effects.py
+++ b/MCprep_addon/spawner/effects.py
@@ -31,6 +31,8 @@ from .. import tracking
 
 from . import spawn_util
 
+from ..conf import ENV
+
 # -----------------------------------------------------------------------------
 # Global enum values
 # -----------------------------------------------------------------------------
@@ -741,9 +743,9 @@ def update_effects_list(context):
 	mcprep_props = context.scene.mcprep_props
 	mcprep_props.effects_list.clear()
 
-	if conf.use_icons and conf.preview_collections["effects"]:
+	if ENV.use_icons and ENV.preview_collections["effects"]:
 		try:
-			bpy.utils.previews.remove(conf.preview_collections["effects"])
+			bpy.utils.previews.remove(ENV.preview_collections["effects"])
 		except Exception as e:
 			print(e)
 			conf.log("MCPREP: Failed to remove icon set, effects")
@@ -946,7 +948,7 @@ def load_image_sequence_effects(context):
 		effect.index = len(mcprep_props.effects_list) - 1  # For icon index.
 
 		# Try to load a middle frame as the icon.
-		if not conf.use_icons or conf.preview_collections["effects"] == "":
+		if not ENV.use_icons or ENV.preview_collections["effects"] == "":
 			continue
 		effect_files = [
 			os.path.join(resource_folder, fname)
@@ -958,7 +960,7 @@ def load_image_sequence_effects(context):
 		if effect_files:
 			# 0 if 1 item, otherwise greater side of median.
 			e_index = int(len(effect_files) / 2)
-			conf.preview_collections["effects"].load(
+			ENV.preview_collections["effects"].load(
 				"effects-{}".format(effect.index), effect_files[e_index], 'IMAGE')
 
 

--- a/MCprep_addon/spawner/effects.py
+++ b/MCprep_addon/spawner/effects.py
@@ -394,7 +394,7 @@ def geo_update_params(context, effect, geo_mod):
 	if os.path.isfile(jpath):
 		geo_fields = geo_fields_from_json(effect, jpath)
 	else:
-		conf.log("No json params path for geonode effects", vv_only=True)
+		env.log("No json params path for geonode effects", vv_only=True)
 		return
 
 	# Determine if these special keywords exist.
@@ -402,7 +402,7 @@ def geo_update_params(context, effect, geo_mod):
 	for input_name in geo_fields.keys():
 		if geo_fields[input_name] == "FOLLOW_OBJ":
 			has_followkey = True
-	conf.log("geonode has_followkey field? " + str(has_followkey), vv_only=True)
+	env.log("geonode has_followkey field? " + str(has_followkey), vv_only=True)
 
 	# Create follow empty if required by the group.
 	camera = context.scene.camera
@@ -429,16 +429,16 @@ def geo_update_params(context, effect, geo_mod):
 		if inp.name in list(geo_fields):
 			value = geo_fields[inp.name]
 			if value == "CAMERA_OBJ":
-				conf.log("Set cam for geonode input", vv_only=True)
+				env.log("Set cam for geonode input", vv_only=True)
 				geo_mod[geo_inp_id[inp.name]] = camera
 			elif value == "FOLLOW_OBJ":
 				if not center_empty:
 					print(">> Center empty missing, not in preset!")
 				else:
-					conf.log("Set follow for geonode input", vv_only=True)
+					env.log("Set follow for geonode input", vv_only=True)
 					geo_mod[geo_inp_id[inp.name]] = center_empty
 			else:
-				conf.log("Set {} for geonode input".format(inp.name), vv_only=True)
+				env.log("Set {} for geonode input".format(inp.name), vv_only=True)
 				geo_mod[geo_inp_id[inp.name]] = value
 		# TODO: check if any socket name in json specified not found in node.
 
@@ -456,7 +456,7 @@ def geo_fields_from_json(effect, jpath):
 		CAMERA_OBJ: Tells MCprep to assign the active camera object to slot.
 		FOLLOW_OBJ: Tells MCprep to assign a generated empty to this slot.
 	"""
-	conf.log("Loading geo fields form json: " + jpath)
+	env.log("Loading geo fields form json: " + jpath)
 	with open(jpath) as fopen:
 		jdata = json.load(fopen)
 
@@ -638,9 +638,9 @@ def import_animated_coll(context, effect, keyname):
 	new_colls = list(set(final_colls) - set(init_colls))
 	if not new_colls:
 		if any_imported:
-			conf.log("New collection loaded, but not picked up")
+			env.log("New collection loaded, but not picked up")
 		else:
-			conf.log("No colleections imported or recognized")
+			env.log("No colleections imported or recognized")
 		raise Exception("No collections imported")
 	elif len(new_colls) > 1:
 		# Pick the closest fitting one. At worst, will pick a random one.
@@ -734,7 +734,7 @@ def offset_animation_to_frame(collection, frame):
 
 def update_effects_path(self, context):
 	"""List for UI effects callback ."""
-	conf.log("Updating effects path", vv_only=True)
+	env.log("Updating effects path", vv_only=True)
 	update_effects_list(context)
 
 
@@ -743,12 +743,12 @@ def update_effects_list(context):
 	mcprep_props = context.scene.mcprep_props
 	mcprep_props.effects_list.clear()
 
-	if env.use_icons and ENV.preview_collections["effects"]:
+	if env.use_icons and env.preview_collections["effects"]:
 		try:
 			bpy.utils.previews.remove(env.preview_collections["effects"])
 		except Exception as e:
 			print(e)
-			conf.log("MCPREP: Failed to remove icon set, effects")
+			env.log("MCPREP: Failed to remove icon set, effects")
 
 	load_geonode_effect_list(context)
 	load_area_particle_effects(context)
@@ -783,15 +783,15 @@ def load_geonode_effect_list(context):
 		and jsf.lower().endswith(".json")
 	]
 
-	conf.log("json pairs of blend files", vv_only=True)
-	conf.log(json_files, vv_only=True)
+	env.log("json pairs of blend files", vv_only=True)
+	env.log(json_files, vv_only=True)
 
 	for bfile in blends:
 		row_items = []
 		using_json = False
 		js_equiv = os.path.splitext(bfile)[0] + ".json"
 		if js_equiv in json_files:
-			conf.log("Loading json preset for geonode for " + bfile)
+			env.log("Loading json preset for geonode for " + bfile)
 			# Read nodegroups to include from json presets file.
 			jpath = os.path.splitext(bfile)[0] + ".json"
 			with open(jpath) as jopen:
@@ -799,7 +799,7 @@ def load_geonode_effect_list(context):
 			row_items = jdata.keys()
 			using_json = True
 		else:
-			conf.log("Loading nodegroups from blend for geonode effects: " + bfile)
+			env.log("Loading nodegroups from blend for geonode effects: " + bfile)
 			# Read nodegroup names from blend file directly.
 			with bpy.data.libraries.load(bfile) as (data_from, _):
 				row_items = list(data_from.node_groups)
@@ -812,7 +812,7 @@ def load_geonode_effect_list(context):
 				# First key in index is nodegroup, save to subpath, but then
 				# the present name (list of keys within) are the actual names.
 				for preset in jdata[itm]:
-					conf.log("\tgeonode preset: " + preset, vv_only=True)
+					env.log("\tgeonode preset: " + preset, vv_only=True)
 					effect = mcprep_props.effects_list.add()
 					effect.name = preset  # This is the assign json preset name.
 					effect.subpath = itm  # This is the node group name.
@@ -911,7 +911,7 @@ def load_image_sequence_effects(context):
 	lvl_3 = os.path.join(resource_folder, "assets", "minecraft", "textures", "particle")
 
 	if not os.path.isdir(resource_folder):
-		conf.log(
+		env.log(
 			"The particle resource directory is missing! Assign another resource pack")
 		return
 	elif os.path.isdir(lvl_0):
@@ -948,7 +948,7 @@ def load_image_sequence_effects(context):
 		effect.index = len(mcprep_props.effects_list) - 1  # For icon index.
 
 		# Try to load a middle frame as the icon.
-		if not env.use_icons or ENV.preview_collections["effects"] == "":
+		if not env.use_icons or env.preview_collections["effects"] == "":
 			continue
 		effect_files = [
 			os.path.join(resource_folder, fname)

--- a/MCprep_addon/spawner/effects.py
+++ b/MCprep_addon/spawner/effects.py
@@ -1237,7 +1237,6 @@ classes = (
 
 def register():
 	for cls in classes:
-		util.make_annotations(cls)
 		bpy.utils.register_class(cls)
 
 

--- a/MCprep_addon/spawner/entities.py
+++ b/MCprep_addon/spawner/entities.py
@@ -256,7 +256,6 @@ classes = (
 
 def register():
 	for cls in classes:
-		util.make_annotations(cls)
 		bpy.utils.register_class(cls)
 
 	global entity_cache

--- a/MCprep_addon/spawner/entities.py
+++ b/MCprep_addon/spawner/entities.py
@@ -53,10 +53,10 @@ def get_entity_cache(context, clear=False):
 	# Note: Only using groups, not objects, for entities.
 	entity_cache = {"groups": [], "objects": []}
 	if not os.path.isfile(entity_path):
-		conf.log("Entity path not found")
+		env.log("Entity path not found")
 		return entity_cache
 	if not entity_path.lower().endswith('.blend'):
-		conf.log("Entity path must be a .blend file")
+		env.log("Entity path must be a .blend file")
 		return entity_cache
 
 	with bpy.data.libraries.load(entity_path) as (data_from, _):
@@ -78,7 +78,7 @@ def getEntityList(context):
 
 def update_entity_path(self, context):
 	"""for UI list path callback"""
-	conf.log("Updating entity path", vv_only=True)
+	env.log("Updating entity path", vv_only=True)
 	if not context.scene.entity_path.lower().endswith('.blend'):
 		print("Entity file is not a .blend, and should be")
 	if not os.path.isfile(bpy.path.abspath(context.scene.entity_path)):

--- a/MCprep_addon/spawner/item.py
+++ b/MCprep_addon/spawner/item.py
@@ -26,7 +26,7 @@ from .. import conf
 from .. import util
 from .. import tracking
 
-from ..conf import ENV
+from ..conf import env
 
 try:
 	import bpy.utils.previews
@@ -46,9 +46,9 @@ def reload_items(context):
 	extensions = [".png", ".jpg", ".jpeg"]
 
 	mcprep_props.item_list.clear()
-	if ENV.use_icons and ENV.preview_collections["items"]:
+	if env.use_icons and env.preview_collections["items"]:
 		try:
-			bpy.utils.previews.remove(ENV.preview_collections["items"])
+			bpy.utils.previews.remove(env.preview_collections["items"])
 		except Exception as e:
 			print(e)
 			conf.log("MCPREP: Failed to remove icon set, items")
@@ -91,9 +91,9 @@ def reload_items(context):
 		asset.index = i
 
 		# if available, load the custom icon too
-		if not ENV.use_icons or ENV.preview_collections["items"] == "":
+		if not env.use_icons or env.preview_collections["items"] == "":
 			continue
-		ENV.preview_collections["items"].load(
+		env.preview_collections["items"].load(
 			"item-{}".format(i), item_file, 'IMAGE')
 
 	if mcprep_props.item_list_index >= len(mcprep_props.item_list):

--- a/MCprep_addon/spawner/item.py
+++ b/MCprep_addon/spawner/item.py
@@ -22,7 +22,6 @@ import bpy
 from bpy_extras.io_utils import ImportHelper
 import mathutils
 
-from .. import conf
 from .. import util
 from .. import tracking
 
@@ -51,7 +50,7 @@ def reload_items(context):
 			bpy.utils.previews.remove(env.preview_collections["items"])
 		except Exception as e:
 			print(e)
-			conf.log("MCPREP: Failed to remove icon set, items")
+			env.log("MCPREP: Failed to remove icon set, items")
 
 	# Check levels
 	lvl_1 = os.path.join(resource_folder, "textures")
@@ -59,7 +58,7 @@ def reload_items(context):
 	lvl_3 = os.path.join(resource_folder, "assets", "minecraft", "textures")
 
 	if not os.path.isdir(resource_folder):
-		conf.log("Error, resource folder does not exist")
+		env.log("Error, resource folder does not exist")
 		return
 	elif os.path.isdir(lvl_1):
 		resource_folder = lvl_1

--- a/MCprep_addon/spawner/item.py
+++ b/MCprep_addon/spawner/item.py
@@ -26,6 +26,8 @@ from .. import conf
 from .. import util
 from .. import tracking
 
+from ..conf import ENV
+
 try:
 	import bpy.utils.previews
 except ImportError:
@@ -44,9 +46,9 @@ def reload_items(context):
 	extensions = [".png", ".jpg", ".jpeg"]
 
 	mcprep_props.item_list.clear()
-	if conf.use_icons and conf.preview_collections["items"]:
+	if ENV.use_icons and ENV.preview_collections["items"]:
 		try:
-			bpy.utils.previews.remove(conf.preview_collections["items"])
+			bpy.utils.previews.remove(ENV.preview_collections["items"])
 		except Exception as e:
 			print(e)
 			conf.log("MCPREP: Failed to remove icon set, items")
@@ -89,9 +91,9 @@ def reload_items(context):
 		asset.index = i
 
 		# if available, load the custom icon too
-		if not conf.use_icons or conf.preview_collections["items"] == "":
+		if not ENV.use_icons or ENV.preview_collections["items"] == "":
 			continue
-		conf.preview_collections["items"].load(
+		ENV.preview_collections["items"].load(
 			"item-{}".format(i), item_file, 'IMAGE')
 
 	if mcprep_props.item_list_index >= len(mcprep_props.item_list):

--- a/MCprep_addon/spawner/item.py
+++ b/MCprep_addon/spawner/item.py
@@ -297,44 +297,44 @@ class ItemSpawnBase():
 	"""Class to inheret reused MCprep item spawning settings and functions."""
 
 	# TODO: add options like spawning attached to rig hand or other,
-	size = bpy.props.FloatProperty(
+	size: bpy.props.FloatProperty(
 		name="Size",
 		default=1.0,
 		min=0.001,
 		description="Size in blender units of the item")
-	thickness = bpy.props.FloatProperty(
+	thickness: bpy.props.FloatProperty(
 		name="Thickness",
 		default=1.0,
 		min=0.0,
 		description=(
 			"The thickness of the item (this can later be changed in "
 			"modifiers)"))
-	transparency = bpy.props.BoolProperty(
+	transparency: bpy.props.BoolProperty(
 		name="Remove transparent faces",
 		description="Transparent pixels will be transparent once rendered",
 		default=True)
-	threshold = bpy.props.FloatProperty(
+	threshold: bpy.props.FloatProperty(
 		name="Transparent threshold",
 		description="1.0 = zero tolerance, no transparent pixels will be generated",
 		default=0.5,
 		min=0.0,
 		max=1.0)
-	max_pixels = bpy.props.IntProperty(
+	max_pixels: bpy.props.IntProperty(
 		name="Max pixels",
 		default=50000,
 		min=1,
 		description=(
 			"If needed, scale down image to generate less than this maximum "
 			"pixel count"))
-	scale_uvs = bpy.props.FloatProperty(
+	scale_uvs: bpy.props.FloatProperty(
 		name="Scale UVs",
 		default=0.75,
 		description="Scale individual UV faces of the generated item")
-	filepath = bpy.props.StringProperty(
+	filepath: bpy.props.StringProperty(
 		default="",
 		subtype="FILE_PATH",
 		options={'HIDDEN', 'SKIP_SAVE'})
-	skipUsage = bpy.props.BoolProperty(
+	skipUsage: bpy.props.BoolProperty(
 		default=False,
 		options={'HIDDEN'})
 
@@ -466,9 +466,7 @@ classes = (
 
 
 def register():
-	util.make_annotations(ItemSpawnBase)  # Don't register, only annotate.
 	for cls in classes:
-		util.make_annotations(cls)
 		bpy.utils.register_class(cls)
 
 

--- a/MCprep_addon/spawner/mcmodel.py
+++ b/MCprep_addon/spawner/mcmodel.py
@@ -416,17 +416,17 @@ def draw_import_mcmodel(self, context):
 
 class ModelSpawnBase():
 	"""Class to inheret reused MCprep item spawning settings and functions."""
-	location = bpy.props.FloatVectorProperty(
+	location: bpy.props.FloatVectorProperty(
 		default=(0, 0, 0),
 		name="Location")
-	snapping = bpy.props.EnumProperty(
+	snapping: bpy.props.EnumProperty(
 		name="Snapping",
 		items=[
 			("none", "No snap", "Keep exact location"),
 			("center", "Snap center", "Snap to block center"),
 			("offset", "Snap offset", "Snap to block center with 0.5 offset")],
 		description="Automatically snap to whole block locations")
-	skipUsage = bpy.props.BoolProperty(
+	skipUsage: bpy.props.BoolProperty(
 		default=False,
 		options={'HIDDEN'})
 
@@ -546,9 +546,7 @@ classes = (
 
 
 def register():
-	util.make_annotations(ModelSpawnBase)  # Don't register, only annotate.
 	for cls in classes:
-		util.make_annotations(cls)
 		bpy.utils.register_class(cls)
 
 	if util.bv28():

--- a/MCprep_addon/spawner/mcmodel.py
+++ b/MCprep_addon/spawner/mcmodel.py
@@ -25,7 +25,7 @@ import bpy
 import bmesh
 from bpy_extras.io_utils import ImportHelper
 
-from .. import conf
+from ..conf import env
 from .. import util
 from .. import tracking
 
@@ -102,7 +102,7 @@ def add_element(
 
 def add_material(name="material", path=""):
 	"""Creates a simple material with an image texture from path."""
-	conf.log(name + ": " + path, vv_only=True)
+	env.log(name + ": " + path, vv_only=True)
 	mat = bpy.data.materials.new(name=name)
 	mat.blend_method = 'CLIP'
 	mat.shadow_method = 'CLIP'
@@ -211,7 +211,7 @@ def read_model(context, model_filepath):
 			elif os.path.isfile(base_path):
 				elements, textures = read_model(context, base_path)
 			else:
-				conf.log("Failed to find mcmodel file " + parent_filepath)
+				env.log("Failed to find mcmodel file " + parent_filepath)
 
 	current_elements = obj_data.get("elements")
 	if current_elements is not None:
@@ -225,10 +225,10 @@ def read_model(context, model_filepath):
 			for img in current_textures:
 				textures[img] = current_textures[img]
 
-	conf.log("\nfile:" + str(model_filepath), vv_only=True)
-	# conf.log("parent:" + str(parent))
-	# conf.log("elements:" + str(elements))
-	# conf.log("textures:" + str(textures))
+	env.log("\nfile:" + str(model_filepath), vv_only=True)
+	# env.log("parent:" + str(parent))
+	# env.log("elements:" + str(elements))
+	# env.log("textures:" + str(textures))
 
 	return elements, textures
 
@@ -362,7 +362,7 @@ def update_model_list(context):
 	if not os.path.isdir(active_pack):
 		scn_props.model_list.clear()
 		scn_props.model_list_index = 0
-		conf.log("No models found for active path " + active_pack)
+		env.log("No models found for active path " + active_pack)
 		return
 	base_has_models = os.path.isdir(base_pack)
 
@@ -377,7 +377,7 @@ def update_model_list(context):
 			if os.path.isfile(os.path.join(active_pack, model))
 			and model.lower().endswith(".json")]
 	else:
-		conf.log("Base resource pack has no models folder: " + base_pack)
+		env.log("Base resource pack has no models folder: " + base_pack)
 		base_models = []
 
 	sorted_models = [

--- a/MCprep_addon/spawner/meshswap.py
+++ b/MCprep_addon/spawner/meshswap.py
@@ -1350,7 +1350,6 @@ classes = (
 
 def register():
 	for cls in classes:
-		util.make_annotations(cls)
 		bpy.utils.register_class(cls)
 
 	global meshswap_cache

--- a/MCprep_addon/spawner/meshswap.py
+++ b/MCprep_addon/spawner/meshswap.py
@@ -58,10 +58,10 @@ def get_meshswap_cache(context, clear=False):
 
 	meshswap_cache = {"groups": [], "objects": []}
 	if not os.path.isfile(meshswap_path):
-		conf.log("Meshswap path not found")
+		env.log("Meshswap path not found")
 		return meshswap_cache
 	if not meshswap_path.lower().endswith('.blend'):
-		conf.log("Meshswap path must be a .blend file")
+		env.log("Meshswap path must be a .blend file")
 		return meshswap_cache
 
 	with bpy.data.libraries.load(meshswap_path) as (data_from, _):
@@ -70,7 +70,7 @@ def get_meshswap_cache(context, clear=False):
 		meshswap_cache["groups"] = grp_list
 		for obj in list(data_from.objects):
 			if obj in meshswap_cache["groups"]:
-				# conf.log("Skipping meshwap obj already in cache: "+str(obj))
+				# env.log("Skipping meshwap obj already in cache: "+str(obj))
 				continue
 			# ignore list? e.g. Point.001,
 			meshswap_cache["objects"].append(obj)
@@ -108,7 +108,7 @@ def move_assets_to_excluded_layer(context, collections):
 
 def update_meshswap_path(self, context):
 	"""for UI list path callback"""
-	conf.log("Updating meshswap path", vv_only=True)
+	env.log("Updating meshswap path", vv_only=True)
 	if not context.scene.meshswap_path.lower().endswith('.blend'):
 		print("Meshswap file is not a .blend, and should be")
 	if not os.path.isfile(bpy.path.abspath(context.scene.meshswap_path)):
@@ -296,7 +296,7 @@ class MCPREP_OT_meshswap_spawner(bpy.types.Operator):
 					self, context, block, pre_groups)
 
 			if not group:
-				conf.log("No group identified, could not retrieve imported group")
+				env.log("No group identified, could not retrieve imported group")
 				self.report({"ERROR"}, "Could not retrieve imported group")
 				return {'CANCELLED'}
 
@@ -574,7 +574,7 @@ class MCPREP_OT_meshswap(bpy.types.Operator):
 
 		# setup the progress bar
 		denom = len(objList)
-		conf.log("Meshswap to check over {} objects".format(denom))
+		env.log("Meshswap to check over {} objects".format(denom))
 		bpy.context.window_manager.progress_begin(0, 100)
 
 		tprep = time.time() - tprep
@@ -592,7 +592,7 @@ class MCPREP_OT_meshswap(bpy.types.Operator):
 			bpy.context.window_manager.progress_update(iter_index / denom)
 			swapGen = util.nameGeneralize(swap.name)
 			# swapGen = generate.get_mc_canonical_name(swap.name)
-			conf.log("Simplified name: {x}".format(x=swapGen))
+			env.log("Simplified name: {x}".format(x=swapGen))
 			# IMPORTS, gets lists properties, etc
 			swapProps = self.checkExternal(context, swapGen)
 
@@ -610,7 +610,7 @@ class MCPREP_OT_meshswap(bpy.types.Operator):
 			if not (swapProps['meshSwap'] or swapProps['groupSwap']):
 				continue
 
-			conf.log(
+			env.log(
 				"Swapping '{x}', simplified name '{y}".format(
 					x=swap.name, y=swapGen))
 
@@ -668,7 +668,7 @@ class MCPREP_OT_meshswap(bpy.types.Operator):
 				if context.selected_objects:
 					new_objects.append(context.selected_objects[0])
 				else:
-					conf.log("No selected objects after join")
+					env.log("No selected objects after join")
 			else:
 				# no joining, so just directly append to new_objects
 				new_objects += dupedObj  # a list
@@ -742,7 +742,7 @@ class MCPREP_OT_meshswap(bpy.types.Operator):
 			instancing = sum(t3s) - sum(t2s)
 			cleanup = t5 - t4
 			total = tprep + loop_prep + face_process + instancing + cleanup
-			conf.log("Total time: {}s, init: {}, prep: {}, poly process: {}, instance:{}, cleanup: {}".format(
+			env.log("Total time: {}s, init: {}, prep: {}, poly process: {}, instance:{}, cleanup: {}".format(
 				round(total, 1), round(tprep, 1), round(loop_prep, 1),
 				round(face_process, 1), round(instancing, 1), round(cleanup, 1)))
 
@@ -850,7 +850,7 @@ class MCPREP_OT_meshswap(bpy.types.Operator):
 		# delete unnecessary ones first
 		if name in rmable:
 			removable = True
-			conf.log("Removable!")
+			env.log("Removable!")
 			return {'removable': removable}
 
 		# check the actual name against the library
@@ -878,7 +878,7 @@ class MCPREP_OT_meshswap(bpy.types.Operator):
 			return False  # if not present, continue
 
 		# now import
-		conf.log("about to link, group {} / mesh {}?".format(
+		env.log("about to link, group {} / mesh {}?".format(
 			groupSwap, meshSwap))
 		toLink = self.link_groups
 		for ob in context.selected_objects:
@@ -935,7 +935,7 @@ class MCPREP_OT_meshswap(bpy.types.Operator):
 			grouped = True
 			# set properties
 			for item in util.collections()[name].items():
-				conf.log("GROUP PROPS:" + str(item))
+				env.log("GROUP PROPS:" + str(item))
 				try:
 					x = item[1].name  # will NOT work if property UI
 				except:
@@ -960,7 +960,7 @@ class MCPREP_OT_meshswap(bpy.types.Operator):
 			# ## BE IN FILE, EG NAME OF MESH TO SWAP CHANGED, INDEX ERROR IS THROWN HERE
 			# ## >> MAKE a more graceful error indication.
 			# filter out non-meshes in case of parent grouping or other pull-ins
-			# conf.log("DEBUG - post importing {}, selected objects: {}".format(
+			# env.log("DEBUG - post importing {}, selected objects: {}".format(
 			# 	name, list(bpy.context.selected_objects)), vv_only=True)
 
 			for ob in bpy.context.selected_objects:
@@ -995,8 +995,8 @@ class MCPREP_OT_meshswap(bpy.types.Operator):
 			for ob in context.selected_objects:
 				util.select_set(ob, False)
 		# #### HERE set the other properties, e.g. variance and edgefloat, now that the obj exists
-		conf.log("groupSwap: {}, meshSwap: {}".format(groupSwap, meshSwap))
-		conf.log("edgeFloat: {}, variance: {}, torchlike: {}".format(
+		env.log("groupSwap: {}, meshSwap: {}".format(groupSwap, meshSwap))
+		env.log("edgeFloat: {}, variance: {}, torchlike: {}".format(
 			edgeFloat, variance, torchlike))
 		return {
 			'importName': name, 'object': importedObj, 'meshSwap': meshSwap,
@@ -1046,10 +1046,10 @@ class MCPREP_OT_meshswap(bpy.types.Operator):
 		# 	if not swapProps['edgeFloat']:
 		# 		#continue
 		# 		print("do nothing, this is for jmc2obj")
-		conf.log(
+		env.log(
 			"Instance:  loc, face.local, face.nrm, hanging offset, if_edgeFloat:",
 			vv_only=True)
-		conf.log(
+		env.log(
 			str([loc, face.l, face.n, [a, b, c], outside_hanging]),
 			vv_only=True)
 
@@ -1092,7 +1092,7 @@ class MCPREP_OT_meshswap(bpy.types.Operator):
 				else:
 					rot_type = 0
 			elif swapProps['edgeFloat']:
-				conf.log("Edge float!", vv_only=True)
+				env.log("Edge float!", vv_only=True)
 				if (y - face.l[1] < 0):
 					rot_type = 8
 				elif (x_diff > 0.3):
@@ -1121,9 +1121,9 @@ class MCPREP_OT_meshswap(bpy.types.Operator):
 			else:
 				rot_type = 0
 		elif self.track_exporter == "Mineways":
-			conf.log("checking: {} {}".format(x_diff, z_diff))
+			env.log("checking: {} {}".format(x_diff, z_diff))
 			if swapProps['torchlike']:  # needs fixing
-				conf.log("recognized it's a torchlike obj..")
+				env.log("recognized it's a torchlike obj..")
 				if (x_diff > .1 and x_diff < 0.6):
 					rot_type = 1
 				elif (z_diff > .1 and z_diff < 0.6):
@@ -1202,7 +1202,7 @@ class MCPREP_OT_meshswap(bpy.types.Operator):
 			if grouped:
 				# definition for randimization, defined at top!
 				randGroup = util.randomizeMeshSawp(swapProps['importName'], 3)
-				conf.log("Rand group: {}".format(randGroup))
+				env.log("Rand group: {}".format(randGroup))
 				new_ob = util.addGroupInstance(randGroup, loc)
 				if hasattr(new_ob, "empty_draw_size"):
 					new_ob.empty_draw_size = 0.25
@@ -1290,7 +1290,7 @@ class MCPREP_OT_meshswap(bpy.types.Operator):
 	def offsetByHalf(self, obj):
 		if obj.type != 'MESH':
 			return
-		conf.log("doing offset")
+		env.log("doing offset")
 		active = bpy.context.object  # preserve current active
 		util.set_active_object(bpy.context, obj)
 		bpy.ops.object.mode_set(mode='EDIT')
@@ -1311,7 +1311,7 @@ class MCPREP_OT_fix_mineways_scale(bpy.types.Operator):
 
 	@tracking.report_error
 	def execute(self, context):
-		conf.log("Attempting to fix Mineways scaling for meshswap")
+		env.log("Attempting to fix Mineways scaling for meshswap")
 
 		# get cursor loc first? shouldn't matter which mode/location though
 		tmp_loc = util.get_cuser_location(context)

--- a/MCprep_addon/spawner/meshswap.py
+++ b/MCprep_addon/spawner/meshswap.py
@@ -735,7 +735,8 @@ class MCPREP_OT_meshswap(bpy.types.Operator):
 		t5 = time.time()
 
 		# run timing calculations
-		if conf.vv:
+		env = conf.MCprepEnv()
+		if env.very_verbose:
 			loop_prep = sum(t1s) - sum(t0s)
 			face_process = sum(t2s) - sum(t1s)
 			instancing = sum(t3s) - sum(t2s)

--- a/MCprep_addon/spawner/meshswap.py
+++ b/MCprep_addon/spawner/meshswap.py
@@ -27,6 +27,7 @@ import mathutils
 
 from . import spawn_util
 from .. import conf
+from ..conf import env
 from ..materials import generate
 from .. import util
 from .. import tracking
@@ -735,7 +736,6 @@ class MCPREP_OT_meshswap(bpy.types.Operator):
 		t5 = time.time()
 
 		# run timing calculations
-		env = conf.MCprepEnv()
 		if env.very_verbose:
 			loop_prep = sum(t1s) - sum(t0s)
 			face_process = sum(t2s) - sum(t1s)

--- a/MCprep_addon/spawner/mobs.py
+++ b/MCprep_addon/spawner/mobs.py
@@ -26,6 +26,7 @@ import bpy
 from bpy_extras.io_utils import ImportHelper
 
 from .. import conf
+from ..conf import env
 from .. import util
 from .. import tracking
 
@@ -51,7 +52,7 @@ def get_rig_list(context):
 
 def update_rig_path(self, context):
 	"""List for UI mobs callback of property spawn_rig_category."""
-	conf.log("Updating rig path", vv_only=True)
+	env.log("Updating rig path", vv_only=True)
 	conf.rig_categories = []
 	update_rig_list(context)
 	spawn_rigs_categories(self, context)
@@ -118,10 +119,10 @@ def update_rig_list(context):
 		try:
 			bpy.utils.previews.remove(conf.preview_collections["mobs"])
 		except:
-			conf.log("MCPREP: Failed to remove icon set, mobs")
+			env.log("MCPREP: Failed to remove icon set, mobs")
 
 	if os.path.isdir(rigpath) is False:
-		conf.log("Rigpath directory not found")
+		env.log("Rigpath directory not found")
 		return
 
 	categories = [
@@ -163,7 +164,7 @@ def update_rig_category(context):
 	scn_props = context.scene.mcprep_props
 
 	if not scn_props.mob_list_all:
-		conf.log("No rigs found, failed to update category")
+		env.log("No rigs found, failed to update category")
 		scn_props.mob_list.clear()
 		return
 
@@ -267,11 +268,11 @@ class MCPREP_OT_mob_spawner(bpy.types.Operator):
 		try:
 			[path, name] = self.mcmob_type.split(':/:')
 		except Exception as err:
-			conf.log("Error: Failed to parse mcmob_type")
+			env.log("Error: Failed to parse mcmob_type")
 			self.report({'ERROR'}, "Failed to parse mcmob_type, try reloading mobs")
 			return {'CANCELLED'}
 		path = os.path.join(context.scene.mcprep_mob_path, path)
-		conf.log("Path is now ", path)
+		env.log("Path is now ", path)
 
 		try:
 			# must be in object mode, this make similar behavior to other objs
@@ -283,7 +284,7 @@ class MCPREP_OT_mob_spawner(bpy.types.Operator):
 
 		if self.toLink:
 			if path == '//':
-				conf.log("This is the local file. Cancelling...")
+				env.log("This is the local file. Cancelling...")
 				return {'CANCELLED'}
 			_ = spawn_util.load_linked(self, context, path, name)
 		else:
@@ -325,7 +326,7 @@ class MCPREP_OT_mob_spawner(bpy.types.Operator):
 		for obj in mod_objs:
 			if obj not in list(context.scene.collection.all_objects):
 				obj.use_fake_user = True
-				conf.log("Set {} as fake user".format(obj.name))
+				env.log("Set {} as fake user".format(obj.name))
 
 
 class MCPREP_OT_install_mob(bpy.types.Operator, ImportHelper):
@@ -367,19 +368,19 @@ class MCPREP_OT_install_mob(bpy.types.Operator, ImportHelper):
 		newrig = bpy.path.abspath(self.filepath)
 
 		if not os.path.isfile(newrig):
-			conf.log("Error: Rig blend file not found!")
+			env.log("Error: Rig blend file not found!")
 			self.report({'ERROR'}, "Rig blend file not found!")
 			return {'CANCELLED'}
 
 		if not newrig.lower().endswith('.blend'):
-			conf.log("Error: Not a blend file! Select a .blend file with a rig")
+			env.log("Error: Not a blend file! Select a .blend file with a rig")
 			self.report({'ERROR'}, "Not a blend file! Select a .blend file with a rig")
 			return {'CANCELLED'}
 
 		# now check the rigs folder indeed exists
 		drpath = bpy.path.abspath(drpath)
 		if not os.path.isdir(drpath):
-			conf.log("Error: Rig directory is not valid!")
+			env.log("Error: Rig directory is not valid!")
 			self.report({'ERROR'}, "Rig directory is not valid!")
 			return {'CANCELLED'}
 
@@ -391,7 +392,7 @@ class MCPREP_OT_install_mob(bpy.types.Operator, ImportHelper):
 			install_groups.pop(install_groups.index('Collection'))
 
 		if not install_groups:
-			conf.log("Error: no groups found in blend file!")
+			env.log("Error: no groups found in blend file!")
 			self.report({'ERROR'}, "No groups found in blend file!")
 			return {'CANCELLED'}
 
@@ -564,18 +565,18 @@ class MCPREP_OT_uninstall_mob(bpy.types.Operator):
 			return {'CANCELLED'}
 
 		if os.path.isfile(path) is False:
-			conf.log("Error: Source filepath not found, didn't delete: " + path)
+			env.log("Error: Source filepath not found, didn't delete: " + path)
 			self.report({'ERROR'}, "Source filepath not found, didn't delete")
 			return {'CANCELLED'}
 		else:
 			try:
 				os.remove(path)
 			except Exception as err:
-				conf.log("Error: could not delete file: " + str(err))
+				env.log("Error: could not delete file: " + str(err))
 				self.report({'ERROR'}, "Could not delete file")
 				return {'CANCELLED'}
 		self.report({'INFO'}, "Removed: " + str(path))
-		conf.log("Removed file: " + str(path))
+		env.log("Removed file: " + str(path))
 		bpy.ops.mcprep.reload_mobs()
 		return {'FINISHED'}
 

--- a/MCprep_addon/spawner/mobs.py
+++ b/MCprep_addon/spawner/mobs.py
@@ -710,7 +710,6 @@ classes = (
 
 def register():
 	for cls in classes:
-		util.make_annotations(cls)
 		bpy.utils.register_class(cls)
 
 

--- a/MCprep_addon/spawner/spawn_util.py
+++ b/MCprep_addon/spawner/spawn_util.py
@@ -80,10 +80,10 @@ def filter_collections(data_from):
 
 		short = name.replace(" ", "").replace("-", "").replace("_", "")
 		if SKIP_COLL in short.lower():
-			conf.log("Skipping collection: " + name)
+			env.log("Skipping collection: " + name)
 			continue
 		if SKIP_COLL_LEGACY in short.lower():
-			conf.log("Skipping legacy collection: " + name)
+			env.log("Skipping legacy collection: " + name)
 			continue
 		elif INCLUDE_COLL in name.lower():
 			any_mcprep = True
@@ -91,7 +91,7 @@ def filter_collections(data_from):
 		all_names.append(name)
 
 	if any_mcprep:
-		conf.log("Filtered from {} down to {} MCprep collections".format(
+		env.log("Filtered from {} down to {} MCprep collections".format(
 			len(all_names), len(mcprep_names)))
 		all_names = mcprep_names
 	return all_names
@@ -167,13 +167,13 @@ def attemptScriptLoad(path):
 	path = path[:-5] + "py"
 
 	if os.path.basename(path) in [txt.name for txt in bpy.data.texts]:
-		conf.log("Script {} already imported, not importing a new one".format(
+		env.log("Script {} already imported, not importing a new one".format(
 			os.path.basename(path)))
 		return
 
 	if not os.path.isfile(path):
 		return  # no script found
-	conf.log("Script found, loading and running it")
+	env.log("Script found, loading and running it")
 	text = bpy.data.texts.load(filepath=path, internal=True)
 	try:
 		ctx = bpy.context.copy()
@@ -186,9 +186,9 @@ def attemptScriptLoad(path):
 		ctx.use_fake_user = True
 		ctx.use_module = True
 	except:
-		conf.log("Failed to run the script, not registering")
+		env.log("Failed to run the script, not registering")
 		return
-	conf.log("Ran the script")
+	env.log("Ran the script")
 	text.use_module = True
 
 
@@ -226,13 +226,13 @@ def fix_armature_target(self, context, new_objs, src_coll):
 			if old_target.animation_data:
 				new_target.animation_data_create()
 				new_target.animation_data.action = old_target.animation_data.action
-				conf.log(
+				env.log(
 					"Updated animation of armature for instance of " + src_coll.name)
 
 			if mod.object in new_objs:
 				continue  # Was already the new object target for modifier.
 			mod.object = new_target
-			conf.log(
+			env.log(
 				"Updated target of armature for instance of " + src_coll.name)
 
 
@@ -305,7 +305,7 @@ def get_rig_from_objects(objects):
 
 def offset_root_bone(context, armature):
 	"""Used to offset bone to world location (cursor)"""
-	conf.log("Attempting offset root")
+	env.log("Attempting offset root")
 	set_bone = False
 	lower_bones = [bone.name.lower() for bone in armature.pose.bones]
 	lower_name = None
@@ -364,7 +364,7 @@ def load_linked(self, context, path, name):
 	# 	act = context.selected_objects[0] # better for 2.8
 	# elif context.object:
 	# 	act = context.object  # assumption of object after linking
-	conf.log("Identified new obj as: {}".format(
+	env.log("Identified new obj as: {}".format(
 		act), vv_only=True)
 
 	if not act:
@@ -453,7 +453,7 @@ def load_append(self, context, path, name):
 		# Could try to recopy thsoe elements, or try re-appending with
 		# renaming of the original group
 		self.report({'ERROR'}, "Group name already exists in local file")
-		conf.log("Group already appended/is here")
+		env.log("Group already appended/is here")
 		return
 
 	path = bpy.path.abspath(path)
@@ -471,7 +471,7 @@ def load_append(self, context, path, name):
 	else:
 		raise Exception("No Group or Collection bpy API endpoint")
 
-	conf.log(os.path.join(path, subpath) + ', ' + name)
+	env.log(os.path.join(path, subpath) + ', ' + name)
 	pregroups = list(util.collections())
 	res = util.bAppendLink(os.path.join(path, subpath), name, False)
 	postgroups = list(util.collections())
@@ -485,10 +485,10 @@ def load_append(self, context, path, name):
 		return
 	if not new_groups and name in util.collections():
 		# this is more likely to fail but serves as a fallback
-		conf.log("Mob spawn: Had to go to fallback group name grab")
+		env.log("Mob spawn: Had to go to fallback group name grab")
 		grp_added = util.collections()[name]
 	elif not new_groups:
-		conf.log("Warning, could not detect imported group")
+		env.log("Warning, could not detect imported group")
 		self.report({'WARNING'}, "Could not detect imported group")
 		return
 	else:
@@ -499,7 +499,7 @@ def load_append(self, context, path, name):
 				# group is a subcollection of another name.
 				grp_added = grp
 
-	conf.log("Identified collection/group {} as the primary imported".format(
+	env.log("Identified collection/group {} as the primary imported".format(
 		grp_added), vv_only=True)
 
 	# if rig not centered in original file, assume its group is
@@ -508,7 +508,7 @@ def load_append(self, context, path, name):
 	elif hasattr(grp_added, "instance_offset"):  # 2.8
 		gl = grp_added.instance_offset
 	else:
-		conf.log("Warning, could not set offset for group; null type?")
+		env.log("Warning, could not set offset for group; null type?")
 		gl = (0, 0, 0)
 	cl = util.get_cuser_location(context)
 
@@ -517,7 +517,7 @@ def load_append(self, context, path, name):
 	addedObjs = [ob for ob in grp_added.objects]
 	for ob in all_objects:
 		if ob not in addedObjs:
-			conf.log("This obj not in group {}: {}".format(
+			env.log("This obj not in group {}: {}".format(
 				grp_added.name, ob.name))
 			# removes things like random bone shapes pulled in,
 			# without deleting them, just unlinking them from the scene
@@ -542,14 +542,14 @@ def load_append(self, context, path, name):
 	# 	pass
 	rig_obj = get_rig_from_objects(addedObjs)
 	if not rig_obj:
-		conf.log("Could not get rig object")
+		env.log("Could not get rig object")
 		self.report({'WARNING'}, "No armatures found!")
 	else:
-		conf.log("Using object as primary rig: " + rig_obj.name)
+		env.log("Using object as primary rig: " + rig_obj.name)
 		try:
 			util.set_active_object(context, rig_obj)
 		except RuntimeError:
-			conf.log("Failed to set {} as active".format(rig_obj))
+			env.log("Failed to set {} as active".format(rig_obj))
 			rig_obj = None
 
 	if rig_obj and self.clearPose or rig_obj and self.relocation == "Offset":
@@ -583,7 +583,7 @@ def load_append(self, context, path, name):
 		if self.relocation == "Offset" and posemode:
 			set_bone = offset_root_bone(context, rig_obj)
 			if not set_bone:
-				conf.log(
+				env.log(
 					"This addon works better when the root bone's name is 'MAIN'")
 				self.report(
 					{'INFO'},

--- a/MCprep_addon/spawner/spawn_util.py
+++ b/MCprep_addon/spawner/spawn_util.py
@@ -813,24 +813,24 @@ class MCPREP_UL_material(bpy.types.UIList):
 
 class ListMobAssetsAll(bpy.types.PropertyGroup):
 	"""For listing hidden group of all mobs, regardless of category"""
-	description = bpy.props.StringProperty()
-	category = bpy.props.StringProperty()
-	mcmob_type = bpy.props.StringProperty()
-	index = bpy.props.IntProperty(min=0, default=0)  # for icon drawing
+	description: bpy.props.StringProperty()
+	category: bpy.props.StringProperty()
+	mcmob_type: bpy.props.StringProperty()
+	index: bpy.props.IntProperty(min=0, default=0)  # for icon drawing
 
 
 class ListMobAssets(bpy.types.PropertyGroup):
 	"""For UI drawing of mob assets and holding data"""
-	description = bpy.props.StringProperty()
-	category = bpy.props.StringProperty()  # category it belongs to
-	mcmob_type = bpy.props.StringProperty()
-	index = bpy.props.IntProperty(min=0, default=0)  # for icon drawing
+	description: bpy.props.StringProperty()
+	category: bpy.props.StringProperty()  # category it belongs to
+	mcmob_type: bpy.props.StringProperty()
+	index: bpy.props.IntProperty(min=0, default=0)  # for icon drawing
 
 
 class ListMeshswapAssets(bpy.types.PropertyGroup):
 	"""For UI drawing of meshswap assets and holding data"""
-	block = bpy.props.StringProperty()  # block name only like "fire"
-	method = bpy.props.EnumProperty(
+	block: bpy.props.StringProperty()  # block name only like "fire"
+	method: bpy.props.EnumProperty(
 		name="Import method",
 		# Collection intentionally first to be default for operator calls.
 		items=[
@@ -838,39 +838,39 @@ class ListMeshswapAssets(bpy.types.PropertyGroup):
 			("object", "Object asset", "Object asset"),
 		]
 	)
-	description = bpy.props.StringProperty()
+	description: bpy.props.StringProperty()
 
 
 class ListEntityAssets(bpy.types.PropertyGroup):
 	"""For UI drawing of meshswap assets and holding data"""
-	entity = bpy.props.StringProperty()  # virtual enum, Group/name
-	description = bpy.props.StringProperty()
+	entity: bpy.props.StringProperty()  # virtual enum, Group/name
+	description: bpy.props.StringProperty()
 
 
 class ListItemAssets(bpy.types.PropertyGroup):
 	"""For UI drawing of item assets and holding data"""
 	# inherited: name
-	description = bpy.props.StringProperty()
-	path = bpy.props.StringProperty(subtype='FILE_PATH')
-	index = bpy.props.IntProperty(min=0, default=0)  # for icon drawing
+	description: bpy.props.StringProperty()
+	path: bpy.props.StringProperty(subtype='FILE_PATH')
+	index: bpy.props.IntProperty(min=0, default=0)  # for icon drawing
 
 
 class ListModelAssets(bpy.types.PropertyGroup):
 	"""For UI drawing of mc model assets and holding data"""
-	filepath = bpy.props.StringProperty(subtype="FILE_PATH")
-	description = bpy.props.StringProperty()
+	filepath: bpy.props.StringProperty(subtype="FILE_PATH")
+	description: bpy.props.StringProperty()
 	# index = bpy.props.IntProperty(min=0, default=0)  # icon pulled by name.
 
 
 class ListEffectsAssets(bpy.types.PropertyGroup):
 	"""For UI drawing for different kinds of effects"""
 	# inherited: name
-	filepath = bpy.props.StringProperty(subtype="FILE_PATH")
-	subpath = bpy.props.StringProperty(
+	filepath: bpy.props.StringProperty(subtype="FILE_PATH")
+	subpath: bpy.props.StringProperty(
 		description="Collection/particle/nodegroup within this file",
 		default="")
-	description = bpy.props.StringProperty()
-	effect_type = bpy.props.EnumProperty(
+	description: bpy.props.StringProperty()
+	effect_type: bpy.props.EnumProperty(
 		name="Effect type",
 		items=(
 			(effects.GEO_AREA, 'Geonode area', 'Instance wide-area geonodes effect'),
@@ -878,7 +878,7 @@ class ListEffectsAssets(bpy.types.PropertyGroup):
 			(effects.COLLECTION, 'Collection effect', 'Instance pre-animated collection'),
 			(effects.IMG_SEQ, 'Image sequence', 'Instance an animated image sequence effect'),
 		))
-	index = bpy.props.IntProperty(min=0, default=0)  # for icon drawing
+	index: bpy.props.IntProperty(min=0, default=0)  # for icon drawing
 
 
 # -----------------------------------------------------------------------------
@@ -909,7 +909,6 @@ classes = (
 
 def register():
 	for cls in classes:
-		util.make_annotations(cls)
 		bpy.utils.register_class(cls)
 
 

--- a/MCprep_addon/tracking.py
+++ b/MCprep_addon/tracking.py
@@ -28,6 +28,8 @@ TIMEOUT = 60
 import os
 import bpy
 
+from MCprep_addon.conf import MCprepEnv
+
 # remaining, wrap in safe-importing
 try:
 	from . import conf
@@ -999,7 +1001,8 @@ def register(bl_info):
 
 	# used to define which server source, not just if's below
 	if VALID_IMPORT:
-		Tracker.dev = conf.dev # True or False
+		env = MCprepEnv()
+		Tracker.dev = env.dev_build # True or False
 	else:
 		Tracker.dev = False
 

--- a/MCprep_addon/tracking.py
+++ b/MCprep_addon/tracking.py
@@ -28,8 +28,6 @@ TIMEOUT = 60
 import os
 import bpy
 
-from MCprep_addon.conf import MCprepEnv
-
 # remaining, wrap in safe-importing
 try:
 	from . import conf
@@ -45,6 +43,7 @@ try:
 	import textwrap
 	import time
 	from datetime import datetime
+	from .conf import ENV
 except Exception as err:
 	print("[MCPREP Error] Failed tracker module load, invalid import module:")
 	print('\t'+str(err))
@@ -1001,8 +1000,7 @@ def register(bl_info):
 
 	# used to define which server source, not just if's below
 	if VALID_IMPORT:
-		env = MCprepEnv()
-		Tracker.dev = env.dev_build # True or False
+		Tracker.dev = ENV.dev_build # True or False
 	else:
 		Tracker.dev = False
 

--- a/MCprep_addon/tracking.py
+++ b/MCprep_addon/tracking.py
@@ -43,7 +43,7 @@ try:
 	import textwrap
 	import time
 	from datetime import datetime
-	from .conf import ENV
+	from .conf import env
 except Exception as err:
 	print("[MCPREP Error] Failed tracker module load, invalid import module:")
 	print('\t'+str(err))
@@ -1000,7 +1000,7 @@ def register(bl_info):
 
 	# used to define which server source, not just if's below
 	if VALID_IMPORT:
-		Tracker.dev = ENV.dev_build # True or False
+		Tracker.dev = env.dev_build # True or False
 	else:
 		Tracker.dev = False
 

--- a/MCprep_addon/tracking.py
+++ b/MCprep_addon/tracking.py
@@ -612,9 +612,9 @@ class TRACK_OT_popup_report_error(bpy.types.Operator):
 	def execute(self, context):
 		# if in headless mode, skip
 		if bpy.app.background:
-			conf.log("Skip Report logging, running headless")
-			conf.log("Would have reported:")
-			#conf.log(self.error_report)
+			env.log("Skip Report logging, running headless")
+			env.log("Would have reported:")
+			#env.log(self.error_report)
 			raise Exception(self.error_report)
 			return {'CANCELLED'}
 
@@ -862,7 +862,7 @@ def report_error(function):
 		elif hasattr(self, "skipUsage") and self.skipUsage is True:
 			return res  # skip running usage
 		elif VALID_IMPORT is False:
-			conf.log("Skipping usage, VALID_IMPORT is False")
+			env.log("Skipping usage, VALID_IMPORT is False")
 			return
 
 		try:
@@ -885,12 +885,12 @@ def report_error(function):
 			and Tracker._last_request.get("function") == self.track_function
 			and Tracker._last_request.get("time") + Tracker._debounce > time.time()
 			):
-			conf.log("Skipping usage due to debounce")
+			env.log("Skipping usage due to debounce")
 			run_track = False
 
 		# If successful completion, run analytics function if relevant
 		if bpy.app.background and run_track:
-			conf.log("Background mode, would have tracked usage: " + self.track_function)
+			env.log("Background mode, would have tracked usage: " + self.track_function)
 		elif run_track:
 			param = None
 			exporter = None

--- a/MCprep_addon/util.py
+++ b/MCprep_addon/util.py
@@ -48,7 +48,7 @@ def apply_colorspace(node, color_enum):
 	noncolor_override = None
 
 	if not node.image:
-		conf.log("Node has no image applied yet, cannot change colorspace")
+		env.log("Node has no image applied yet, cannot change colorspace")
 
 	# For later 2.8, fix images color space user
 	if hasattr(node, "color_space"):  # 2.7 and earlier 2.8 versions
@@ -127,7 +127,7 @@ def bAppendLink(directory, name, toLink, active_layer=True):
 	Returns: true if successful, false if not.
 	"""
 
-	conf.log("Appending " + directory + " : " + name, vv_only=True)
+	env.log("Appending " + directory + " : " + name, vv_only=True)
 
 	# for compatibility, add ending character
 	if directory[-1] != "/" and directory[-1] != os.path.sep:
@@ -135,7 +135,7 @@ def bAppendLink(directory, name, toLink, active_layer=True):
 
 	if "link_append" in dir(bpy.ops.wm):
 		# OLD method of importing, e.g. in blender 2.70
-		conf.log("Using old method of append/link, 2.72 <=", vv_only=True)
+		env.log("Using old method of append/link, 2.72 <=", vv_only=True)
 		try:
 			bpy.ops.wm.link_append(directory=directory, filename=name, link=toLink)
 			return True
@@ -143,7 +143,7 @@ def bAppendLink(directory, name, toLink, active_layer=True):
 			print("bAppendLink", e)
 			return False
 	elif "link" in dir(bpy.ops.wm) and "append" in dir(bpy.ops.wm):
-		conf.log("Using post-2.72 method of append/link", vv_only=True)
+		env.log("Using post-2.72 method of append/link", vv_only=True)
 		if toLink:
 			bpy.ops.wm.link(directory=directory, filename=name)
 		elif bv28():
@@ -156,7 +156,7 @@ def bAppendLink(directory, name, toLink, active_layer=True):
 				print("bAppendLink", e)
 				return False
 		else:
-			conf.log("{} {} {}".format(directory, name, active_layer))
+			env.log("{} {} {}".format(directory, name, active_layer))
 			try:
 				bpy.ops.wm.append(
 					directory=directory,
@@ -268,13 +268,13 @@ def loadTexture(texture):
 		if base_filepath == bpy.path.abspath(texture):
 			data_img = bpy.data.images[base]
 			data_img.reload()
-			conf.log("Using already loaded texture", vv_only=True)
+			env.log("Using already loaded texture", vv_only=True)
 		else:
 			data_img = bpy.data.images.load(texture, check_existing=True)
-			conf.log("Loading new texture image", vv_only=True)
+			env.log("Loading new texture image", vv_only=True)
 	else:
 		data_img = bpy.data.images.load(texture, check_existing=True)
-		conf.log("Loading new texture image", vv_only=True)
+		env.log("Loading new texture image", vv_only=True)
 	return data_img
 
 
@@ -308,11 +308,11 @@ def link_selected_objects_to_scene():
 def open_program(executable):
 	# Open an external program from filepath/executbale
 	executable = bpy.path.abspath(executable)
-	conf.log("Open program request: " + executable)
+	env.log("Open program request: " + executable)
 
 	# input could be .app file, which appears as if a folder
 	if not os.path.isfile(executable):
-		conf.log("File not executable")
+		env.log("File not executable")
 		if not os.path.isdir(executable):
 			return -1
 		elif not executable.lower().endswith(".app"):
@@ -322,7 +322,7 @@ def open_program(executable):
 	osx_or_linux = platform.system() == "Darwin"
 	osx_or_linux = osx_or_linux or 'linux' in platform.system().lower()
 	if executable.lower().endswith('.exe') and osx_or_linux:
-		conf.log("Opening program via wine")
+		env.log("Opening program via wine")
 		p = Popen(['which', 'wine'], stdin=PIPE, stdout=PIPE, stderr=PIPE)
 		stdout, err = p.communicate(b"")
 		has_wine = stdout and not err
@@ -330,7 +330,7 @@ def open_program(executable):
 		if has_wine:
 			# wine is installed; this will hang blender until mineways closes.
 			p = Popen(['wine', executable], stdin=PIPE, stdout=PIPE, stderr=PIPE)
-			conf.log(
+			env.log(
 				"Opening via wine + direct executable, will hang blender till closed")
 
 			# communicating with process makes it hang, so trust it works
@@ -343,18 +343,18 @@ def open_program(executable):
 	try:  # attempt to use blender's built-in method
 		res = bpy.ops.wm.path_open(filepath=executable)
 		if res == {"FINISHED"}:
-			conf.log("Opened using built in path opener")
+			env.log("Opened using built in path opener")
 			return 0
 		else:
-			conf.log("Did not get finished response: ", str(res))
+			env.log("Did not get finished response: ", str(res))
 	except:
-		conf.log("failed to open using builtin mehtod")
+		env.log("failed to open using builtin mehtod")
 		pass
 
 	if platform.system() == "Darwin" and executable.lower().endswith(".app"):
 		# for mac, if folder, check that it has .app otherwise throw -1
 		# (right now says will open even if just folder!!)
-		conf.log("Attempting to open .app via system Open")
+		env.log("Attempting to open .app via system Open")
 		p = Popen(['open', executable], stdin=PIPE, stdout=PIPE, stderr=PIPE)
 		stdout, err = p.communicate(b"")
 		if err != b"":
@@ -436,13 +436,13 @@ def load_mcprep_json():
 		"make_real": []
 	}
 	if not os.path.isfile(path):
-		conf.log("Error, json file does not exist: " + path)
+		env.log("Error, json file does not exist: " + path)
 		env.json_data = default
 		return False
 	with open(path) as data_file:
 		try:
 			env.json_data = json.load(data_file)
-			conf.log("Successfully read the JSON file")
+			env.log("Successfully read the JSON file")
 			return True
 		except Exception as err:
 			print("Failed to load json file:")

--- a/MCprep_addon/util.py
+++ b/MCprep_addon/util.py
@@ -28,6 +28,7 @@ import subprocess
 import bpy
 
 from . import conf
+from .conf import ENV
 
 
 # Commonly used name for an excluded collection in Blender 2.8+
@@ -417,7 +418,7 @@ def addGroupInstance(group_name, loc, select=True):
 
 def load_mcprep_json():
 	"""Load in the json file, defered so not at addon enable time."""
-	path = conf.json_path
+	path = ENV.json_path
 	default = {
 		"blocks": {
 			"reflective": [],
@@ -436,17 +437,17 @@ def load_mcprep_json():
 	}
 	if not os.path.isfile(path):
 		conf.log("Error, json file does not exist: " + path)
-		conf.json_data = default
+		ENV.json_data = default
 		return False
 	with open(path) as data_file:
 		try:
-			conf.json_data = json.load(data_file)
+			ENV.json_data = json.load(data_file)
 			conf.log("Successfully read the JSON file")
 			return True
 		except Exception as err:
 			print("Failed to load json file:")
 			print('\t', err)
-			conf.json_data = default
+			ENV.json_data = default
 
 
 def ui_scale():

--- a/MCprep_addon/util.py
+++ b/MCprep_addon/util.py
@@ -28,7 +28,7 @@ import subprocess
 import bpy
 
 from . import conf
-from .conf import ENV
+from .conf import env
 
 
 # Commonly used name for an excluded collection in Blender 2.8+
@@ -418,7 +418,7 @@ def addGroupInstance(group_name, loc, select=True):
 
 def load_mcprep_json():
 	"""Load in the json file, defered so not at addon enable time."""
-	path = ENV.json_path
+	path = env.json_path
 	default = {
 		"blocks": {
 			"reflective": [],
@@ -437,17 +437,17 @@ def load_mcprep_json():
 	}
 	if not os.path.isfile(path):
 		conf.log("Error, json file does not exist: " + path)
-		ENV.json_data = default
+		env.json_data = default
 		return False
 	with open(path) as data_file:
 		try:
-			ENV.json_data = json.load(data_file)
+			env.json_data = json.load(data_file)
 			conf.log("Successfully read the JSON file")
 			return True
 		except Exception as err:
 			print("Failed to load json file:")
 			print('\t', err)
-			ENV.json_data = default
+			env.json_data = default
 
 
 def ui_scale():

--- a/MCprep_addon/util.py
+++ b/MCprep_addon/util.py
@@ -213,6 +213,7 @@ def min_bv(version, *, inclusive=True):
 
 def bv28():
 	"""Check if blender 2.8, for layouts, UI, and properties. """
+	deprecation_warning()
 	return min_bv((2, 80))
 
 

--- a/MCprep_addon/util.py
+++ b/MCprep_addon/util.py
@@ -558,6 +558,10 @@ def natural_sort(elements):
 
 	return sorted(elements, key=alphanum_key)
 
+def deprecation_warning():
+	print("DEPRECATION WARNING: THIS FUNCTION WILL BE DEPRECATED")
+	import traceback
+	traceback.print_stack()
 
 # -----------------------------------------------------------------------------
 # Cross blender 2.7 and 2.8 functions
@@ -566,6 +570,7 @@ def natural_sort(elements):
 
 def make_annotations(cls):
 	"""Add annotation attribute to class fields to avoid Blender 2.8 warnings"""
+	deprecation_warning()
 	if not hasattr(bpy.app, "version") or bpy.app.version < (2, 80):
 		return cls
 	if bpy.app.version < (2, 93, 0):

--- a/MCprep_addon/world_tools.py
+++ b/MCprep_addon/world_tools.py
@@ -23,6 +23,7 @@ import bpy
 from bpy_extras.io_utils import ExportHelper, ImportHelper
 
 from . import conf
+from .conf import env
 from . import util
 from . import tracking
 
@@ -566,11 +567,11 @@ class MCPREP_OT_prep_world(bpy.types.Operator):
 				sky_used = True
 				break
 		if sky_used:
-			conf.log("MCprep sky being used with atmosphere")
+			env.log("MCprep sky being used with atmosphere")
 			context.scene.world.use_sky_blend = False
 			context.scene.world.horizon_color = (0.00938029, 0.0125943, 0.0140572)
 		else:
-			conf.log("No MCprep sky with atmosphere")
+			env.log("No MCprep sky with atmosphere")
 			context.scene.world.use_sky_blend = True
 			context.scene.world.horizon_color = (0.647705, 0.859927, 0.940392)
 			context.scene.world.zenith_color = (0.0954261, 0.546859, 1)
@@ -712,7 +713,7 @@ class MCPREP_OT_add_mc_sky(bpy.types.Operator):
 				self.report(
 					{'ERROR'},
 					"Source MCprep world blend file does not exist: " + blendfile)
-				conf.log(
+				env.log(
 					"Source MCprep world blend file does not exist: " + blendfile)
 				return {'CANCELLED'}
 			if wname in bpy.data.worlds:
@@ -745,7 +746,7 @@ class MCPREP_OT_add_mc_sky(bpy.types.Operator):
 
 			time_obj = get_time_object()
 			if not time_obj:
-				conf.log(
+				env.log(
 					"TODO: implement create time_obj, parent sun to it & driver setup")
 
 		if self.world_type in ("world_static_mesh", "world_mesh"):
@@ -753,7 +754,7 @@ class MCPREP_OT_add_mc_sky(bpy.types.Operator):
 				self.report(
 					{'ERROR'},
 					"Source MCprep world blend file does not exist: " + blendfile)
-				conf.log(
+				env.log(
 					"Source MCprep world blend file does not exist: " + blendfile)
 				return {'CANCELLED'}
 			resource = blendfile + "/Object"
@@ -855,7 +856,7 @@ class MCPREP_OT_add_mc_sky(bpy.types.Operator):
 			context.scene.world["mcprep_world"] = True
 		else:
 			self.report({'ERROR'}, "Failed to import new world")
-			conf.log("Failed to import new world")
+			env.log("Failed to import new world")
 
 		# assign sun/moon shader accordingly
 		use_shader = 1 if self.world_type == "world_shader" else 0
@@ -877,7 +878,7 @@ class MCPREP_OT_add_mc_sky(bpy.types.Operator):
 
 		# if needed: create time object and setup drivers
 		# if not time_obj:
-		# 	conf.log("Creating time_obj")
+		# 	env.log("Creating time_obj")
 		# 	time_obj = bpy.data.objects.new('MCprep Time Control', None)
 		# 	util.obj_link_scene(time_obj, context)
 		# 	global time_obj_cache
@@ -891,7 +892,7 @@ class MCPREP_OT_add_mc_sky(bpy.types.Operator):
 		# if (not world.node_tree.animation_data
 		# 		or not world.node_tree.animation_data.drivers
 		# 		or not world.node_tree.animation_data.drivers[0].driver):
-		# 	conf.log("Could not get driver from imported dynamic world")
+		# 	env.log("Could not get driver from imported dynamic world")
 		# 	self.report({'WARNING'}, "Could not update driver for dynamic world")
 		# 	driver = None
 		# else:
@@ -993,7 +994,7 @@ class MCPREP_OT_render_helper():
 
 	def cleanup_scene(self):
 		# Clean up
-		conf.log("Cleanup pano rendering")
+		env.log("Cleanup pano rendering")
 		for i in range(len(self.render_queue_cleanup)):
 			util.obj_unlink_remove(self.render_queue_cleanup[i]["camera"], True)
 
@@ -1030,7 +1031,7 @@ class MCPREP_OT_render_helper():
 		return camera
 
 	def cancel_render(self, scene):
-		conf.log("Cancelling pano render queue")
+		env.log("Cancelling pano render queue")
 		self.render_queue = []
 		self.cleanup_scene()
 
@@ -1056,7 +1057,7 @@ class MCPREP_OT_render_helper():
 		else:
 			header_text = "Pano render finished"
 
-		conf.log(header_text)
+		env.log(header_text)
 		area.header_text_set(header_text)
 		area.show_menus = False
 
@@ -1086,7 +1087,7 @@ class MCPREP_OT_render_helper():
 			self.prior_frame = self.current_render
 
 		if not self.render_queue:
-			conf.log("Finished pano render queue")
+			env.log("Finished pano render queue")
 			self.cleanup_scene()
 			return
 
@@ -1097,7 +1098,7 @@ class MCPREP_OT_render_helper():
 		bpy.context.scene.render.filepath = os.path.join(
 			self.filepath, self.current_render["filename"])
 
-		conf.log("Starting pano render {}".format(self.current_render["filename"]))
+		env.log("Starting pano render {}".format(self.current_render["filename"]))
 		self.display_current()
 
 		bpy.app.timers.register(
@@ -1109,7 +1110,7 @@ render_helper = MCPREP_OT_render_helper()
 
 def init_render_timer():
 	"""Helper for pano renders to offset the start of the queue from op run."""
-	conf.log("Initial render timer started pano queue")
+	env.log("Initial render timer started pano queue")
 	render_helper.render_next_in_queue(None, None)
 
 

--- a/MCprep_addon/world_tools.py
+++ b/MCprep_addon/world_tools.py
@@ -1278,7 +1278,6 @@ classes = (
 
 def register():
 	for cls in classes:
-		util.make_annotations(cls)
 		bpy.utils.register_class(cls)
 
 

--- a/mcprep_data_refresh.py
+++ b/mcprep_data_refresh.py
@@ -1,4 +1,3 @@
-#!/opt/homebrew/bin/python3
 # Tool to pull down material names from jmc2obj and Mineways
 
 import json

--- a/run_tests.sh
+++ b/run_tests.sh
@@ -28,7 +28,7 @@ TEST_RUNNERS=(
 )
 
 # Update the mappings.
-./mcprep_data_refresh.py -auto
+python3 ./mcprep_data_refresh.py -auto
 
 # First, do a soft reload of python files.
 echo "Soft py file reload"


### PR DESCRIPTION
Alright, this is a new branch tracking deprecations and migrating 2.7x style code to 2.8. The term "Rewritten Core" I think acts as a nice theme for this migration, as it requires going into parts of MCprep that have long been forgotten about.

# Faq (for anyone that stumbles apon this)
 - Q: Will this have any performance improvements?
	 - A: No, any performance improvements will be negligible at most
 - Q: When's the earliest I can use this?
 	- A: As of writing, we can't say. When this does go into public testing (likely as 3.4.99), we'll create a GitHub discussion for bug reports and testing
 - Q: Why are you removing 2.7x support?
 	- A: See #399, but the gist is that the effort of maintaining compatibility is not worth it for the small amount of 2.7x users
- Q: Can I contribute code?
	- A: Sure, but you should have a good understanding of bpy and Git
- Q: I'm a 2.7x user, what does this mean for me?
	- A: This means you will have to either stick with the MCprep 3.4 series, or upgrade. I've talked with 2.7x users who've moved to modern versions of Blender, and according to them, as long as you choose the 2.7x keybinds, migrating is pretty painless

# Plans
- [ ] Migrate `PropertyGroups` to use annotations
- [x] Remove Blender Internal support 
- [ ] Add annotations to common functions
- [ ] Replace use of `os` with `pathlib` for file operations
- [ ] Start using dataclasses when it makes sense 
- [ ] Start using f-strings for readability

# Deprecations
## `util.make_annotations(cls)` and `util.bv28()`
Dropped as 2.7x support will also be dropped. Just use type annotations for properties instead of the old 2.7x syntax and don't target 2.7x when writing code