### PR TITLE
Big formatting commit

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -207,7 +207,7 @@ Add this to a file called .gitmessage, and then execute the following command:
 To use for each commit, you can use `git config --local commit.verbose true` to tell Git to perform a verbose commit all the time for just the MCprep repo.
 
 ## Dependencies
-If you're using an IDE, it's recommened to install `bpy` as a Python module. In our experience, the [fake-bpy package](https://github.com/nutti/fake-bpy-module) seems to be the best. In addition, we also use `darker` to perform PEP8 formatting on changed code (this is a requirement, we expect you to use `darker` on your changes)
+If you're using an IDE, it's recommened to install `bpy` as a Python module. In our experience, the [fake-bpy package](https://github.com/nutti/fake-bpy-module) seems to be the best. In addition, we also use `black` to perform PEP8 formatting on changed code (this is a requirement, we expect you to use `darker` on your changes)
 
 It's also recommened to use a virtual environment (especially if you're on Linux) as to avoid issues with system wide packages and different versions of `bpy`. [See this for more details](https://realpython.com/python-virtual-environments-a-primer/)
 
@@ -226,7 +226,7 @@ If you decide to use Poetry, then simply run the following command:
 
 `poetry install`
 
-To enable the virtual environment, run `poetry shell`, then type `exit` when you're done. When you make a change to a file, **please please please** run `poetry run darker <changed file>` to apply PEP8 formatting to the changes (or if you've enabled the virtual environment, you can just type `darker <changed file>`)
+To enable the virtual environment, run `poetry shell`, then type `exit` when you're done. When you make a change to a file, **please please please** run `poetry run black <changed file>` to apply PEP8 formatting to the changes (or if you've enabled the virtual environment, you can just type `darker <changed file>`)
 
 ### Manual: Requirements.txt Edition
 First create a virtual environment:
@@ -247,7 +247,7 @@ Install dependencies:
 
 `python3 -m pip install -r requirements.txt`
 
-### Manual: Setting up `bpy` + `darker` Manually Edition
+### Manual: Setting up `bpy` + `black` Manually Edition
 First, we need to come up with a name. For MCprep development, it's recommended to use the following convention:
 `mcprep_venv_<version>`
 
@@ -273,9 +273,9 @@ Next we need to install `fake-bpy`:
 
 If you use PyCharm, you should check the GitHub for [additional instructions](https://github.com/nutti/fake-bpy-module#install-via-pip-package)
 
-In addition, for PEP8 formatting, we need to install `darker`:
-`python3 -m pip install darker`
+In addition, for PEP8 formatting, we need to install `black`:
+`python3 -m pip install black`
 
-When you make a change to a file, **please please please** run `darker <changed file>` to apply PEP8 formatting to the changes.
+When you make a change to a file, **please please please** run `black <changed file>` to apply PEP8 formatting to the changes.
 
 Now you're ready to do MCprep development

--- a/MCprep_addon/__init__.py
+++ b/MCprep_addon/__init__.py
@@ -39,34 +39,35 @@ Disclaimer: This is not an official Google product
 # 								error = 51
 
 bl_info = {
-	"name": "MCprep",
-	"category": "Object",
-	"version": (3, 4, 3),
-	"blender": (2, 80, 0),
-	"location": "3D window toolshelf > MCprep tab",
-	"description": "Minecraft workflow addon for rendering and animation",
-	"warning": "",
-	"wiki_url": "https://TheDuckCow.com/MCprep",
-	"author": "Patrick W. Crawford <support@theduckcow.com>",
-	"tracker_url": "https://github.com/TheDuckCow/MCprep/issues"
+    "name": "MCprep",
+    "category": "Object",
+    "version": (3, 4, 3),
+    "blender": (2, 80, 0),
+    "location": "3D window toolshelf > MCprep tab",
+    "description": "Minecraft workflow addon for rendering and animation",
+    "warning": "",
+    "wiki_url": "https://TheDuckCow.com/MCprep",
+    "author": "Patrick W. Crawford <support@theduckcow.com>",
+    "tracker_url": "https://github.com/TheDuckCow/MCprep/issues",
 }
 
 import importlib
 
 if "load_modules" in locals():
-	importlib.reload(load_modules)
+    importlib.reload(load_modules)
 else:
-	from . import load_modules
+    from . import load_modules
 
 import bpy
 
+
 def register():
-	load_modules.register(bl_info)
+    load_modules.register(bl_info)
 
 
 def unregister():
-	load_modules.unregister(bl_info)
+    load_modules.unregister(bl_info)
 
 
 if __name__ == "__main__":
-	register()
+    register()

--- a/MCprep_addon/addon_updater.py
+++ b/MCprep_addon/addon_updater.py
@@ -48,1579 +48,1597 @@ import addon_utils
 
 
 class SingletonUpdater:
-	"""Addon updater service class.
-
-	This is the singleton class to instance once and then reference where
-	needed throughout the addon. It implements all the interfaces for running
-	updates.
-	"""
-	def __init__(self):
-
-		self._engine = GithubEngine()
-		self._user = None
-		self._repo = None
-		self._website = None
-		self._current_version = None
-		self._subfolder_path = None
-		self._tags = list()
-		self._tag_latest = None
-		self._tag_names = list()
-		self._latest_release = None
-		self._use_releases = False
-		self._include_branches = False
-		self._include_branch_list = ['master']
-		self._include_branch_auto_check = False
-		self._manual_only = False
-		self._version_min_update = None
-		self._version_max_update = None
-
-		# By default, backup current addon on update/target install.
-		self._backup_current = True
-		self._backup_ignore_patterns = None
-
-		# Set patterns the files to overwrite during an update.
-		self._overwrite_patterns = ["*.py", "*.pyc"]
-		self._remove_pre_update_patterns = list()
-
-		# By default, don't auto disable+re-enable the addon after an update,
-		# as this is less stable/often won't fully reload all modules anyways.
-		self._auto_reload_post_update = False
-
-		# Settings for the frequency of automated background checks.
-		self._check_interval_enabled = False
-		self._check_interval_months = 0
-		self._check_interval_days = 7
-		self._check_interval_hours = 0
-		self._check_interval_minutes = 0
-
-		# runtime variables, initial conditions
-		self._verbose = False
-		self._use_print_traces = True
-		self._fake_install = False
-		self._async_checking = False  # only true when async daemon started
-		self._update_ready = None
-		self._update_link = None
-		self._update_version = None
-		self._source_zip = None
-		self._check_thread = None
-		self._select_link = None
-		self.skip_tag = None
-
-		# Get data from the running blender module (addon).
-		self._addon = __package__.lower()
-		self._addon_package = __package__  # Must not change.
-		self._updater_path = os.path.join(
-			os.path.dirname(__file__), self._addon + "_updater")
-		self._addon_root = os.path.dirname(__file__)
-		self._json = dict()
-		self._error = None
-		self._error_msg = None
-		self._prefiltered_tag_count = 0
-
-		# UI properties, not used within this module but still useful to have.
-
-		# to verify a valid import, in place of placeholder import
-		self.show_popups = True  # UI uses to show popups or not.
-		self.invalid_updater = False
-
-		# pre-assign basic select-link function
-		def select_link_function(self, tag):
-			return tag["zipball_url"]
-
-		self._select_link = select_link_function
-
-	def print_trace(self):
-		"""Print handled exception details when use_print_traces is set"""
-		if self._use_print_traces:
-			traceback.print_exc()
-
-	def print_verbose(self, msg):
-		"""Print out a verbose logging message if verbose is true."""
-		if not self._verbose:
-			return
-		print("{} addon: ".format(self.addon) + msg)
-
-	# -------------------------------------------------------------------------
-	# Getters and setters
-	# -------------------------------------------------------------------------
-	@property
-	def addon(self):
-		return self._addon
-
-	@addon.setter
-	def addon(self, value):
-		self._addon = str(value)
-
-	@property
-	def api_url(self):
-		return self._engine.api_url
-
-	@api_url.setter
-	def api_url(self, value):
-		if not self.check_is_url(value):
-			raise ValueError("Not a valid URL: " + value)
-		self._engine.api_url = value
-
-	@property
-	def async_checking(self):
-		return self._async_checking
-
-	@property
-	def auto_reload_post_update(self):
-		return self._auto_reload_post_update
-
-	@auto_reload_post_update.setter
-	def auto_reload_post_update(self, value):
-		try:
-			self._auto_reload_post_update = bool(value)
-		except:
-			raise ValueError("auto_reload_post_update must be a boolean value")
-
-	@property
-	def backup_current(self):
-		return self._backup_current
-
-	@backup_current.setter
-	def backup_current(self, value):
-		if value is None:
-			self._backup_current = False
-		else:
-			self._backup_current = value
-
-	@property
-	def backup_ignore_patterns(self):
-		return self._backup_ignore_patterns
-
-	@backup_ignore_patterns.setter
-	def backup_ignore_patterns(self, value):
-		if value is None:
-			self._backup_ignore_patterns = None
-		elif not isinstance(value, list):
-			raise ValueError("Backup pattern must be in list format")
-		else:
-			self._backup_ignore_patterns = value
-
-	@property
-	def check_interval(self):
-		return (self._check_interval_enabled,
-				self._check_interval_months,
-				self._check_interval_days,
-				self._check_interval_hours,
-				self._check_interval_minutes)
-
-	@property
-	def current_version(self):
-		return self._current_version
-
-	@current_version.setter
-	def current_version(self, tuple_values):
-		if tuple_values is None:
-			self._current_version = None
-			return
-		elif type(tuple_values) is not tuple:
-			try:
-				tuple(tuple_values)
-			except:
-				raise ValueError(
-					"current_version must be a tuple of integers")
-		for i in tuple_values:
-			if type(i) is not int:
-				raise ValueError(
-					"current_version must be a tuple of integers")
-		self._current_version = tuple(tuple_values)
-
-	@property
-	def engine(self):
-		return self._engine.name
-
-	@engine.setter
-	def engine(self, value):
-		engine = value.lower()
-		if engine == "github":
-			self._engine = GithubEngine()
-		elif engine == "gitlab":
-			self._engine = GitlabEngine()
-		elif engine == "bitbucket":
-			self._engine = BitbucketEngine()
-		else:
-			raise ValueError("Invalid engine selection")
-
-	@property
-	def error(self):
-		return self._error
-
-	@property
-	def error_msg(self):
-		return self._error_msg
-
-	@property
-	def fake_install(self):
-		return self._fake_install
-
-	@fake_install.setter
-	def fake_install(self, value):
-		if not isinstance(value, bool):
-			raise ValueError("fake_install must be a boolean value")
-		self._fake_install = bool(value)
-
-	# not currently used
-	@property
-	def include_branch_auto_check(self):
-		return self._include_branch_auto_check
-
-	@include_branch_auto_check.setter
-	def include_branch_auto_check(self, value):
-		try:
-			self._include_branch_auto_check = bool(value)
-		except:
-			raise ValueError("include_branch_autocheck must be a boolean")
-
-	@property
-	def include_branch_list(self):
-		return self._include_branch_list
-
-	@include_branch_list.setter
-	def include_branch_list(self, value):
-		try:
-			if value is None:
-				self._include_branch_list = ['master']
-			elif not isinstance(value, list) or len(value) == 0:
-				raise ValueError(
-					"include_branch_list should be a list of valid branches")
-			else:
-				self._include_branch_list = value
-		except:
-			raise ValueError(
-				"include_branch_list should be a list of valid branches")
-
-	@property
-	def include_branches(self):
-		return self._include_branches
-
-	@include_branches.setter
-	def include_branches(self, value):
-		try:
-			self._include_branches = bool(value)
-		except:
-			raise ValueError("include_branches must be a boolean value")
-
-	@property
-	def json(self):
-		if len(self._json) == 0:
-			self.set_updater_json()
-		return self._json
-
-	@property
-	def latest_release(self):
-		if self._latest_release is None:
-			return None
-		return self._latest_release
-
-	@property
-	def manual_only(self):
-		return self._manual_only
-
-	@manual_only.setter
-	def manual_only(self, value):
-		try:
-			self._manual_only = bool(value)
-		except:
-			raise ValueError("manual_only must be a boolean value")
-
-	@property
-	def overwrite_patterns(self):
-		return self._overwrite_patterns
-
-	@overwrite_patterns.setter
-	def overwrite_patterns(self, value):
-		if value is None:
-			self._overwrite_patterns = ["*.py", "*.pyc"]
-		elif not isinstance(value, list):
-			raise ValueError("overwrite_patterns needs to be in a list format")
-		else:
-			self._overwrite_patterns = value
-
-	@property
-	def private_token(self):
-		return self._engine.token
-
-	@private_token.setter
-	def private_token(self, value):
-		if value is None:
-			self._engine.token = None
-		else:
-			self._engine.token = str(value)
-
-	@property
-	def remove_pre_update_patterns(self):
-		return self._remove_pre_update_patterns
-
-	@remove_pre_update_patterns.setter
-	def remove_pre_update_patterns(self, value):
-		if value is None:
-			self._remove_pre_update_patterns = list()
-		elif not isinstance(value, list):
-			raise ValueError(
-				"remove_pre_update_patterns needs to be in a list format")
-		else:
-			self._remove_pre_update_patterns = value
-
-	@property
-	def repo(self):
-		return self._repo
-
-	@repo.setter
-	def repo(self, value):
-		try:
-			self._repo = str(value)
-		except:
-			raise ValueError("repo must be a string value")
-
-	@property
-	def select_link(self):
-		return self._select_link
-
-	@select_link.setter
-	def select_link(self, value):
-		# ensure it is a function assignment, with signature:
-		# input self, tag; returns link name
-		if not hasattr(value, "__call__"):
-			raise ValueError("select_link must be a function")
-		self._select_link = value
-
-	@property
-	def stage_path(self):
-		return self._updater_path
-
-	@stage_path.setter
-	def stage_path(self, value):
-		if value is None:
-			self.print_verbose("Aborting assigning stage_path, it's null")
-			return
-		elif value is not None and not os.path.exists(value):
-			try:
-				os.makedirs(value)
-			except:
-				self.print_verbose("Error trying to staging path")
-				self.print_trace()
-				return
-		self._updater_path = value
-
-	@property
-	def subfolder_path(self):
-		return self._subfolder_path
-
-	@subfolder_path.setter
-	def subfolder_path(self, value):
-		self._subfolder_path = value
-
-	@property
-	def tags(self):
-		if len(self._tags) == 0:
-			return list()
-		tag_names = list()
-		for tag in self._tags:
-			tag_names.append(tag["name"])
-		return tag_names
-
-	@property
-	def tag_latest(self):
-		if self._tag_latest is None:
-			return None
-		return self._tag_latest["name"]
-
-	@property
-	def update_link(self):
-		return self._update_link
-
-	@property
-	def update_ready(self):
-		return self._update_ready
-
-	@property
-	def update_version(self):
-		return self._update_version
-
-	@property
-	def use_releases(self):
-		return self._use_releases
-
-	@use_releases.setter
-	def use_releases(self, value):
-		try:
-			self._use_releases = bool(value)
-		except:
-			raise ValueError("use_releases must be a boolean value")
-
-	@property
-	def user(self):
-		return self._user
-
-	@user.setter
-	def user(self, value):
-		try:
-			self._user = str(value)
-		except:
-			raise ValueError("User must be a string value")
-
-	@property
-	def verbose(self):
-		return self._verbose
-
-	@verbose.setter
-	def verbose(self, value):
-		try:
-			self._verbose = bool(value)
-			self.print_verbose("Verbose is enabled")
-		except:
-			raise ValueError("Verbose must be a boolean value")
-
-	@property
-	def use_print_traces(self):
-		return self._use_print_traces
-
-	@use_print_traces.setter
-	def use_print_traces(self, value):
-		try:
-			self._use_print_traces = bool(value)
-		except:
-			raise ValueError("use_print_traces must be a boolean value")
-
-	@property
-	def version_max_update(self):
-		return self._version_max_update
-
-	@version_max_update.setter
-	def version_max_update(self, value):
-		if value is None:
-			self._version_max_update = None
-			return
-		if not isinstance(value, tuple):
-			raise ValueError("Version maximum must be a tuple")
-		for subvalue in value:
-			if type(subvalue) is not int:
-				raise ValueError("Version elements must be integers")
-		self._version_max_update = value
-
-	@property
-	def version_min_update(self):
-		return self._version_min_update
-
-	@version_min_update.setter
-	def version_min_update(self, value):
-		if value is None:
-			self._version_min_update = None
-			return
-		if not isinstance(value, tuple):
-			raise ValueError("Version minimum must be a tuple")
-		for subvalue in value:
-			if type(subvalue) != int:
-				raise ValueError("Version elements must be integers")
-		self._version_min_update = value
-
-	@property
-	def website(self):
-		return self._website
-
-	@website.setter
-	def website(self, value):
-		if not self.check_is_url(value):
-			raise ValueError("Not a valid URL: " + value)
-		self._website = value
-
-	# -------------------------------------------------------------------------
-	# Parameter validation related functions
-	# -------------------------------------------------------------------------
-	@staticmethod
-	def check_is_url(url):
-		if not ("http://" in url or "https://" in url):
-			return False
-		if "." not in url:
-			return False
-		return True
-
-	def _get_tag_names(self):
-		tag_names = list()
-		self.get_tags()
-		for tag in self._tags:
-			tag_names.append(tag["name"])
-		return tag_names
-
-	def set_check_interval(self, enabled=False,
-						   months=0, days=14, hours=0, minutes=0):
-		"""Set the time interval between automated checks, and if enabled.
-
-		Has enabled = False as default to not check against frequency,
-		if enabled, default is 2 weeks.
-		"""
-
-		if type(enabled) is not bool:
-			raise ValueError("Enable must be a boolean value")
-		if type(months) is not int:
-			raise ValueError("Months must be an integer value")
-		if type(days) is not int:
-			raise ValueError("Days must be an integer value")
-		if type(hours) is not int:
-			raise ValueError("Hours must be an integer value")
-		if type(minutes) is not int:
-			raise ValueError("Minutes must be an integer value")
-
-		if not enabled:
-			self._check_interval_enabled = False
-		else:
-			self._check_interval_enabled = True
-
-		self._check_interval_months = months
-		self._check_interval_days = days
-		self._check_interval_hours = hours
-		self._check_interval_minutes = minutes
-
-	def __repr__(self):
-		return "<Module updater from {a}>".format(a=__file__)
-
-	def __str__(self):
-		return "Updater, with user: {a}, repository: {b}, url: {c}".format(
-			a=self._user, b=self._repo, c=self.form_repo_url())
-
-	# -------------------------------------------------------------------------
-	# API-related functions
-	# -------------------------------------------------------------------------
-	def form_repo_url(self):
-		return self._engine.form_repo_url(self)
-
-	def form_tags_url(self):
-		return self._engine.form_tags_url(self)
-
-	def form_branch_url(self, branch):
-		return self._engine.form_branch_url(branch, self)
-
-	def get_tags(self):
-		request = self.form_tags_url()
-		self.print_verbose("Getting tags from server")
-
-		# get all tags, internet call
-		all_tags = self._engine.parse_tags(self.get_api(request), self)
-		if all_tags is not None:
-			self._prefiltered_tag_count = len(all_tags)
-		else:
-			self._prefiltered_tag_count = 0
-			all_tags = list()
-
-		# pre-process to skip tags
-		if self.skip_tag is not None:
-			self._tags = [tg for tg in all_tags if not self.skip_tag(self, tg)]
-		else:
-			self._tags = all_tags
-
-		# get additional branches too, if needed, and place in front
-		# Does NO checking here whether branch is valid
-		if self._include_branches:
-			temp_branches = self._include_branch_list.copy()
-			temp_branches.reverse()
-			for branch in temp_branches:
-				request = self.form_branch_url(branch)
-				include = {
-					"name": branch.title(),
-					"zipball_url": request
-				}
-				self._tags = [include] + self._tags  # append to front
-
-		if self._tags is None:
-			# some error occurred
-			self._tag_latest = None
-			self._tags = list()
-
-		elif self._prefiltered_tag_count == 0 and not self._include_branches:
-			self._tag_latest = None
-			if self._error is None:  # if not None, could have had no internet
-				self._error = "No releases found"
-				self._error_msg = "No releases or tags found in repository"
-			self.print_verbose("No releases or tags found in repository")
-
-		elif self._prefiltered_tag_count == 0 and self._include_branches:
-			if not self._error:
-				self._tag_latest = self._tags[0]
-			branch = self._include_branch_list[0]
-			self.print_verbose("{} branch found, no releases: {}".format(
-				branch, self._tags[0]))
-
-		elif ((len(self._tags) - len(self._include_branch_list) == 0
-				and self._include_branches)
-				or (len(self._tags) == 0 and not self._include_branches)
-				and self._prefiltered_tag_count > 0):
-			self._tag_latest = None
-			self._error = "No releases available"
-			self._error_msg = "No versions found within compatible version range"
-			self.print_verbose(self._error_msg)
-
-		else:
-			if not self._include_branches:
-				self._tag_latest = self._tags[0]
-				self.print_verbose(
-					"Most recent tag found:" + str(self._tags[0]['name']))
-			else:
-				# Don't return branch if in list.
-				n = len(self._include_branch_list)
-				self._tag_latest = self._tags[n]  # guaranteed at least len()=n+1
-				self.print_verbose(
-					"Most recent tag found:" + str(self._tags[n]['name']))
-
-	def get_raw(self, url):
-		"""All API calls to base url."""
-		request = urllib.request.Request(url)
-		try:
-			context = ssl._create_unverified_context()
-		except:
-			# Some blender packaged python versions don't have this, largely
-			# useful for local network setups otherwise minimal impact.
-			context = None
-
-		# Setup private request headers if appropriate.
-		if self._engine.token is not None:
-			if self._engine.name == "gitlab":
-				request.add_header('PRIVATE-TOKEN', self._engine.token)
-			else:
-				self.print_verbose("Tokens not setup for engine yet")
-
-		# Always set user agent.
-		request.add_header(
-			'User-Agent', "Python/" + str(platform.python_version()))
-
-		# Run the request.
-		try:
-			if context:
-				result = urllib.request.urlopen(request, context=context)
-			else:
-				result = urllib.request.urlopen(request)
-		except urllib.error.HTTPError as e:
-			if str(e.code) == "403":
-				self._error = "HTTP error (access denied)"
-				self._error_msg = str(e.code) + " - server error response"
-				print(self._error, self._error_msg)
-			else:
-				self._error = "HTTP error"
-				self._error_msg = str(e.code)
-				print(self._error, self._error_msg)
-			self.print_trace()
-			self._update_ready = None
-		except urllib.error.URLError as e:
-			reason = str(e.reason)
-			if "TLSV1_ALERT" in reason or "SSL" in reason.upper():
-				self._error = "Connection rejected, download manually"
-				self._error_msg = reason
-				print(self._error, self._error_msg)
-			else:
-				self._error = "URL error, check internet connection"
-				self._error_msg = reason
-				print(self._error, self._error_msg)
-			self.print_trace()
-			self._update_ready = None
-			return None
-		else:
-			result_string = result.read()
-			result.close()
-			return result_string.decode()
-
-	def get_api(self, url):
-		"""Result of all api calls, decoded into json format."""
-		get = None
-		get = self.get_raw(url)
-		if get is not None:
-			try:
-				return json.JSONDecoder().decode(get)
-			except Exception as e:
-				self._error = "API response has invalid JSON format"
-				self._error_msg = str(e.reason)
-				self._update_ready = None
-				print(self._error, self._error_msg)
-				self.print_trace()
-				return None
-		else:
-			return None
-
-	def stage_repository(self, url):
-		"""Create a working directory and download the new files"""
-
-		local = os.path.join(self._updater_path, "update_staging")
-		error = None
-
-		# Make/clear the staging folder, to ensure the folder is always clean.
-		self.print_verbose(
-			"Preparing staging folder for download:\n" + str(local))
-		if os.path.isdir(local):
-			try:
-				shutil.rmtree(local)
-				os.makedirs(local)
-			except:
-				error = "failed to remove existing staging directory"
-				self.print_trace()
-		else:
-			try:
-				os.makedirs(local)
-			except:
-				error = "failed to create staging directory"
-				self.print_trace()
-
-		if error is not None:
-			self.print_verbose("Error: Aborting update, " + error)
-			self._error = "Update aborted, staging path error"
-			self._error_msg = "Error: {}".format(error)
-			return False
-
-		if self._backup_current:
-			self.create_backup()
-
-		self.print_verbose("Now retrieving the new source zip")
-		self._source_zip = os.path.join(local, "source.zip")
-		self.print_verbose("Starting download update zip")
-		try:
-			request = urllib.request.Request(url)
-			context = ssl._create_unverified_context()
-
-			# Setup private token if appropriate.
-			if self._engine.token is not None:
-				if self._engine.name == "gitlab":
-					request.add_header('PRIVATE-TOKEN', self._engine.token)
-				else:
-					self.print_verbose(
-						"Tokens not setup for selected engine yet")
-
-			# Always set user agent
-			request.add_header(
-				'User-Agent', "Python/" + str(platform.python_version()))
-
-			self.url_retrieve(urllib.request.urlopen(request, context=context),
-							  self._source_zip)
-			# Add additional checks on file size being non-zero.
-			self.print_verbose("Successfully downloaded update zip")
-			return True
-		except Exception as e:
-			self._error = "Error retrieving download, bad link?"
-			self._error_msg = "Error: {}".format(e)
-			print("Error retrieving download, bad link?")
-			print("Error: {}".format(e))
-			self.print_trace()
-			return False
-
-	def create_backup(self):
-		"""Save a backup of the current installed addon prior to an update."""
-		self.print_verbose("Backing up current addon folder")
-		local = os.path.join(self._updater_path, "backup")
-		tempdest = os.path.join(
-			self._addon_root, os.pardir, self._addon + "_updater_backup_temp")
-
-		self.print_verbose("Backup destination path: " + str(local))
-
-		if os.path.isdir(local):
-			try:
-				shutil.rmtree(local)
-			except:
-				self.print_verbose(
-					"Failed to removed previous backup folder, continuing")
-				self.print_trace()
-
-		# Remove the temp folder.
-		# Shouldn't exist but could if previously interrupted.
-		if os.path.isdir(tempdest):
-			try:
-				shutil.rmtree(tempdest)
-			except:
-				self.print_verbose(
-					"Failed to remove existing temp folder, continuing")
-				self.print_trace()
-
-		# Make a full addon copy, temporarily placed outside the addon folder.
-		if self._backup_ignore_patterns is not None:
-			try:
-				shutil.copytree(self._addon_root, tempdest,
-								ignore=shutil.ignore_patterns(
-									*self._backup_ignore_patterns))
-			except:
-				print("Failed to create backup, still attempting update.")
-				self.print_trace()
-				return
-		else:
-			try:
-				shutil.copytree(self._addon_root, tempdest)
-			except:
-				print("Failed to create backup, still attempting update.")
-				self.print_trace()
-				return
-		shutil.move(tempdest, local)
-
-		# Save the date for future reference.
-		now = datetime.now()
-		self._json["backup_date"] = "{m}-{d}-{yr}".format(
-			m=now.strftime("%B"), d=now.day, yr=now.year)
-		self.save_updater_json()
-
-	def restore_backup(self):
-		"""Restore the last backed up addon version, user initiated only"""
-		self.print_verbose("Restoring backup, backing up current addon folder")
-		backuploc = os.path.join(self._updater_path, "backup")
-		tempdest = os.path.join(
-			self._addon_root, os.pardir, self._addon + "_updater_backup_temp")
-		tempdest = os.path.abspath(tempdest)
-
-		# Move instead contents back in place, instead of copy.
-		shutil.move(backuploc, tempdest)
-		shutil.rmtree(self._addon_root)
-		os.rename(tempdest, self._addon_root)
-
-		self._json["backup_date"] = ""
-		self._json["just_restored"] = True
-		self._json["just_updated"] = True
-		self.save_updater_json()
-
-		self.reload_addon()
-
-	def unpack_staged_zip(self, clean=False):
-		"""Unzip the downloaded file, and validate contents"""
-		if not os.path.isfile(self._source_zip):
-			self.print_verbose("Error, update zip not found")
-			self._error = "Install failed"
-			self._error_msg = "Downloaded zip not found"
-			return -1
-
-		# Clear the existing source folder in case previous files remain.
-		outdir = os.path.join(self._updater_path, "source")
-		try:
-			shutil.rmtree(outdir)
-			self.print_verbose("Source folder cleared")
-		except:
-			self.print_trace()
-
-		# Create parent directories if needed, would not be relevant unless
-		# installing addon into another location or via an addon manager.
-		try:
-			os.mkdir(outdir)
-		except Exception as err:
-			print("Error occurred while making extract dir:")
-			print(str(err))
-			self.print_trace()
-			self._error = "Install failed"
-			self._error_msg = "Failed to make extract directory"
-			return -1
-
-		if not os.path.isdir(outdir):
-			print("Failed to create source directory")
-			self._error = "Install failed"
-			self._error_msg = "Failed to create extract directory"
-			return -1
-
-		self.print_verbose(
-			"Begin extracting source from zip:" + str(self._source_zip))
-		with zipfile.ZipFile(self._source_zip, "r") as zfile:
-			if not zfile:
-				self._error = "Install failed"
-				self._error_msg = "Resulting file is not a zip, cannot extract"
-				self.print_verbose(self._error_msg)
-				return -1
-
-			# Now extract directly from the first subfolder (not root)
-			# this avoids adding the first subfolder to the path length,
-			# which can be too long if the download has the SHA in the name.
-			zsep = '/'  # Not using os.sep, always the / value even on windows.
-			for name in zfile.namelist():
-				if zsep not in name:
-					continue
-				top_folder = name[:name.index(zsep) + 1]
-				if name == top_folder + zsep:
-					continue  # skip top level folder
-				sub_path = name[name.index(zsep) + 1:]
-				if name.endswith(zsep):
-					try:
-						os.mkdir(os.path.join(outdir, sub_path))
-						self.print_verbose(
-							"Extract - mkdir: " + os.path.join(outdir, sub_path))
-					except OSError as exc:
-						if exc.errno != errno.EEXIST:
-							self._error = "Install failed"
-							self._error_msg = "Could not create folder from zip"
-							self.print_trace()
-							return -1
-				else:
-					with open(os.path.join(outdir, sub_path), "wb") as outfile:
-						data = zfile.read(name)
-						outfile.write(data)
-						self.print_verbose(
-							"Extract - create: " + os.path.join(outdir, sub_path))
-
-		self.print_verbose("Extracted source")
-
-		unpath = os.path.join(self._updater_path, "source")
-		if not os.path.isdir(unpath):
-			self._error = "Install failed"
-			self._error_msg = "Extracted path does not exist"
-			print("Extracted path does not exist: ", unpath)
-			return -1
-
-		if self._subfolder_path:
-			self._subfolder_path.replace('/', os.path.sep)
-			self._subfolder_path.replace('\\', os.path.sep)
-
-		# Either directly in root of zip/one subfolder, or use specified path.
-		if not os.path.isfile(os.path.join(unpath, "__init__.py")):
-			dirlist = os.listdir(unpath)
-			if len(dirlist) > 0:
-				if self._subfolder_path == "" or self._subfolder_path is None:
-					unpath = os.path.join(unpath, dirlist[0])
-				else:
-					unpath = os.path.join(unpath, self._subfolder_path)
-
-			# Smarter check for additional sub folders for a single folder
-			# containing the __init__.py file.
-			if not os.path.isfile(os.path.join(unpath, "__init__.py")):
-				print("Not a valid addon found")
-				print("Paths:")
-				print(dirlist)
-				self._error = "Install failed"
-				self._error_msg = "No __init__ file found in new source"
-				return -1
-
-		# Merge code with the addon directory, using blender default behavior,
-		# plus any modifiers indicated by user (e.g. force remove/keep).
-		self.deep_merge_directory(self._addon_root, unpath, clean)
-
-		# Now save the json state.
-		# Change to True to trigger the handler on other side if allowing
-		# reloading within same blender session.
-		self._json["just_updated"] = True
-		self.save_updater_json()
-		self.reload_addon()
-		self._update_ready = False
-		return 0
-
-	def deep_merge_directory(self, base, merger, clean=False):
-		"""Merge folder 'merger' into 'base' without deleting existing"""
-		if not os.path.exists(base):
-			self.print_verbose("Base path does not exist:" + str(base))
-			return -1
-		elif not os.path.exists(merger):
-			self.print_verbose("Merger path does not exist")
-			return -1
-
-		# Path to be aware of and not overwrite/remove/etc.
-		staging_path = os.path.join(self._updater_path, "update_staging")
-
-		# If clean install is enabled, clear existing files ahead of time
-		# note: will not delete the update.json, update folder, staging, or
-		# staging but will delete all other folders/files in addon directory.
-		error = None
-		if clean:
-			try:
-				# Implement clearing of all folders/files, except the updater
-				# folder and updater json.
-				# Careful, this deletes entire subdirectories recursively...
-				# Make sure that base is not a high level shared folder, but
-				# is dedicated just to the addon itself.
-				self.print_verbose(
-					"clean=True, clearing addon folder to fresh install state")
-
-				# Remove root files and folders (except update folder).
-				files = [f for f in os.listdir(base)
-						 if os.path.isfile(os.path.join(base, f))]
-				folders = [f for f in os.listdir(base)
-						   if os.path.isdir(os.path.join(base, f))]
-
-				for f in files:
-					os.remove(os.path.join(base, f))
-					self.print_verbose(
-						"Clean removing file {}".format(os.path.join(base, f)))
-				for f in folders:
-					if os.path.join(base, f) is self._updater_path:
-						continue
-					shutil.rmtree(os.path.join(base, f))
-					self.print_verbose(
-						"Clean removing folder and contents {}".format(
-							os.path.join(base, f)))
-
-			except Exception as err:
-				error = "failed to create clean existing addon folder"
-				print(error, str(err))
-				self.print_trace()
-
-		# Walk through the base addon folder for rules on pre-removing
-		# but avoid removing/altering backup and updater file.
-		for path, dirs, files in os.walk(base):
-			# Prune ie skip updater folder.
-			dirs[:] = [d for d in dirs
-					   if os.path.join(path, d) not in [self._updater_path]]
-			for file in files:
-				for pattern in self.remove_pre_update_patterns:
-					if fnmatch.filter([file], pattern):
-						try:
-							fl = os.path.join(path, file)
-							os.remove(fl)
-							self.print_verbose("Pre-removed file " + file)
-						except OSError:
-							print("Failed to pre-remove " + file)
-							self.print_trace()
-
-		# Walk through the temp addon sub folder for replacements
-		# this implements the overwrite rules, which apply after
-		# the above pre-removal rules. This also performs the
-		# actual file copying/replacements.
-		for path, dirs, files in os.walk(merger):
-			# Verify structure works to prune updater sub folder overwriting.
-			dirs[:] = [d for d in dirs
-					   if os.path.join(path, d) not in [self._updater_path]]
-			rel_path = os.path.relpath(path, merger)
-			dest_path = os.path.join(base, rel_path)
-			if not os.path.exists(dest_path):
-				os.makedirs(dest_path)
-			for file in files:
-				# Bring in additional logic around copying/replacing.
-				# Blender default: overwrite .py's, don't overwrite the rest.
-				dest_file = os.path.join(dest_path, file)
-				srcFile = os.path.join(path, file)
-
-				# Decide to replace if file already exists, and copy new over.
-				if os.path.isfile(dest_file):
-					# Otherwise, check each file for overwrite pattern match.
-					replaced = False
-					for pattern in self._overwrite_patterns:
-						if fnmatch.filter([file], pattern):
-							replaced = True
-							break
-					if replaced:
-						os.remove(dest_file)
-						os.rename(srcFile, dest_file)
-						self.print_verbose(
-							"Overwrote file " + os.path.basename(dest_file))
-					else:
-						self.print_verbose(
-							"Pattern not matched to {}, not overwritten".format(
-								os.path.basename(dest_file)))
-				else:
-					# File did not previously exist, simply move it over.
-					os.rename(srcFile, dest_file)
-					self.print_verbose(
-						"New file " + os.path.basename(dest_file))
-
-		# now remove the temp staging folder and downloaded zip
-		try:
-			shutil.rmtree(staging_path)
-		except:
-			error = ("Error: Failed to remove existing staging directory, "
-					 "consider manually removing ") + staging_path
-			self.print_verbose(error)
-			self.print_trace()
-
-	def reload_addon(self):
-		# if post_update false, skip this function
-		# else, unload/reload addon & trigger popup
-		if not self._auto_reload_post_update:
-			print("Restart blender to reload addon and complete update")
-			return
-
-		self.print_verbose("Reloading addon...")
-		addon_utils.modules(refresh=True)
-		bpy.utils.refresh_script_paths()
-
-		# not allowed in restricted context, such as register module
-		# toggle to refresh
-		if "addon_disable" in dir(bpy.ops.wm):  # 2.7
-			bpy.ops.wm.addon_disable(module=self._addon_package)
-			bpy.ops.wm.addon_refresh()
-			bpy.ops.wm.addon_enable(module=self._addon_package)
-			print("2.7 reload complete")
-		else:  # 2.8
-			bpy.ops.preferences.addon_disable(module=self._addon_package)
-			bpy.ops.preferences.addon_refresh()
-			bpy.ops.preferences.addon_enable(module=self._addon_package)
-			print("2.8 reload complete")
-
-	# -------------------------------------------------------------------------
-	# Other non-api functions and setups
-	# -------------------------------------------------------------------------
-	def clear_state(self):
-		self._update_ready = None
-		self._update_link = None
-		self._update_version = None
-		self._source_zip = None
-		self._error = None
-		self._error_msg = None
-
-	def url_retrieve(self, url_file, filepath):
-		"""Custom urlretrieve implementation"""
-		chunk = 1024 * 8
-		f = open(filepath, "wb")
-		while 1:
-			data = url_file.read(chunk)
-			if not data:
-				# print("done.")
-				break
-			f.write(data)
-			# print("Read %s bytes" % len(data))
-		f.close()
-
-	def version_tuple_from_text(self, text):
-		"""Convert text into a tuple of numbers (int).
-
-		Should go through string and remove all non-integers, and for any
-		given break split into a different section.
-		"""
-		if text is None:
-			return ()
-
-		segments = list()
-		tmp = ''
-		for char in str(text):
-			if not char.isdigit():
-				if len(tmp) > 0:
-					segments.append(int(tmp))
-					tmp = ''
-			else:
-				tmp += char
-		if len(tmp) > 0:
-			segments.append(int(tmp))
-
-		if len(segments) == 0:
-			self.print_verbose("No version strings found text: " + str(text))
-			if not self._include_branches:
-				return ()
-			else:
-				return (text)
-		return tuple(segments)
-
-	def check_for_update_async(self, callback=None):
-		"""Called for running check in a background thread"""
-		is_ready = (
-			self._json is not None
-			and "update_ready" in self._json
-			and self._json["version_text"] != dict()
-			and self._json["update_ready"])
-
-		if is_ready:
-			self._update_ready = True
-			self._update_link = self._json["version_text"]["link"]
-			self._update_version = str(self._json["version_text"]["version"])
-			# Cached update.
-			callback(True)
-			return
-
-		# do the check
-		if not self._check_interval_enabled:
-			return
-		elif self._async_checking:
-			self.print_verbose("Skipping async check, already started")
-			# already running the bg thread
-		elif self._update_ready is None:
-			print("{} updater: Running background check for update".format(
-				  self.addon))
-			self.start_async_check_update(False, callback)
-
-	def check_for_update_now(self, callback=None):
-		self._error = None
-		self._error_msg = None
-		self.print_verbose(
-			"Check update pressed, first getting current status")
-		if self._async_checking:
-			self.print_verbose("Skipping async check, already started")
-			return  # already running the bg thread
-		elif self._update_ready is None:
-			self.start_async_check_update(True, callback)
-		else:
-			self._update_ready = None
-			self.start_async_check_update(True, callback)
-
-	def check_for_update(self, now=False):
-		"""Check for update not in a syncrhonous manner.
-
-		This function is not async, will always return in sequential fashion
-		but should have a parent which calls it in another thread.
-		"""
-		self.print_verbose("Checking for update function")
-
-		# clear the errors if any
-		self._error = None
-		self._error_msg = None
-
-		# avoid running again in, just return past result if found
-		# but if force now check, then still do it
-		if self._update_ready is not None and not now:
-			return (self._update_ready,
-					self._update_version,
-					self._update_link)
-
-		if self._current_version is None:
-			raise ValueError("current_version not yet defined")
-
-		if self._repo is None:
-			raise ValueError("repo not yet defined")
-
-		if self._user is None:
-			raise ValueError("username not yet defined")
-
-		self.set_updater_json()  # self._json
-
-		if not now and not self.past_interval_timestamp():
-			self.print_verbose(
-				"Aborting check for updated, check interval not reached")
-			return (False, None, None)
-
-		# check if using tags or releases
-		# note that if called the first time, this will pull tags from online
-		if self._fake_install:
-			self.print_verbose(
-				"fake_install = True, setting fake version as ready")
-			self._update_ready = True
-			self._update_version = "(999,999,999)"
-			self._update_link = "http://127.0.0.1"
-
-			return (self._update_ready,
-					self._update_version,
-					self._update_link)
-
-		# Primary internet call, sets self._tags and self._tag_latest.
-		self.get_tags()
-
-		self._json["last_check"] = str(datetime.now())
-		self.save_updater_json()
-
-		# Can be () or ('master') in addition to branches, and version tag.
-		new_version = self.version_tuple_from_text(self.tag_latest)
-
-		if len(self._tags) == 0:
-			self._update_ready = False
-			self._update_version = None
-			self._update_link = None
-			return (False, None, None)
-
-		if not self._include_branches:
-			link = self.select_link(self, self._tags[0])
-		else:
-			n = len(self._include_branch_list)
-			if len(self._tags) == n:
-				# effectively means no tags found on repo
-				# so provide the first one as default
-				link = self.select_link(self, self._tags[0])
-			else:
-				link = self.select_link(self, self._tags[n])
-
-		if new_version == ():
-			self._update_ready = False
-			self._update_version = None
-			self._update_link = None
-			return (False, None, None)
-		elif str(new_version).lower() in self._include_branch_list:
-			# Handle situation where master/whichever branch is included
-			# however, this code effectively is not triggered now
-			# as new_version will only be tag names, not branch names.
-			if not self._include_branch_auto_check:
-				# Don't offer update as ready, but set the link for the
-				# default branch for installing.
-				self._update_ready = False
-				self._update_version = new_version
-				self._update_link = link
-				self.save_updater_json()
-				return (True, new_version, link)
-			else:
-				# Bypass releases and look at timestamp of last update from a
-				# branch compared to now, see if commit values match or not.
-				raise ValueError("include_branch_autocheck: NOT YET DEVELOPED")
-
-		else:
-			# Situation where branches not included.
-			if new_version > self._current_version:
-
-				self._update_ready = True
-				self._update_version = new_version
-				self._update_link = link
-				self.save_updater_json()
-				return (True, new_version, link)
-
-		# If no update, set ready to False from None to show it was checked.
-		self._update_ready = False
-		self._update_version = None
-		self._update_link = None
-		return (False, None, None)
-
-	def set_tag(self, name):
-		"""Assign the tag name and url to update to"""
-		tg = None
-		for tag in self._tags:
-			if name == tag["name"]:
-				tg = tag
-				break
-		if tg:
-			new_version = self.version_tuple_from_text(self.tag_latest)
-			self._update_version = new_version
-			self._update_link = self.select_link(self, tg)
-		elif self._include_branches and name in self._include_branch_list:
-			# scenario if reverting to a specific branch name instead of tag
-			tg = name
-			link = self.form_branch_url(tg)
-			self._update_version = name  # this will break things
-			self._update_link = link
-		if not tg:
-			raise ValueError("Version tag not found: " + name)
-
-	def run_update(self, force=False, revert_tag=None, clean=False, callback=None):
-		"""Runs an install, update, or reversion of an addon from online source
-
-		Arguments:
-			force: Install assigned link, even if self.update_ready is False
-			revert_tag: Version to install, if none uses detected update link
-			clean: not used, but in future could use to totally refresh addon
-			callback: used to run function on update completion
-		"""
-		self._json["update_ready"] = False
-		self._json["ignore"] = False  # clear ignore flag
-		self._json["version_text"] = dict()
-
-		if revert_tag is not None:
-			self.set_tag(revert_tag)
-			self._update_ready = True
-
-		# clear the errors if any
-		self._error = None
-		self._error_msg = None
-
-		self.print_verbose("Running update")
-
-		if self._fake_install:
-			# Change to True, to trigger the reload/"update installed" handler.
-			self.print_verbose("fake_install=True")
-			self.print_verbose(
-				"Just reloading and running any handler triggers")
-			self._json["just_updated"] = True
-			self.save_updater_json()
-			if self._backup_current is True:
-				self.create_backup()
-			self.reload_addon()
-			self._update_ready = False
-			res = True  # fake "success" zip download flag
-
-		elif not force:
-			if not self._update_ready:
-				self.print_verbose("Update stopped, new version not ready")
-				if callback:
-					callback(
-						self._addon_package,
-						"Update stopped, new version not ready")
-				return "Update stopped, new version not ready"
-			elif self._update_link is None:
-				# this shouldn't happen if update is ready
-				self.print_verbose("Update stopped, update link unavailable")
-				if callback:
-					callback(self._addon_package,
-							 "Update stopped, update link unavailable")
-				return "Update stopped, update link unavailable"
-
-			if revert_tag is None:
-				self.print_verbose("Staging update")
-			else:
-				self.print_verbose("Staging install")
-
-			res = self.stage_repository(self._update_link)
-			if not res:
-				print("Error in staging repository: " + str(res))
-				if callback is not None:
-					callback(self._addon_package, self._error_msg)
-				return self._error_msg
-			res = self.unpack_staged_zip(clean)
-			if res < 0:
-				if callback:
-					callback(self._addon_package, self._error_msg)
-				return res
-
-		else:
-			if self._update_link is None:
-				self.print_verbose("Update stopped, could not get link")
-				return "Update stopped, could not get link"
-			self.print_verbose("Forcing update")
-
-			res = self.stage_repository(self._update_link)
-			if not res:
-				print("Error in staging repository: " + str(res))
-				if callback:
-					callback(self._addon_package, self._error_msg)
-				return self._error_msg
-			res = self.unpack_staged_zip(clean)
-			if res < 0:
-				return res
-			# would need to compare against other versions held in tags
-
-		# run the front-end's callback if provided
-		if callback:
-			callback(self._addon_package)
-
-		# return something meaningful, 0 means it worked
-		return 0
-
-	def past_interval_timestamp(self):
-		if not self._check_interval_enabled:
-			return True  # ie this exact feature is disabled
-
-		if "last_check" not in self._json or self._json["last_check"] == "":
-			return True
-
-		now = datetime.now()
-		last_check = datetime.strptime(
-			self._json["last_check"], "%Y-%m-%d %H:%M:%S.%f")
-		offset = timedelta(
-			days=self._check_interval_days + 30 * self._check_interval_months,
-			hours=self._check_interval_hours,
-			minutes=self._check_interval_minutes)
-
-		delta = (now - offset) - last_check
-		if delta.total_seconds() > 0:
-			self.print_verbose("Time to check for updates!")
-			return True
-
-		self.print_verbose("Determined it's not yet time to check for updates")
-		return False
-
-	def get_json_path(self):
-		"""Returns the full path to the JSON state file used by this updater.
-
-		Will also rename old file paths to addon-specific path if found.
-		"""
-		json_path = os.path.join(
-			self._updater_path,
-			"{}_updater_status.json".format(self._addon_package))
-		old_json_path = os.path.join(self._updater_path, "updater_status.json")
-
-		# Rename old file if it exists.
-		try:
-			os.rename(old_json_path, json_path)
-		except FileNotFoundError:
-			pass
-		except Exception as err:
-			print("Other OS error occurred while trying to rename old JSON")
-			print(err)
-			self.print_trace()
-		return json_path
-
-	def set_updater_json(self):
-		"""Load or initialize JSON dictionary data for updater state"""
-		if self._updater_path is None:
-			raise ValueError("updater_path is not defined")
-		elif not os.path.isdir(self._updater_path):
-			os.makedirs(self._updater_path)
-
-		jpath = self.get_json_path()
-		if os.path.isfile(jpath):
-			with open(jpath) as data_file:
-				self._json = json.load(data_file)
-				self.print_verbose("Read in JSON settings from file")
-		else:
-			self._json = {
-				"last_check": "",
-				"backup_date": "",
-				"update_ready": False,
-				"ignore": False,
-				"just_restored": False,
-				"just_updated": False,
-				"version_text": dict()
-			}
-			self.save_updater_json()
-
-	def save_updater_json(self):
-		"""Trigger save of current json structure into file within addon"""
-		if self._update_ready:
-			if isinstance(self._update_version, tuple):
-				self._json["update_ready"] = True
-				self._json["version_text"]["link"] = self._update_link
-				self._json["version_text"]["version"] = self._update_version
-			else:
-				self._json["update_ready"] = False
-				self._json["version_text"] = dict()
-		else:
-			self._json["update_ready"] = False
-			self._json["version_text"] = dict()
-
-		jpath = self.get_json_path()
-		if not os.path.isdir(os.path.dirname(jpath)):
-			print("State error: Directory does not exist, cannot save json: ",
-				  os.path.basename(jpath))
-			return
-		try:
-			with open(jpath, 'w') as outf:
-				data_out = json.dumps(self._json, indent=4)
-				outf.write(data_out)
-		except:
-			print("Failed to open/save data to json: ", jpath)
-			self.print_trace()
-		self.print_verbose("Wrote out updater JSON settings with content:")
-		self.print_verbose(str(self._json))
-
-	def json_reset_postupdate(self):
-		self._json["just_updated"] = False
-		self._json["update_ready"] = False
-		self._json["version_text"] = dict()
-		self.save_updater_json()
-
-	def json_reset_restore(self):
-		self._json["just_restored"] = False
-		self._json["update_ready"] = False
-		self._json["version_text"] = dict()
-		self.save_updater_json()
-		self._update_ready = None  # Reset so you could check update again.
-
-	def ignore_update(self):
-		self._json["ignore"] = True
-		self.save_updater_json()
-
-	# -------------------------------------------------------------------------
-	# ASYNC related methods
-	# -------------------------------------------------------------------------
-	def start_async_check_update(self, now=False, callback=None):
-		"""Start a background thread which will check for updates"""
-		if self._async_checking:
-			return
-		self.print_verbose("Starting background checking thread")
-		check_thread = threading.Thread(target=self.async_check_update,
-										args=(now, callback,))
-		check_thread.daemon = True
-		self._check_thread = check_thread
-		check_thread.start()
-
-	def async_check_update(self, now, callback=None):
-		"""Perform update check, run as target of background thread"""
-		self._async_checking = True
-		self.print_verbose("Checking for update now in background")
-
-		try:
-			self.check_for_update(now=now)
-		except Exception as exception:
-			print("Checking for update error:")
-			print(exception)
-			self.print_trace()
-			if not self._error:
-				self._update_ready = False
-				self._update_version = None
-				self._update_link = None
-				self._error = "Error occurred"
-				self._error_msg = "Encountered an error while checking for updates"
-
-		self._async_checking = False
-		self._check_thread = None
-
-		if callback:
-			self.print_verbose("Finished check update, doing callback")
-			callback(self._update_ready)
-		self.print_verbose("BG thread: Finished check update, no callback")
-
-	def stop_async_check_update(self):
-		"""Method to give impression of stopping check for update.
-
-		Currently does nothing but allows user to retry/stop blocking UI from
-		hitting a refresh button. This does not actually stop the thread, as it
-		will complete after the connection timeout regardless. If the thread
-		does complete with a successful response, this will be still displayed
-		on next UI refresh (ie no update, or update available).
-		"""
-		if self._check_thread is not None:
-			self.print_verbose("Thread will end in normal course.")
-			# however, "There is no direct kill method on a thread object."
-			# better to let it run its course
-			# self._check_thread.stop()
-		self._async_checking = False
-		self._error = None
-		self._error_msg = None
+    """Addon updater service class.
+
+    This is the singleton class to instance once and then reference where
+    needed throughout the addon. It implements all the interfaces for running
+    updates.
+    """
+
+    def __init__(self):
+        self._engine = GithubEngine()
+        self._user = None
+        self._repo = None
+        self._website = None
+        self._current_version = None
+        self._subfolder_path = None
+        self._tags = list()
+        self._tag_latest = None
+        self._tag_names = list()
+        self._latest_release = None
+        self._use_releases = False
+        self._include_branches = False
+        self._include_branch_list = ["master"]
+        self._include_branch_auto_check = False
+        self._manual_only = False
+        self._version_min_update = None
+        self._version_max_update = None
+
+        # By default, backup current addon on update/target install.
+        self._backup_current = True
+        self._backup_ignore_patterns = None
+
+        # Set patterns the files to overwrite during an update.
+        self._overwrite_patterns = ["*.py", "*.pyc"]
+        self._remove_pre_update_patterns = list()
+
+        # By default, don't auto disable+re-enable the addon after an update,
+        # as this is less stable/often won't fully reload all modules anyways.
+        self._auto_reload_post_update = False
+
+        # Settings for the frequency of automated background checks.
+        self._check_interval_enabled = False
+        self._check_interval_months = 0
+        self._check_interval_days = 7
+        self._check_interval_hours = 0
+        self._check_interval_minutes = 0
+
+        # runtime variables, initial conditions
+        self._verbose = False
+        self._use_print_traces = True
+        self._fake_install = False
+        self._async_checking = False  # only true when async daemon started
+        self._update_ready = None
+        self._update_link = None
+        self._update_version = None
+        self._source_zip = None
+        self._check_thread = None
+        self._select_link = None
+        self.skip_tag = None
+
+        # Get data from the running blender module (addon).
+        self._addon = __package__.lower()
+        self._addon_package = __package__  # Must not change.
+        self._updater_path = os.path.join(
+            os.path.dirname(__file__), self._addon + "_updater"
+        )
+        self._addon_root = os.path.dirname(__file__)
+        self._json = dict()
+        self._error = None
+        self._error_msg = None
+        self._prefiltered_tag_count = 0
+
+        # UI properties, not used within this module but still useful to have.
+
+        # to verify a valid import, in place of placeholder import
+        self.show_popups = True  # UI uses to show popups or not.
+        self.invalid_updater = False
+
+        # pre-assign basic select-link function
+        def select_link_function(self, tag):
+            return tag["zipball_url"]
+
+        self._select_link = select_link_function
+
+    def print_trace(self):
+        """Print handled exception details when use_print_traces is set"""
+        if self._use_print_traces:
+            traceback.print_exc()
+
+    def print_verbose(self, msg):
+        """Print out a verbose logging message if verbose is true."""
+        if not self._verbose:
+            return
+        print("{} addon: ".format(self.addon) + msg)
+
+    # -------------------------------------------------------------------------
+    # Getters and setters
+    # -------------------------------------------------------------------------
+    @property
+    def addon(self):
+        return self._addon
+
+    @addon.setter
+    def addon(self, value):
+        self._addon = str(value)
+
+    @property
+    def api_url(self):
+        return self._engine.api_url
+
+    @api_url.setter
+    def api_url(self, value):
+        if not self.check_is_url(value):
+            raise ValueError("Not a valid URL: " + value)
+        self._engine.api_url = value
+
+    @property
+    def async_checking(self):
+        return self._async_checking
+
+    @property
+    def auto_reload_post_update(self):
+        return self._auto_reload_post_update
+
+    @auto_reload_post_update.setter
+    def auto_reload_post_update(self, value):
+        try:
+            self._auto_reload_post_update = bool(value)
+        except:
+            raise ValueError("auto_reload_post_update must be a boolean value")
+
+    @property
+    def backup_current(self):
+        return self._backup_current
+
+    @backup_current.setter
+    def backup_current(self, value):
+        if value is None:
+            self._backup_current = False
+        else:
+            self._backup_current = value
+
+    @property
+    def backup_ignore_patterns(self):
+        return self._backup_ignore_patterns
+
+    @backup_ignore_patterns.setter
+    def backup_ignore_patterns(self, value):
+        if value is None:
+            self._backup_ignore_patterns = None
+        elif not isinstance(value, list):
+            raise ValueError("Backup pattern must be in list format")
+        else:
+            self._backup_ignore_patterns = value
+
+    @property
+    def check_interval(self):
+        return (
+            self._check_interval_enabled,
+            self._check_interval_months,
+            self._check_interval_days,
+            self._check_interval_hours,
+            self._check_interval_minutes,
+        )
+
+    @property
+    def current_version(self):
+        return self._current_version
+
+    @current_version.setter
+    def current_version(self, tuple_values):
+        if tuple_values is None:
+            self._current_version = None
+            return
+        elif type(tuple_values) is not tuple:
+            try:
+                tuple(tuple_values)
+            except:
+                raise ValueError("current_version must be a tuple of integers")
+        for i in tuple_values:
+            if type(i) is not int:
+                raise ValueError("current_version must be a tuple of integers")
+        self._current_version = tuple(tuple_values)
+
+    @property
+    def engine(self):
+        return self._engine.name
+
+    @engine.setter
+    def engine(self, value):
+        engine = value.lower()
+        if engine == "github":
+            self._engine = GithubEngine()
+        elif engine == "gitlab":
+            self._engine = GitlabEngine()
+        elif engine == "bitbucket":
+            self._engine = BitbucketEngine()
+        else:
+            raise ValueError("Invalid engine selection")
+
+    @property
+    def error(self):
+        return self._error
+
+    @property
+    def error_msg(self):
+        return self._error_msg
+
+    @property
+    def fake_install(self):
+        return self._fake_install
+
+    @fake_install.setter
+    def fake_install(self, value):
+        if not isinstance(value, bool):
+            raise ValueError("fake_install must be a boolean value")
+        self._fake_install = bool(value)
+
+    # not currently used
+    @property
+    def include_branch_auto_check(self):
+        return self._include_branch_auto_check
+
+    @include_branch_auto_check.setter
+    def include_branch_auto_check(self, value):
+        try:
+            self._include_branch_auto_check = bool(value)
+        except:
+            raise ValueError("include_branch_autocheck must be a boolean")
+
+    @property
+    def include_branch_list(self):
+        return self._include_branch_list
+
+    @include_branch_list.setter
+    def include_branch_list(self, value):
+        try:
+            if value is None:
+                self._include_branch_list = ["master"]
+            elif not isinstance(value, list) or len(value) == 0:
+                raise ValueError(
+                    "include_branch_list should be a list of valid branches"
+                )
+            else:
+                self._include_branch_list = value
+        except:
+            raise ValueError("include_branch_list should be a list of valid branches")
+
+    @property
+    def include_branches(self):
+        return self._include_branches
+
+    @include_branches.setter
+    def include_branches(self, value):
+        try:
+            self._include_branches = bool(value)
+        except:
+            raise ValueError("include_branches must be a boolean value")
+
+    @property
+    def json(self):
+        if len(self._json) == 0:
+            self.set_updater_json()
+        return self._json
+
+    @property
+    def latest_release(self):
+        if self._latest_release is None:
+            return None
+        return self._latest_release
+
+    @property
+    def manual_only(self):
+        return self._manual_only
+
+    @manual_only.setter
+    def manual_only(self, value):
+        try:
+            self._manual_only = bool(value)
+        except:
+            raise ValueError("manual_only must be a boolean value")
+
+    @property
+    def overwrite_patterns(self):
+        return self._overwrite_patterns
+
+    @overwrite_patterns.setter
+    def overwrite_patterns(self, value):
+        if value is None:
+            self._overwrite_patterns = ["*.py", "*.pyc"]
+        elif not isinstance(value, list):
+            raise ValueError("overwrite_patterns needs to be in a list format")
+        else:
+            self._overwrite_patterns = value
+
+    @property
+    def private_token(self):
+        return self._engine.token
+
+    @private_token.setter
+    def private_token(self, value):
+        if value is None:
+            self._engine.token = None
+        else:
+            self._engine.token = str(value)
+
+    @property
+    def remove_pre_update_patterns(self):
+        return self._remove_pre_update_patterns
+
+    @remove_pre_update_patterns.setter
+    def remove_pre_update_patterns(self, value):
+        if value is None:
+            self._remove_pre_update_patterns = list()
+        elif not isinstance(value, list):
+            raise ValueError("remove_pre_update_patterns needs to be in a list format")
+        else:
+            self._remove_pre_update_patterns = value
+
+    @property
+    def repo(self):
+        return self._repo
+
+    @repo.setter
+    def repo(self, value):
+        try:
+            self._repo = str(value)
+        except:
+            raise ValueError("repo must be a string value")
+
+    @property
+    def select_link(self):
+        return self._select_link
+
+    @select_link.setter
+    def select_link(self, value):
+        # ensure it is a function assignment, with signature:
+        # input self, tag; returns link name
+        if not hasattr(value, "__call__"):
+            raise ValueError("select_link must be a function")
+        self._select_link = value
+
+    @property
+    def stage_path(self):
+        return self._updater_path
+
+    @stage_path.setter
+    def stage_path(self, value):
+        if value is None:
+            self.print_verbose("Aborting assigning stage_path, it's null")
+            return
+        elif value is not None and not os.path.exists(value):
+            try:
+                os.makedirs(value)
+            except:
+                self.print_verbose("Error trying to staging path")
+                self.print_trace()
+                return
+        self._updater_path = value
+
+    @property
+    def subfolder_path(self):
+        return self._subfolder_path
+
+    @subfolder_path.setter
+    def subfolder_path(self, value):
+        self._subfolder_path = value
+
+    @property
+    def tags(self):
+        if len(self._tags) == 0:
+            return list()
+        tag_names = list()
+        for tag in self._tags:
+            tag_names.append(tag["name"])
+        return tag_names
+
+    @property
+    def tag_latest(self):
+        if self._tag_latest is None:
+            return None
+        return self._tag_latest["name"]
+
+    @property
+    def update_link(self):
+        return self._update_link
+
+    @property
+    def update_ready(self):
+        return self._update_ready
+
+    @property
+    def update_version(self):
+        return self._update_version
+
+    @property
+    def use_releases(self):
+        return self._use_releases
+
+    @use_releases.setter
+    def use_releases(self, value):
+        try:
+            self._use_releases = bool(value)
+        except:
+            raise ValueError("use_releases must be a boolean value")
+
+    @property
+    def user(self):
+        return self._user
+
+    @user.setter
+    def user(self, value):
+        try:
+            self._user = str(value)
+        except:
+            raise ValueError("User must be a string value")
+
+    @property
+    def verbose(self):
+        return self._verbose
+
+    @verbose.setter
+    def verbose(self, value):
+        try:
+            self._verbose = bool(value)
+            self.print_verbose("Verbose is enabled")
+        except:
+            raise ValueError("Verbose must be a boolean value")
+
+    @property
+    def use_print_traces(self):
+        return self._use_print_traces
+
+    @use_print_traces.setter
+    def use_print_traces(self, value):
+        try:
+            self._use_print_traces = bool(value)
+        except:
+            raise ValueError("use_print_traces must be a boolean value")
+
+    @property
+    def version_max_update(self):
+        return self._version_max_update
+
+    @version_max_update.setter
+    def version_max_update(self, value):
+        if value is None:
+            self._version_max_update = None
+            return
+        if not isinstance(value, tuple):
+            raise ValueError("Version maximum must be a tuple")
+        for subvalue in value:
+            if type(subvalue) is not int:
+                raise ValueError("Version elements must be integers")
+        self._version_max_update = value
+
+    @property
+    def version_min_update(self):
+        return self._version_min_update
+
+    @version_min_update.setter
+    def version_min_update(self, value):
+        if value is None:
+            self._version_min_update = None
+            return
+        if not isinstance(value, tuple):
+            raise ValueError("Version minimum must be a tuple")
+        for subvalue in value:
+            if type(subvalue) != int:
+                raise ValueError("Version elements must be integers")
+        self._version_min_update = value
+
+    @property
+    def website(self):
+        return self._website
+
+    @website.setter
+    def website(self, value):
+        if not self.check_is_url(value):
+            raise ValueError("Not a valid URL: " + value)
+        self._website = value
+
+    # -------------------------------------------------------------------------
+    # Parameter validation related functions
+    # -------------------------------------------------------------------------
+    @staticmethod
+    def check_is_url(url):
+        if not ("http://" in url or "https://" in url):
+            return False
+        if "." not in url:
+            return False
+        return True
+
+    def _get_tag_names(self):
+        tag_names = list()
+        self.get_tags()
+        for tag in self._tags:
+            tag_names.append(tag["name"])
+        return tag_names
+
+    def set_check_interval(self, enabled=False, months=0, days=14, hours=0, minutes=0):
+        """Set the time interval between automated checks, and if enabled.
+
+        Has enabled = False as default to not check against frequency,
+        if enabled, default is 2 weeks.
+        """
+
+        if type(enabled) is not bool:
+            raise ValueError("Enable must be a boolean value")
+        if type(months) is not int:
+            raise ValueError("Months must be an integer value")
+        if type(days) is not int:
+            raise ValueError("Days must be an integer value")
+        if type(hours) is not int:
+            raise ValueError("Hours must be an integer value")
+        if type(minutes) is not int:
+            raise ValueError("Minutes must be an integer value")
+
+        if not enabled:
+            self._check_interval_enabled = False
+        else:
+            self._check_interval_enabled = True
+
+        self._check_interval_months = months
+        self._check_interval_days = days
+        self._check_interval_hours = hours
+        self._check_interval_minutes = minutes
+
+    def __repr__(self):
+        return "<Module updater from {a}>".format(a=__file__)
+
+    def __str__(self):
+        return "Updater, with user: {a}, repository: {b}, url: {c}".format(
+            a=self._user, b=self._repo, c=self.form_repo_url()
+        )
+
+    # -------------------------------------------------------------------------
+    # API-related functions
+    # -------------------------------------------------------------------------
+    def form_repo_url(self):
+        return self._engine.form_repo_url(self)
+
+    def form_tags_url(self):
+        return self._engine.form_tags_url(self)
+
+    def form_branch_url(self, branch):
+        return self._engine.form_branch_url(branch, self)
+
+    def get_tags(self):
+        request = self.form_tags_url()
+        self.print_verbose("Getting tags from server")
+
+        # get all tags, internet call
+        all_tags = self._engine.parse_tags(self.get_api(request), self)
+        if all_tags is not None:
+            self._prefiltered_tag_count = len(all_tags)
+        else:
+            self._prefiltered_tag_count = 0
+            all_tags = list()
+
+        # pre-process to skip tags
+        if self.skip_tag is not None:
+            self._tags = [tg for tg in all_tags if not self.skip_tag(self, tg)]
+        else:
+            self._tags = all_tags
+
+        # get additional branches too, if needed, and place in front
+        # Does NO checking here whether branch is valid
+        if self._include_branches:
+            temp_branches = self._include_branch_list.copy()
+            temp_branches.reverse()
+            for branch in temp_branches:
+                request = self.form_branch_url(branch)
+                include = {"name": branch.title(), "zipball_url": request}
+                self._tags = [include] + self._tags  # append to front
+
+        if self._tags is None:
+            # some error occurred
+            self._tag_latest = None
+            self._tags = list()
+
+        elif self._prefiltered_tag_count == 0 and not self._include_branches:
+            self._tag_latest = None
+            if self._error is None:  # if not None, could have had no internet
+                self._error = "No releases found"
+                self._error_msg = "No releases or tags found in repository"
+            self.print_verbose("No releases or tags found in repository")
+
+        elif self._prefiltered_tag_count == 0 and self._include_branches:
+            if not self._error:
+                self._tag_latest = self._tags[0]
+            branch = self._include_branch_list[0]
+            self.print_verbose(
+                "{} branch found, no releases: {}".format(branch, self._tags[0])
+            )
+
+        elif (
+            (
+                len(self._tags) - len(self._include_branch_list) == 0
+                and self._include_branches
+            )
+            or (len(self._tags) == 0 and not self._include_branches)
+            and self._prefiltered_tag_count > 0
+        ):
+            self._tag_latest = None
+            self._error = "No releases available"
+            self._error_msg = "No versions found within compatible version range"
+            self.print_verbose(self._error_msg)
+
+        else:
+            if not self._include_branches:
+                self._tag_latest = self._tags[0]
+                self.print_verbose(
+                    "Most recent tag found:" + str(self._tags[0]["name"])
+                )
+            else:
+                # Don't return branch if in list.
+                n = len(self._include_branch_list)
+                self._tag_latest = self._tags[n]  # guaranteed at least len()=n+1
+                self.print_verbose(
+                    "Most recent tag found:" + str(self._tags[n]["name"])
+                )
+
+    def get_raw(self, url):
+        """All API calls to base url."""
+        request = urllib.request.Request(url)
+        try:
+            context = ssl._create_unverified_context()
+        except:
+            # Some blender packaged python versions don't have this, largely
+            # useful for local network setups otherwise minimal impact.
+            context = None
+
+        # Setup private request headers if appropriate.
+        if self._engine.token is not None:
+            if self._engine.name == "gitlab":
+                request.add_header("PRIVATE-TOKEN", self._engine.token)
+            else:
+                self.print_verbose("Tokens not setup for engine yet")
+
+        # Always set user agent.
+        request.add_header("User-Agent", "Python/" + str(platform.python_version()))
+
+        # Run the request.
+        try:
+            if context:
+                result = urllib.request.urlopen(request, context=context)
+            else:
+                result = urllib.request.urlopen(request)
+        except urllib.error.HTTPError as e:
+            if str(e.code) == "403":
+                self._error = "HTTP error (access denied)"
+                self._error_msg = str(e.code) + " - server error response"
+                print(self._error, self._error_msg)
+            else:
+                self._error = "HTTP error"
+                self._error_msg = str(e.code)
+                print(self._error, self._error_msg)
+            self.print_trace()
+            self._update_ready = None
+        except urllib.error.URLError as e:
+            reason = str(e.reason)
+            if "TLSV1_ALERT" in reason or "SSL" in reason.upper():
+                self._error = "Connection rejected, download manually"
+                self._error_msg = reason
+                print(self._error, self._error_msg)
+            else:
+                self._error = "URL error, check internet connection"
+                self._error_msg = reason
+                print(self._error, self._error_msg)
+            self.print_trace()
+            self._update_ready = None
+            return None
+        else:
+            result_string = result.read()
+            result.close()
+            return result_string.decode()
+
+    def get_api(self, url):
+        """Result of all api calls, decoded into json format."""
+        get = None
+        get = self.get_raw(url)
+        if get is not None:
+            try:
+                return json.JSONDecoder().decode(get)
+            except Exception as e:
+                self._error = "API response has invalid JSON format"
+                self._error_msg = str(e.reason)
+                self._update_ready = None
+                print(self._error, self._error_msg)
+                self.print_trace()
+                return None
+        else:
+            return None
+
+    def stage_repository(self, url):
+        """Create a working directory and download the new files"""
+
+        local = os.path.join(self._updater_path, "update_staging")
+        error = None
+
+        # Make/clear the staging folder, to ensure the folder is always clean.
+        self.print_verbose("Preparing staging folder for download:\n" + str(local))
+        if os.path.isdir(local):
+            try:
+                shutil.rmtree(local)
+                os.makedirs(local)
+            except:
+                error = "failed to remove existing staging directory"
+                self.print_trace()
+        else:
+            try:
+                os.makedirs(local)
+            except:
+                error = "failed to create staging directory"
+                self.print_trace()
+
+        if error is not None:
+            self.print_verbose("Error: Aborting update, " + error)
+            self._error = "Update aborted, staging path error"
+            self._error_msg = "Error: {}".format(error)
+            return False
+
+        if self._backup_current:
+            self.create_backup()
+
+        self.print_verbose("Now retrieving the new source zip")
+        self._source_zip = os.path.join(local, "source.zip")
+        self.print_verbose("Starting download update zip")
+        try:
+            request = urllib.request.Request(url)
+            context = ssl._create_unverified_context()
+
+            # Setup private token if appropriate.
+            if self._engine.token is not None:
+                if self._engine.name == "gitlab":
+                    request.add_header("PRIVATE-TOKEN", self._engine.token)
+                else:
+                    self.print_verbose("Tokens not setup for selected engine yet")
+
+            # Always set user agent
+            request.add_header("User-Agent", "Python/" + str(platform.python_version()))
+
+            self.url_retrieve(
+                urllib.request.urlopen(request, context=context), self._source_zip
+            )
+            # Add additional checks on file size being non-zero.
+            self.print_verbose("Successfully downloaded update zip")
+            return True
+        except Exception as e:
+            self._error = "Error retrieving download, bad link?"
+            self._error_msg = "Error: {}".format(e)
+            print("Error retrieving download, bad link?")
+            print("Error: {}".format(e))
+            self.print_trace()
+            return False
+
+    def create_backup(self):
+        """Save a backup of the current installed addon prior to an update."""
+        self.print_verbose("Backing up current addon folder")
+        local = os.path.join(self._updater_path, "backup")
+        tempdest = os.path.join(
+            self._addon_root, os.pardir, self._addon + "_updater_backup_temp"
+        )
+
+        self.print_verbose("Backup destination path: " + str(local))
+
+        if os.path.isdir(local):
+            try:
+                shutil.rmtree(local)
+            except:
+                self.print_verbose(
+                    "Failed to removed previous backup folder, continuing"
+                )
+                self.print_trace()
+
+        # Remove the temp folder.
+        # Shouldn't exist but could if previously interrupted.
+        if os.path.isdir(tempdest):
+            try:
+                shutil.rmtree(tempdest)
+            except:
+                self.print_verbose("Failed to remove existing temp folder, continuing")
+                self.print_trace()
+
+        # Make a full addon copy, temporarily placed outside the addon folder.
+        if self._backup_ignore_patterns is not None:
+            try:
+                shutil.copytree(
+                    self._addon_root,
+                    tempdest,
+                    ignore=shutil.ignore_patterns(*self._backup_ignore_patterns),
+                )
+            except:
+                print("Failed to create backup, still attempting update.")
+                self.print_trace()
+                return
+        else:
+            try:
+                shutil.copytree(self._addon_root, tempdest)
+            except:
+                print("Failed to create backup, still attempting update.")
+                self.print_trace()
+                return
+        shutil.move(tempdest, local)
+
+        # Save the date for future reference.
+        now = datetime.now()
+        self._json["backup_date"] = "{m}-{d}-{yr}".format(
+            m=now.strftime("%B"), d=now.day, yr=now.year
+        )
+        self.save_updater_json()
+
+    def restore_backup(self):
+        """Restore the last backed up addon version, user initiated only"""
+        self.print_verbose("Restoring backup, backing up current addon folder")
+        backuploc = os.path.join(self._updater_path, "backup")
+        tempdest = os.path.join(
+            self._addon_root, os.pardir, self._addon + "_updater_backup_temp"
+        )
+        tempdest = os.path.abspath(tempdest)
+
+        # Move instead contents back in place, instead of copy.
+        shutil.move(backuploc, tempdest)
+        shutil.rmtree(self._addon_root)
+        os.rename(tempdest, self._addon_root)
+
+        self._json["backup_date"] = ""
+        self._json["just_restored"] = True
+        self._json["just_updated"] = True
+        self.save_updater_json()
+
+        self.reload_addon()
+
+    def unpack_staged_zip(self, clean=False):
+        """Unzip the downloaded file, and validate contents"""
+        if not os.path.isfile(self._source_zip):
+            self.print_verbose("Error, update zip not found")
+            self._error = "Install failed"
+            self._error_msg = "Downloaded zip not found"
+            return -1
+
+        # Clear the existing source folder in case previous files remain.
+        outdir = os.path.join(self._updater_path, "source")
+        try:
+            shutil.rmtree(outdir)
+            self.print_verbose("Source folder cleared")
+        except:
+            self.print_trace()
+
+        # Create parent directories if needed, would not be relevant unless
+        # installing addon into another location or via an addon manager.
+        try:
+            os.mkdir(outdir)
+        except Exception as err:
+            print("Error occurred while making extract dir:")
+            print(str(err))
+            self.print_trace()
+            self._error = "Install failed"
+            self._error_msg = "Failed to make extract directory"
+            return -1
+
+        if not os.path.isdir(outdir):
+            print("Failed to create source directory")
+            self._error = "Install failed"
+            self._error_msg = "Failed to create extract directory"
+            return -1
+
+        self.print_verbose("Begin extracting source from zip:" + str(self._source_zip))
+        with zipfile.ZipFile(self._source_zip, "r") as zfile:
+            if not zfile:
+                self._error = "Install failed"
+                self._error_msg = "Resulting file is not a zip, cannot extract"
+                self.print_verbose(self._error_msg)
+                return -1
+
+            # Now extract directly from the first subfolder (not root)
+            # this avoids adding the first subfolder to the path length,
+            # which can be too long if the download has the SHA in the name.
+            zsep = "/"  # Not using os.sep, always the / value even on windows.
+            for name in zfile.namelist():
+                if zsep not in name:
+                    continue
+                top_folder = name[: name.index(zsep) + 1]
+                if name == top_folder + zsep:
+                    continue  # skip top level folder
+                sub_path = name[name.index(zsep) + 1 :]
+                if name.endswith(zsep):
+                    try:
+                        os.mkdir(os.path.join(outdir, sub_path))
+                        self.print_verbose(
+                            "Extract - mkdir: " + os.path.join(outdir, sub_path)
+                        )
+                    except OSError as exc:
+                        if exc.errno != errno.EEXIST:
+                            self._error = "Install failed"
+                            self._error_msg = "Could not create folder from zip"
+                            self.print_trace()
+                            return -1
+                else:
+                    with open(os.path.join(outdir, sub_path), "wb") as outfile:
+                        data = zfile.read(name)
+                        outfile.write(data)
+                        self.print_verbose(
+                            "Extract - create: " + os.path.join(outdir, sub_path)
+                        )
+
+        self.print_verbose("Extracted source")
+
+        unpath = os.path.join(self._updater_path, "source")
+        if not os.path.isdir(unpath):
+            self._error = "Install failed"
+            self._error_msg = "Extracted path does not exist"
+            print("Extracted path does not exist: ", unpath)
+            return -1
+
+        if self._subfolder_path:
+            self._subfolder_path.replace("/", os.path.sep)
+            self._subfolder_path.replace("\\", os.path.sep)
+
+        # Either directly in root of zip/one subfolder, or use specified path.
+        if not os.path.isfile(os.path.join(unpath, "__init__.py")):
+            dirlist = os.listdir(unpath)
+            if len(dirlist) > 0:
+                if self._subfolder_path == "" or self._subfolder_path is None:
+                    unpath = os.path.join(unpath, dirlist[0])
+                else:
+                    unpath = os.path.join(unpath, self._subfolder_path)
+
+            # Smarter check for additional sub folders for a single folder
+            # containing the __init__.py file.
+            if not os.path.isfile(os.path.join(unpath, "__init__.py")):
+                print("Not a valid addon found")
+                print("Paths:")
+                print(dirlist)
+                self._error = "Install failed"
+                self._error_msg = "No __init__ file found in new source"
+                return -1
+
+        # Merge code with the addon directory, using blender default behavior,
+        # plus any modifiers indicated by user (e.g. force remove/keep).
+        self.deep_merge_directory(self._addon_root, unpath, clean)
+
+        # Now save the json state.
+        # Change to True to trigger the handler on other side if allowing
+        # reloading within same blender session.
+        self._json["just_updated"] = True
+        self.save_updater_json()
+        self.reload_addon()
+        self._update_ready = False
+        return 0
+
+    def deep_merge_directory(self, base, merger, clean=False):
+        """Merge folder 'merger' into 'base' without deleting existing"""
+        if not os.path.exists(base):
+            self.print_verbose("Base path does not exist:" + str(base))
+            return -1
+        elif not os.path.exists(merger):
+            self.print_verbose("Merger path does not exist")
+            return -1
+
+        # Path to be aware of and not overwrite/remove/etc.
+        staging_path = os.path.join(self._updater_path, "update_staging")
+
+        # If clean install is enabled, clear existing files ahead of time
+        # note: will not delete the update.json, update folder, staging, or
+        # staging but will delete all other folders/files in addon directory.
+        error = None
+        if clean:
+            try:
+                # Implement clearing of all folders/files, except the updater
+                # folder and updater json.
+                # Careful, this deletes entire subdirectories recursively...
+                # Make sure that base is not a high level shared folder, but
+                # is dedicated just to the addon itself.
+                self.print_verbose(
+                    "clean=True, clearing addon folder to fresh install state"
+                )
+
+                # Remove root files and folders (except update folder).
+                files = [
+                    f for f in os.listdir(base) if os.path.isfile(os.path.join(base, f))
+                ]
+                folders = [
+                    f for f in os.listdir(base) if os.path.isdir(os.path.join(base, f))
+                ]
+
+                for f in files:
+                    os.remove(os.path.join(base, f))
+                    self.print_verbose(
+                        "Clean removing file {}".format(os.path.join(base, f))
+                    )
+                for f in folders:
+                    if os.path.join(base, f) is self._updater_path:
+                        continue
+                    shutil.rmtree(os.path.join(base, f))
+                    self.print_verbose(
+                        "Clean removing folder and contents {}".format(
+                            os.path.join(base, f)
+                        )
+                    )
+
+            except Exception as err:
+                error = "failed to create clean existing addon folder"
+                print(error, str(err))
+                self.print_trace()
+
+        # Walk through the base addon folder for rules on pre-removing
+        # but avoid removing/altering backup and updater file.
+        for path, dirs, files in os.walk(base):
+            # Prune ie skip updater folder.
+            dirs[:] = [
+                d for d in dirs if os.path.join(path, d) not in [self._updater_path]
+            ]
+            for file in files:
+                for pattern in self.remove_pre_update_patterns:
+                    if fnmatch.filter([file], pattern):
+                        try:
+                            fl = os.path.join(path, file)
+                            os.remove(fl)
+                            self.print_verbose("Pre-removed file " + file)
+                        except OSError:
+                            print("Failed to pre-remove " + file)
+                            self.print_trace()
+
+        # Walk through the temp addon sub folder for replacements
+        # this implements the overwrite rules, which apply after
+        # the above pre-removal rules. This also performs the
+        # actual file copying/replacements.
+        for path, dirs, files in os.walk(merger):
+            # Verify structure works to prune updater sub folder overwriting.
+            dirs[:] = [
+                d for d in dirs if os.path.join(path, d) not in [self._updater_path]
+            ]
+            rel_path = os.path.relpath(path, merger)
+            dest_path = os.path.join(base, rel_path)
+            if not os.path.exists(dest_path):
+                os.makedirs(dest_path)
+            for file in files:
+                # Bring in additional logic around copying/replacing.
+                # Blender default: overwrite .py's, don't overwrite the rest.
+                dest_file = os.path.join(dest_path, file)
+                srcFile = os.path.join(path, file)
+
+                # Decide to replace if file already exists, and copy new over.
+                if os.path.isfile(dest_file):
+                    # Otherwise, check each file for overwrite pattern match.
+                    replaced = False
+                    for pattern in self._overwrite_patterns:
+                        if fnmatch.filter([file], pattern):
+                            replaced = True
+                            break
+                    if replaced:
+                        os.remove(dest_file)
+                        os.rename(srcFile, dest_file)
+                        self.print_verbose(
+                            "Overwrote file " + os.path.basename(dest_file)
+                        )
+                    else:
+                        self.print_verbose(
+                            "Pattern not matched to {}, not overwritten".format(
+                                os.path.basename(dest_file)
+                            )
+                        )
+                else:
+                    # File did not previously exist, simply move it over.
+                    os.rename(srcFile, dest_file)
+                    self.print_verbose("New file " + os.path.basename(dest_file))
+
+        # now remove the temp staging folder and downloaded zip
+        try:
+            shutil.rmtree(staging_path)
+        except:
+            error = (
+                "Error: Failed to remove existing staging directory, "
+                "consider manually removing "
+            ) + staging_path
+            self.print_verbose(error)
+            self.print_trace()
+
+    def reload_addon(self):
+        # if post_update false, skip this function
+        # else, unload/reload addon & trigger popup
+        if not self._auto_reload_post_update:
+            print("Restart blender to reload addon and complete update")
+            return
+
+        self.print_verbose("Reloading addon...")
+        addon_utils.modules(refresh=True)
+        bpy.utils.refresh_script_paths()
+
+        # not allowed in restricted context, such as register module
+        # toggle to refresh
+        if "addon_disable" in dir(bpy.ops.wm):  # 2.7
+            bpy.ops.wm.addon_disable(module=self._addon_package)
+            bpy.ops.wm.addon_refresh()
+            bpy.ops.wm.addon_enable(module=self._addon_package)
+            print("2.7 reload complete")
+        else:  # 2.8
+            bpy.ops.preferences.addon_disable(module=self._addon_package)
+            bpy.ops.preferences.addon_refresh()
+            bpy.ops.preferences.addon_enable(module=self._addon_package)
+            print("2.8 reload complete")
+
+    # -------------------------------------------------------------------------
+    # Other non-api functions and setups
+    # -------------------------------------------------------------------------
+    def clear_state(self):
+        self._update_ready = None
+        self._update_link = None
+        self._update_version = None
+        self._source_zip = None
+        self._error = None
+        self._error_msg = None
+
+    def url_retrieve(self, url_file, filepath):
+        """Custom urlretrieve implementation"""
+        chunk = 1024 * 8
+        f = open(filepath, "wb")
+        while 1:
+            data = url_file.read(chunk)
+            if not data:
+                # print("done.")
+                break
+            f.write(data)
+            # print("Read %s bytes" % len(data))
+        f.close()
+
+    def version_tuple_from_text(self, text):
+        """Convert text into a tuple of numbers (int).
+
+        Should go through string and remove all non-integers, and for any
+        given break split into a different section.
+        """
+        if text is None:
+            return ()
+
+        segments = list()
+        tmp = ""
+        for char in str(text):
+            if not char.isdigit():
+                if len(tmp) > 0:
+                    segments.append(int(tmp))
+                    tmp = ""
+            else:
+                tmp += char
+        if len(tmp) > 0:
+            segments.append(int(tmp))
+
+        if len(segments) == 0:
+            self.print_verbose("No version strings found text: " + str(text))
+            if not self._include_branches:
+                return ()
+            else:
+                return text
+        return tuple(segments)
+
+    def check_for_update_async(self, callback=None):
+        """Called for running check in a background thread"""
+        is_ready = (
+            self._json is not None
+            and "update_ready" in self._json
+            and self._json["version_text"] != dict()
+            and self._json["update_ready"]
+        )
+
+        if is_ready:
+            self._update_ready = True
+            self._update_link = self._json["version_text"]["link"]
+            self._update_version = str(self._json["version_text"]["version"])
+            # Cached update.
+            callback(True)
+            return
+
+        # do the check
+        if not self._check_interval_enabled:
+            return
+        elif self._async_checking:
+            self.print_verbose("Skipping async check, already started")
+            # already running the bg thread
+        elif self._update_ready is None:
+            print("{} updater: Running background check for update".format(self.addon))
+            self.start_async_check_update(False, callback)
+
+    def check_for_update_now(self, callback=None):
+        self._error = None
+        self._error_msg = None
+        self.print_verbose("Check update pressed, first getting current status")
+        if self._async_checking:
+            self.print_verbose("Skipping async check, already started")
+            return  # already running the bg thread
+        elif self._update_ready is None:
+            self.start_async_check_update(True, callback)
+        else:
+            self._update_ready = None
+            self.start_async_check_update(True, callback)
+
+    def check_for_update(self, now=False):
+        """Check for update not in a syncrhonous manner.
+
+        This function is not async, will always return in sequential fashion
+        but should have a parent which calls it in another thread.
+        """
+        self.print_verbose("Checking for update function")
+
+        # clear the errors if any
+        self._error = None
+        self._error_msg = None
+
+        # avoid running again in, just return past result if found
+        # but if force now check, then still do it
+        if self._update_ready is not None and not now:
+            return (self._update_ready, self._update_version, self._update_link)
+
+        if self._current_version is None:
+            raise ValueError("current_version not yet defined")
+
+        if self._repo is None:
+            raise ValueError("repo not yet defined")
+
+        if self._user is None:
+            raise ValueError("username not yet defined")
+
+        self.set_updater_json()  # self._json
+
+        if not now and not self.past_interval_timestamp():
+            self.print_verbose("Aborting check for updated, check interval not reached")
+            return (False, None, None)
+
+        # check if using tags or releases
+        # note that if called the first time, this will pull tags from online
+        if self._fake_install:
+            self.print_verbose("fake_install = True, setting fake version as ready")
+            self._update_ready = True
+            self._update_version = "(999,999,999)"
+            self._update_link = "http://127.0.0.1"
+
+            return (self._update_ready, self._update_version, self._update_link)
+
+        # Primary internet call, sets self._tags and self._tag_latest.
+        self.get_tags()
+
+        self._json["last_check"] = str(datetime.now())
+        self.save_updater_json()
+
+        # Can be () or ('master') in addition to branches, and version tag.
+        new_version = self.version_tuple_from_text(self.tag_latest)
+
+        if len(self._tags) == 0:
+            self._update_ready = False
+            self._update_version = None
+            self._update_link = None
+            return (False, None, None)
+
+        if not self._include_branches:
+            link = self.select_link(self, self._tags[0])
+        else:
+            n = len(self._include_branch_list)
+            if len(self._tags) == n:
+                # effectively means no tags found on repo
+                # so provide the first one as default
+                link = self.select_link(self, self._tags[0])
+            else:
+                link = self.select_link(self, self._tags[n])
+
+        if new_version == ():
+            self._update_ready = False
+            self._update_version = None
+            self._update_link = None
+            return (False, None, None)
+        elif str(new_version).lower() in self._include_branch_list:
+            # Handle situation where master/whichever branch is included
+            # however, this code effectively is not triggered now
+            # as new_version will only be tag names, not branch names.
+            if not self._include_branch_auto_check:
+                # Don't offer update as ready, but set the link for the
+                # default branch for installing.
+                self._update_ready = False
+                self._update_version = new_version
+                self._update_link = link
+                self.save_updater_json()
+                return (True, new_version, link)
+            else:
+                # Bypass releases and look at timestamp of last update from a
+                # branch compared to now, see if commit values match or not.
+                raise ValueError("include_branch_autocheck: NOT YET DEVELOPED")
+
+        else:
+            # Situation where branches not included.
+            if new_version > self._current_version:
+                self._update_ready = True
+                self._update_version = new_version
+                self._update_link = link
+                self.save_updater_json()
+                return (True, new_version, link)
+
+        # If no update, set ready to False from None to show it was checked.
+        self._update_ready = False
+        self._update_version = None
+        self._update_link = None
+        return (False, None, None)
+
+    def set_tag(self, name):
+        """Assign the tag name and url to update to"""
+        tg = None
+        for tag in self._tags:
+            if name == tag["name"]:
+                tg = tag
+                break
+        if tg:
+            new_version = self.version_tuple_from_text(self.tag_latest)
+            self._update_version = new_version
+            self._update_link = self.select_link(self, tg)
+        elif self._include_branches and name in self._include_branch_list:
+            # scenario if reverting to a specific branch name instead of tag
+            tg = name
+            link = self.form_branch_url(tg)
+            self._update_version = name  # this will break things
+            self._update_link = link
+        if not tg:
+            raise ValueError("Version tag not found: " + name)
+
+    def run_update(self, force=False, revert_tag=None, clean=False, callback=None):
+        """Runs an install, update, or reversion of an addon from online source
+
+        Arguments:
+                force: Install assigned link, even if self.update_ready is False
+                revert_tag: Version to install, if none uses detected update link
+                clean: not used, but in future could use to totally refresh addon
+                callback: used to run function on update completion
+        """
+        self._json["update_ready"] = False
+        self._json["ignore"] = False  # clear ignore flag
+        self._json["version_text"] = dict()
+
+        if revert_tag is not None:
+            self.set_tag(revert_tag)
+            self._update_ready = True
+
+        # clear the errors if any
+        self._error = None
+        self._error_msg = None
+
+        self.print_verbose("Running update")
+
+        if self._fake_install:
+            # Change to True, to trigger the reload/"update installed" handler.
+            self.print_verbose("fake_install=True")
+            self.print_verbose("Just reloading and running any handler triggers")
+            self._json["just_updated"] = True
+            self.save_updater_json()
+            if self._backup_current is True:
+                self.create_backup()
+            self.reload_addon()
+            self._update_ready = False
+            res = True  # fake "success" zip download flag
+
+        elif not force:
+            if not self._update_ready:
+                self.print_verbose("Update stopped, new version not ready")
+                if callback:
+                    callback(
+                        self._addon_package, "Update stopped, new version not ready"
+                    )
+                return "Update stopped, new version not ready"
+            elif self._update_link is None:
+                # this shouldn't happen if update is ready
+                self.print_verbose("Update stopped, update link unavailable")
+                if callback:
+                    callback(
+                        self._addon_package, "Update stopped, update link unavailable"
+                    )
+                return "Update stopped, update link unavailable"
+
+            if revert_tag is None:
+                self.print_verbose("Staging update")
+            else:
+                self.print_verbose("Staging install")
+
+            res = self.stage_repository(self._update_link)
+            if not res:
+                print("Error in staging repository: " + str(res))
+                if callback is not None:
+                    callback(self._addon_package, self._error_msg)
+                return self._error_msg
+            res = self.unpack_staged_zip(clean)
+            if res < 0:
+                if callback:
+                    callback(self._addon_package, self._error_msg)
+                return res
+
+        else:
+            if self._update_link is None:
+                self.print_verbose("Update stopped, could not get link")
+                return "Update stopped, could not get link"
+            self.print_verbose("Forcing update")
+
+            res = self.stage_repository(self._update_link)
+            if not res:
+                print("Error in staging repository: " + str(res))
+                if callback:
+                    callback(self._addon_package, self._error_msg)
+                return self._error_msg
+            res = self.unpack_staged_zip(clean)
+            if res < 0:
+                return res
+            # would need to compare against other versions held in tags
+
+        # run the front-end's callback if provided
+        if callback:
+            callback(self._addon_package)
+
+        # return something meaningful, 0 means it worked
+        return 0
+
+    def past_interval_timestamp(self):
+        if not self._check_interval_enabled:
+            return True  # ie this exact feature is disabled
+
+        if "last_check" not in self._json or self._json["last_check"] == "":
+            return True
+
+        now = datetime.now()
+        last_check = datetime.strptime(self._json["last_check"], "%Y-%m-%d %H:%M:%S.%f")
+        offset = timedelta(
+            days=self._check_interval_days + 30 * self._check_interval_months,
+            hours=self._check_interval_hours,
+            minutes=self._check_interval_minutes,
+        )
+
+        delta = (now - offset) - last_check
+        if delta.total_seconds() > 0:
+            self.print_verbose("Time to check for updates!")
+            return True
+
+        self.print_verbose("Determined it's not yet time to check for updates")
+        return False
+
+    def get_json_path(self):
+        """Returns the full path to the JSON state file used by this updater.
+
+        Will also rename old file paths to addon-specific path if found.
+        """
+        json_path = os.path.join(
+            self._updater_path, "{}_updater_status.json".format(self._addon_package)
+        )
+        old_json_path = os.path.join(self._updater_path, "updater_status.json")
+
+        # Rename old file if it exists.
+        try:
+            os.rename(old_json_path, json_path)
+        except FileNotFoundError:
+            pass
+        except Exception as err:
+            print("Other OS error occurred while trying to rename old JSON")
+            print(err)
+            self.print_trace()
+        return json_path
+
+    def set_updater_json(self):
+        """Load or initialize JSON dictionary data for updater state"""
+        if self._updater_path is None:
+            raise ValueError("updater_path is not defined")
+        elif not os.path.isdir(self._updater_path):
+            os.makedirs(self._updater_path)
+
+        jpath = self.get_json_path()
+        if os.path.isfile(jpath):
+            with open(jpath) as data_file:
+                self._json = json.load(data_file)
+                self.print_verbose("Read in JSON settings from file")
+        else:
+            self._json = {
+                "last_check": "",
+                "backup_date": "",
+                "update_ready": False,
+                "ignore": False,
+                "just_restored": False,
+                "just_updated": False,
+                "version_text": dict(),
+            }
+            self.save_updater_json()
+
+    def save_updater_json(self):
+        """Trigger save of current json structure into file within addon"""
+        if self._update_ready:
+            if isinstance(self._update_version, tuple):
+                self._json["update_ready"] = True
+                self._json["version_text"]["link"] = self._update_link
+                self._json["version_text"]["version"] = self._update_version
+            else:
+                self._json["update_ready"] = False
+                self._json["version_text"] = dict()
+        else:
+            self._json["update_ready"] = False
+            self._json["version_text"] = dict()
+
+        jpath = self.get_json_path()
+        if not os.path.isdir(os.path.dirname(jpath)):
+            print(
+                "State error: Directory does not exist, cannot save json: ",
+                os.path.basename(jpath),
+            )
+            return
+        try:
+            with open(jpath, "w") as outf:
+                data_out = json.dumps(self._json, indent=4)
+                outf.write(data_out)
+        except:
+            print("Failed to open/save data to json: ", jpath)
+            self.print_trace()
+        self.print_verbose("Wrote out updater JSON settings with content:")
+        self.print_verbose(str(self._json))
+
+    def json_reset_postupdate(self):
+        self._json["just_updated"] = False
+        self._json["update_ready"] = False
+        self._json["version_text"] = dict()
+        self.save_updater_json()
+
+    def json_reset_restore(self):
+        self._json["just_restored"] = False
+        self._json["update_ready"] = False
+        self._json["version_text"] = dict()
+        self.save_updater_json()
+        self._update_ready = None  # Reset so you could check update again.
+
+    def ignore_update(self):
+        self._json["ignore"] = True
+        self.save_updater_json()
+
+    # -------------------------------------------------------------------------
+    # ASYNC related methods
+    # -------------------------------------------------------------------------
+    def start_async_check_update(self, now=False, callback=None):
+        """Start a background thread which will check for updates"""
+        if self._async_checking:
+            return
+        self.print_verbose("Starting background checking thread")
+        check_thread = threading.Thread(
+            target=self.async_check_update,
+            args=(
+                now,
+                callback,
+            ),
+        )
+        check_thread.daemon = True
+        self._check_thread = check_thread
+        check_thread.start()
+
+    def async_check_update(self, now, callback=None):
+        """Perform update check, run as target of background thread"""
+        self._async_checking = True
+        self.print_verbose("Checking for update now in background")
+
+        try:
+            self.check_for_update(now=now)
+        except Exception as exception:
+            print("Checking for update error:")
+            print(exception)
+            self.print_trace()
+            if not self._error:
+                self._update_ready = False
+                self._update_version = None
+                self._update_link = None
+                self._error = "Error occurred"
+                self._error_msg = "Encountered an error while checking for updates"
+
+        self._async_checking = False
+        self._check_thread = None
+
+        if callback:
+            self.print_verbose("Finished check update, doing callback")
+            callback(self._update_ready)
+        self.print_verbose("BG thread: Finished check update, no callback")
+
+    def stop_async_check_update(self):
+        """Method to give impression of stopping check for update.
+
+        Currently does nothing but allows user to retry/stop blocking UI from
+        hitting a refresh button. This does not actually stop the thread, as it
+        will complete after the connection timeout regardless. If the thread
+        does complete with a successful response, this will be still displayed
+        on next UI refresh (ie no update, or update available).
+        """
+        if self._check_thread is not None:
+            self.print_verbose("Thread will end in normal course.")
+            # however, "There is no direct kill method on a thread object."
+            # better to let it run its course
+            # self._check_thread.stop()
+        self._async_checking = False
+        self._error = None
+        self._error_msg = None
 
 
 # -----------------------------------------------------------------------------
@@ -1629,110 +1647,110 @@ class SingletonUpdater:
 
 
 class BitbucketEngine:
-	"""Integration to Bitbucket API for git-formatted repositories"""
+    """Integration to Bitbucket API for git-formatted repositories"""
 
-	def __init__(self):
-		self.api_url = 'https://api.bitbucket.org'
-		self.token = None
-		self.name = "bitbucket"
+    def __init__(self):
+        self.api_url = "https://api.bitbucket.org"
+        self.token = None
+        self.name = "bitbucket"
 
-	def form_repo_url(self, updater):
-		return "{}/2.0/repositories/{}/{}".format(
-			self.api_url, updater.user, updater.repo)
+    def form_repo_url(self, updater):
+        return "{}/2.0/repositories/{}/{}".format(
+            self.api_url, updater.user, updater.repo
+        )
 
-	def form_tags_url(self, updater):
-		return self.form_repo_url(updater) + "/refs/tags?sort=-name"
+    def form_tags_url(self, updater):
+        return self.form_repo_url(updater) + "/refs/tags?sort=-name"
 
-	def form_branch_url(self, branch, updater):
-		return self.get_zip_url(branch, updater)
+    def form_branch_url(self, branch, updater):
+        return self.get_zip_url(branch, updater)
 
-	def get_zip_url(self, name, updater):
-		return "https://bitbucket.org/{user}/{repo}/get/{name}.zip".format(
-			user=updater.user,
-			repo=updater.repo,
-			name=name)
+    def get_zip_url(self, name, updater):
+        return "https://bitbucket.org/{user}/{repo}/get/{name}.zip".format(
+            user=updater.user, repo=updater.repo, name=name
+        )
 
-	def parse_tags(self, response, updater):
-		if response is None:
-			return list()
-		return [
-			{
-				"name": tag["name"],
-				"zipball_url": self.get_zip_url(tag["name"], updater)
-			} for tag in response["values"]]
+    def parse_tags(self, response, updater):
+        if response is None:
+            return list()
+        return [
+            {"name": tag["name"], "zipball_url": self.get_zip_url(tag["name"], updater)}
+            for tag in response["values"]
+        ]
 
 
 class GithubEngine:
-	"""Integration to Github API"""
+    """Integration to Github API"""
 
-	def __init__(self):
-		self.api_url = 'https://api.github.com'
-		self.token = None
-		self.name = "github"
+    def __init__(self):
+        self.api_url = "https://api.github.com"
+        self.token = None
+        self.name = "github"
 
-	def form_repo_url(self, updater):
-		return "{}/repos/{}/{}".format(
-			self.api_url, updater.user, updater.repo)
+    def form_repo_url(self, updater):
+        return "{}/repos/{}/{}".format(self.api_url, updater.user, updater.repo)
 
-	def form_tags_url(self, updater):
-		if updater.use_releases:
-			return "{}/releases".format(self.form_repo_url(updater))
-		else:
-			return "{}/tags".format(self.form_repo_url(updater))
+    def form_tags_url(self, updater):
+        if updater.use_releases:
+            return "{}/releases".format(self.form_repo_url(updater))
+        else:
+            return "{}/tags".format(self.form_repo_url(updater))
 
-	def form_branch_list_url(self, updater):
-		return "{}/branches".format(self.form_repo_url(updater))
+    def form_branch_list_url(self, updater):
+        return "{}/branches".format(self.form_repo_url(updater))
 
-	def form_branch_url(self, branch, updater):
-		return "{}/zipball/{}".format(self.form_repo_url(updater), branch)
+    def form_branch_url(self, branch, updater):
+        return "{}/zipball/{}".format(self.form_repo_url(updater), branch)
 
-	def parse_tags(self, response, updater):
-		if response is None:
-			return list()
-		return response
+    def parse_tags(self, response, updater):
+        if response is None:
+            return list()
+        return response
 
 
 class GitlabEngine:
-	"""Integration to GitLab API"""
+    """Integration to GitLab API"""
 
-	def __init__(self):
-		self.api_url = 'https://gitlab.com'
-		self.token = None
-		self.name = "gitlab"
+    def __init__(self):
+        self.api_url = "https://gitlab.com"
+        self.token = None
+        self.name = "gitlab"
 
-	def form_repo_url(self, updater):
-		return "{}/api/v4/projects/{}".format(self.api_url, updater.repo)
+    def form_repo_url(self, updater):
+        return "{}/api/v4/projects/{}".format(self.api_url, updater.repo)
 
-	def form_tags_url(self, updater):
-		return "{}/repository/tags".format(self.form_repo_url(updater))
+    def form_tags_url(self, updater):
+        return "{}/repository/tags".format(self.form_repo_url(updater))
 
-	def form_branch_list_url(self, updater):
-		# does not validate branch name.
-		return "{}/repository/branches".format(
-			self.form_repo_url(updater))
+    def form_branch_list_url(self, updater):
+        # does not validate branch name.
+        return "{}/repository/branches".format(self.form_repo_url(updater))
 
-	def form_branch_url(self, branch, updater):
-		# Could clash with tag names and if it does, it will download TAG zip
-		# instead of branch zip to get direct path, would need.
-		return "{}/repository/archive.zip?sha={}".format(
-			self.form_repo_url(updater), branch)
+    def form_branch_url(self, branch, updater):
+        # Could clash with tag names and if it does, it will download TAG zip
+        # instead of branch zip to get direct path, would need.
+        return "{}/repository/archive.zip?sha={}".format(
+            self.form_repo_url(updater), branch
+        )
 
-	def get_zip_url(self, sha, updater):
-		return "{base}/repository/archive.zip?sha={sha}".format(
-			base=self.form_repo_url(updater),
-			sha=sha)
+    def get_zip_url(self, sha, updater):
+        return "{base}/repository/archive.zip?sha={sha}".format(
+            base=self.form_repo_url(updater), sha=sha
+        )
 
-	# def get_commit_zip(self, id, updater):
-	# 	return self.form_repo_url(updater)+"/repository/archive.zip?sha:"+id
+    # def get_commit_zip(self, id, updater):
+    # 	return self.form_repo_url(updater)+"/repository/archive.zip?sha:"+id
 
-	def parse_tags(self, response, updater):
-		if response is None:
-			return list()
-		return [
-			{
-				"name": tag["name"],
-				"zipball_url": self.get_zip_url(tag["commit"]["id"], updater)
-			} for tag in response]
+    def parse_tags(self, response, updater):
+        if response is None:
+            return list()
+        return [
+            {
+                "name": tag["name"],
+                "zipball_url": self.get_zip_url(tag["commit"]["id"], updater),
+            }
+            for tag in response
+        ]
 
 
 # -----------------------------------------------------------------------------

--- a/MCprep_addon/addon_updater_ops.py
+++ b/MCprep_addon/addon_updater_ops.py
@@ -33,42 +33,42 @@ from . import tracking
 # Prevents popups for users with invalid python installs e.g. missing libraries
 # and will replace with a fake class instead if it fails (so UI draws work).
 try:
-	from .addon_updater import Updater as updater
+    from .addon_updater import Updater as updater
 except Exception as e:
-	print("ERROR INITIALIZING UPDATER")
-	print(str(e))
-	traceback.print_exc()
+    print("ERROR INITIALIZING UPDATER")
+    print(str(e))
+    traceback.print_exc()
 
-	class SingletonUpdaterNone(object):
-		"""Fake, bare minimum fields and functions for the updater object."""
+    class SingletonUpdaterNone(object):
+        """Fake, bare minimum fields and functions for the updater object."""
 
-		def __init__(self):
-			self.invalid_updater = True  # Used to distinguish bad install.
+        def __init__(self):
+            self.invalid_updater = True  # Used to distinguish bad install.
 
-			self.addon = None
-			self.verbose = False
-			self.use_print_traces = True
-			self.error = None
-			self.error_msg = None
-			self.async_checking = None
+            self.addon = None
+            self.verbose = False
+            self.use_print_traces = True
+            self.error = None
+            self.error_msg = None
+            self.async_checking = None
 
-		def clear_state(self):
-			self.addon = None
-			self.verbose = False
-			self.invalid_updater = True
-			self.error = None
-			self.error_msg = None
-			self.async_checking = None
+        def clear_state(self):
+            self.addon = None
+            self.verbose = False
+            self.invalid_updater = True
+            self.error = None
+            self.error_msg = None
+            self.async_checking = None
 
-		def run_update(self, force, callback, clean):
-			pass
+        def run_update(self, force, callback, clean):
+            pass
 
-		def check_for_update(self, now):
-			pass
+        def check_for_update(self, now):
+            pass
 
-	updater = SingletonUpdaterNone()
-	updater.error = "Error initializing updater module"
-	updater.error_msg = str(e)
+    updater = SingletonUpdaterNone()
+    updater.error = "Error initializing updater module"
+    updater.error_msg = str(e)
 
 # Must declare this before classes are loaded, otherwise the bl_idname's will
 # not match and have errors. Must be all lowercase and no spaces! Should also
@@ -81,50 +81,52 @@ updater.addon = "mcprep"
 # Blender version utils
 # -----------------------------------------------------------------------------
 def make_annotations(cls):
-	"""Add annotation attribute to fields to avoid Blender 2.8+ warnings.
+    """Add annotation attribute to fields to avoid Blender 2.8+ warnings.
 
-	Deprecated operator as MCprep 3.5 moves to support 2.8+ only and using
-	native python annotations.
-	"""
-	if not hasattr(bpy.app, "version") or bpy.app.version < (2, 80):
-		return cls
-	if bpy.app.version < (2, 93, 0):
-		bl_props = {k: v for k, v in cls.__dict__.items()
-					if isinstance(v, tuple)}
-	else:
-		bl_props = {k: v for k, v in cls.__dict__.items()
-					if isinstance(v, bpy.props._PropertyDeferred)}
-	if bl_props:
-		if '__annotations__' not in cls.__dict__:
-			setattr(cls, '__annotations__', {})
-		annotations = cls.__dict__['__annotations__']
-		for k, v in bl_props.items():
-			annotations[k] = v
-			delattr(cls, k)
-	return cls
+    Deprecated operator as MCprep 3.5 moves to support 2.8+ only and using
+    native python annotations.
+    """
+    if not hasattr(bpy.app, "version") or bpy.app.version < (2, 80):
+        return cls
+    if bpy.app.version < (2, 93, 0):
+        bl_props = {k: v for k, v in cls.__dict__.items() if isinstance(v, tuple)}
+    else:
+        bl_props = {
+            k: v
+            for k, v in cls.__dict__.items()
+            if isinstance(v, bpy.props._PropertyDeferred)
+        }
+    if bl_props:
+        if "__annotations__" not in cls.__dict__:
+            setattr(cls, "__annotations__", {})
+        annotations = cls.__dict__["__annotations__"]
+        for k, v in bl_props.items():
+            annotations[k] = v
+            delattr(cls, k)
+    return cls
 
 
 def layout_split(layout, factor=0.0, align=False):
-	"""Intermediate method for pre and post blender 2.8 split UI function"""
-	if not hasattr(bpy.app, "version") or bpy.app.version < (2, 80):
-		return layout.split(percentage=factor, align=align)
-	return layout.split(factor=factor, align=align)
+    """Intermediate method for pre and post blender 2.8 split UI function"""
+    if not hasattr(bpy.app, "version") or bpy.app.version < (2, 80):
+        return layout.split(percentage=factor, align=align)
+    return layout.split(factor=factor, align=align)
 
 
 def get_user_preferences(context=None):
-	"""Intermediate method for pre and post blender 2.8 grabbing preferences"""
-	if not context:
-		context = bpy.context
-	prefs = None
-	if hasattr(context, "user_preferences"):
-		prefs = context.user_preferences.addons.get(__package__, None)
-	elif hasattr(context, "preferences"):
-		prefs = context.preferences.addons.get(__package__, None)
-	if prefs:
-		return prefs.preferences
-	# To make the addon stable and non-exception prone, return None
-	# raise Exception("Could not fetch user preferences")
-	return None
+    """Intermediate method for pre and post blender 2.8 grabbing preferences"""
+    if not context:
+        context = bpy.context
+    prefs = None
+    if hasattr(context, "user_preferences"):
+        prefs = context.user_preferences.addons.get(__package__, None)
+    elif hasattr(context, "preferences"):
+        prefs = context.preferences.addons.get(__package__, None)
+    if prefs:
+        return prefs.preferences
+    # To make the addon stable and non-exception prone, return None
+    # raise Exception("Could not fetch user preferences")
+    return None
 
 
 # -----------------------------------------------------------------------------
@@ -134,517 +136,519 @@ def get_user_preferences(context=None):
 
 # Simple popup to prompt use to check for update & offer install if available.
 class AddonUpdaterInstallPopup(bpy.types.Operator):
-	"""Check and install update if available"""
-	bl_label = "Update {x} addon".format(x=updater.addon)
-	bl_idname = updater.addon + ".updater_install_popup"
-	bl_description = "Popup to check and display current updates available"
-	bl_options = {'REGISTER', 'INTERNAL'}
+    """Check and install update if available"""
 
-	# if true, run clean install - ie remove all files before adding new
-	# equivalent to deleting the addon and reinstalling, except the
-	# updater folder/backup folder remains
-	clean_install = bpy.props.BoolProperty(
-		name="Clean install",
-		description=("If enabled, completely clear the addon's folder before "
-					 "installing new update, creating a fresh install"),
-		default=False,
-		options={'HIDDEN'}
-	)
+    bl_label = "Update {x} addon".format(x=updater.addon)
+    bl_idname = updater.addon + ".updater_install_popup"
+    bl_description = "Popup to check and display current updates available"
+    bl_options = {"REGISTER", "INTERNAL"}
 
-	ignore_enum = bpy.props.EnumProperty(
-		name="Process update",
-		description="Decide to install, ignore, or defer new addon update",
-		items=[
-			("install", "Update Now", "Install update now"),
-			("ignore", "Ignore", "Ignore this update to prevent future popups"),
-			("defer", "Defer", "Defer choice till next blender session")
-		],
-		options={'HIDDEN'}
-	)
+    # if true, run clean install - ie remove all files before adding new
+    # equivalent to deleting the addon and reinstalling, except the
+    # updater folder/backup folder remains
+    clean_install = bpy.props.BoolProperty(
+        name="Clean install",
+        description=(
+            "If enabled, completely clear the addon's folder before "
+            "installing new update, creating a fresh install"
+        ),
+        default=False,
+        options={"HIDDEN"},
+    )
 
-	def check(self, context):
-		return True
+    ignore_enum = bpy.props.EnumProperty(
+        name="Process update",
+        description="Decide to install, ignore, or defer new addon update",
+        items=[
+            ("install", "Update Now", "Install update now"),
+            ("ignore", "Ignore", "Ignore this update to prevent future popups"),
+            ("defer", "Defer", "Defer choice till next blender session"),
+        ],
+        options={"HIDDEN"},
+    )
 
-	def invoke(self, context, event):
-		return context.window_manager.invoke_props_dialog(self)
+    def check(self, context):
+        return True
 
-	def draw(self, context):
-		layout = self.layout
-		if updater.invalid_updater:
-			layout.label(text="Updater module error")
-			return
-		elif updater.update_ready:
-			col = layout.column()
-			col.scale_y = 0.7
-			col.label(text="Update {} ready!".format(updater.update_version),
-					  icon="LOOP_FORWARDS")
-			col.label(text="Choose 'Update Now' & press OK to install, ",
-					  icon="BLANK1")
-			col.label(text="or click outside window to defer", icon="BLANK1")
-			row = col.row()
-			row.prop(self, "ignore_enum", expand=True)
-			col.split()
-		elif not updater.update_ready:
-			col = layout.column()
-			col.scale_y = 0.7
-			col.label(text="No updates available")
-			col.label(text="Press okay to dismiss dialog")
-			# add option to force install
-		else:
-			# Case: updater.update_ready = None
-			# we have not yet checked for the update.
-			layout.label(text="Check for update now?")
+    def invoke(self, context, event):
+        return context.window_manager.invoke_props_dialog(self)
 
-		# Potentially in future, UI to 'check to select/revert to old version'.
+    def draw(self, context):
+        layout = self.layout
+        if updater.invalid_updater:
+            layout.label(text="Updater module error")
+            return
+        elif updater.update_ready:
+            col = layout.column()
+            col.scale_y = 0.7
+            col.label(
+                text="Update {} ready!".format(updater.update_version),
+                icon="LOOP_FORWARDS",
+            )
+            col.label(text="Choose 'Update Now' & press OK to install, ", icon="BLANK1")
+            col.label(text="or click outside window to defer", icon="BLANK1")
+            row = col.row()
+            row.prop(self, "ignore_enum", expand=True)
+            col.split()
+        elif not updater.update_ready:
+            col = layout.column()
+            col.scale_y = 0.7
+            col.label(text="No updates available")
+            col.label(text="Press okay to dismiss dialog")
+            # add option to force install
+        else:
+            # Case: updater.update_ready = None
+            # we have not yet checked for the update.
+            layout.label(text="Check for update now?")
 
-	track_function = "install_update_popup"
-	track_param = None
-	@tracking.report_error
-	def execute(self, context):
-		# In case of error importing updater.
-		if updater.invalid_updater:
-			return {'CANCELLED'}
+        # Potentially in future, UI to 'check to select/revert to old version'.
 
-		if updater.manual_only:
-			bpy.ops.wm.url_open(url=updater.website)
-		elif updater.update_ready:
+    track_function = "install_update_popup"
+    track_param = None
 
-			# Action based on enum selection.
-			if self.ignore_enum == 'defer':
-				return {'FINISHED'}
-			elif self.ignore_enum == 'ignore':
-				updater.ignore_update()
-				return {'FINISHED'}
+    @tracking.report_error
+    def execute(self, context):
+        # In case of error importing updater.
+        if updater.invalid_updater:
+            return {"CANCELLED"}
 
-			res = updater.run_update(force=False,
-									 callback=post_update_callback,
-									 clean=self.clean_install)
+        if updater.manual_only:
+            bpy.ops.wm.url_open(url=updater.website)
+        elif updater.update_ready:
+            # Action based on enum selection.
+            if self.ignore_enum == "defer":
+                return {"FINISHED"}
+            elif self.ignore_enum == "ignore":
+                updater.ignore_update()
+                return {"FINISHED"}
 
-			# Should return 0, if not something happened.
-			if updater.verbose:
-				if res == 0:
-					print("Updater returned successful")
-				else:
-					print("Updater returned {}, error occurred".format(res))
-		elif updater.update_ready is None:
-			_ = updater.check_for_update(now=True)
+            res = updater.run_update(
+                force=False, callback=post_update_callback, clean=self.clean_install
+            )
 
-			# Re-launch this dialog.
-			atr = AddonUpdaterInstallPopup.bl_idname.split(".")
-			getattr(getattr(bpy.ops, atr[0]), atr[1])('INVOKE_DEFAULT')
-		else:
-			updater.print_verbose("Doing nothing, not ready for update")
-		return {'FINISHED'}
+            # Should return 0, if not something happened.
+            if updater.verbose:
+                if res == 0:
+                    print("Updater returned successful")
+                else:
+                    print("Updater returned {}, error occurred".format(res))
+        elif updater.update_ready is None:
+            _ = updater.check_for_update(now=True)
+
+            # Re-launch this dialog.
+            atr = AddonUpdaterInstallPopup.bl_idname.split(".")
+            getattr(getattr(bpy.ops, atr[0]), atr[1])("INVOKE_DEFAULT")
+        else:
+            updater.print_verbose("Doing nothing, not ready for update")
+        return {"FINISHED"}
 
 
 # User preference check-now operator
 class AddonUpdaterCheckNow(bpy.types.Operator):
-	bl_label = "Check now for " + updater.addon + " update"
-	bl_idname = updater.addon + ".updater_check_now"
-	bl_description = "Check now for an update to the {} addon".format(
-		updater.addon)
-	bl_options = {'REGISTER', 'INTERNAL'}
+    bl_label = "Check now for " + updater.addon + " update"
+    bl_idname = updater.addon + ".updater_check_now"
+    bl_description = "Check now for an update to the {} addon".format(updater.addon)
+    bl_options = {"REGISTER", "INTERNAL"}
 
-	@tracking.report_error
-	def execute(self, context):
-		if updater.invalid_updater:
-			return {'CANCELLED'}
+    @tracking.report_error
+    def execute(self, context):
+        if updater.invalid_updater:
+            return {"CANCELLED"}
 
-		if updater.async_checking and updater.error is None:
-			# Check already happened.
-			# Used here to just avoid constant applying settings below.
-			# Ignoring if error, to prevent being stuck on the error screen.
-			return {'CANCELLED'}
+        if updater.async_checking and updater.error is None:
+            # Check already happened.
+            # Used here to just avoid constant applying settings below.
+            # Ignoring if error, to prevent being stuck on the error screen.
+            return {"CANCELLED"}
 
-		# apply the UI settings
-		settings = get_user_preferences(context)
-		if not settings:
-			updater.print_verbose(
-				"Could not get {} preferences, update check skipped".format(
-					__package__))
-			return {'CANCELLED'}
+        # apply the UI settings
+        settings = get_user_preferences(context)
+        if not settings:
+            updater.print_verbose(
+                "Could not get {} preferences, update check skipped".format(__package__)
+            )
+            return {"CANCELLED"}
 
-		updater.set_check_interval(
-			enabled=settings.auto_check_update,
-			months=settings.updater_interval_months,
-			days=settings.updater_interval_days,
-			hours=settings.updater_interval_hours,
-			minutes=settings.updater_interval_minutes)
+        updater.set_check_interval(
+            enabled=settings.auto_check_update,
+            months=settings.updater_interval_months,
+            days=settings.updater_interval_days,
+            hours=settings.updater_interval_hours,
+            minutes=settings.updater_interval_minutes,
+        )
 
-		# Input is an optional callback function. This function should take a
-		# bool input. If true: update ready, if false: no update ready.
-		updater.check_for_update_now(ui_refresh)
+        # Input is an optional callback function. This function should take a
+        # bool input. If true: update ready, if false: no update ready.
+        updater.check_for_update_now(ui_refresh)
 
-		return {'FINISHED'}
+        return {"FINISHED"}
 
 
 class AddonUpdaterUpdateNow(bpy.types.Operator):
-	bl_label = "Update " + updater.addon + " addon now"
-	bl_idname = updater.addon + ".updater_update_now"
-	bl_description = "Update to the latest version of the {x} addon".format(
-		x=updater.addon)
-	bl_options = {'REGISTER', 'INTERNAL'}
+    bl_label = "Update " + updater.addon + " addon now"
+    bl_idname = updater.addon + ".updater_update_now"
+    bl_description = "Update to the latest version of the {x} addon".format(
+        x=updater.addon
+    )
+    bl_options = {"REGISTER", "INTERNAL"}
 
-	# If true, run clean install - ie remove all files before adding new
-	# equivalent to deleting the addon and reinstalling, except the updater
-	# folder/backup folder remains.
-	clean_install = bpy.props.BoolProperty(
-		name="Clean install",
-		description=("If enabled, completely clear the addon's folder before "
-					 "installing new update, creating a fresh install"),
-		default=False,
-		options={'HIDDEN'}
-	)
+    # If true, run clean install - ie remove all files before adding new
+    # equivalent to deleting the addon and reinstalling, except the updater
+    # folder/backup folder remains.
+    clean_install = bpy.props.BoolProperty(
+        name="Clean install",
+        description=(
+            "If enabled, completely clear the addon's folder before "
+            "installing new update, creating a fresh install"
+        ),
+        default=False,
+        options={"HIDDEN"},
+    )
 
-	track_function = "install_update"
-	track_param = None
-	@tracking.report_error
-	def execute(self, context):
+    track_function = "install_update"
+    track_param = None
 
-		# in case of error importing updater
-		if updater.invalid_updater:
-			return {'CANCELLED'}
+    @tracking.report_error
+    def execute(self, context):
+        # in case of error importing updater
+        if updater.invalid_updater:
+            return {"CANCELLED"}
 
-		if updater.manual_only:
-			bpy.ops.wm.url_open(url=updater.website)
-		if updater.update_ready:
-			# if it fails, offer to open the website instead
-			try:
-				res = updater.run_update(force=False,
-										 callback=post_update_callback,
-										 clean=self.clean_install)
+        if updater.manual_only:
+            bpy.ops.wm.url_open(url=updater.website)
+        if updater.update_ready:
+            # if it fails, offer to open the website instead
+            try:
+                res = updater.run_update(
+                    force=False, callback=post_update_callback, clean=self.clean_install
+                )
 
-				# Should return 0, if not something happened.
-				if updater.verbose:
-					if res == 0:
-						print("Updater returned successful")
-					else:
-						print("Updater error response: {}".format(res))
-			except Exception as expt:
-				updater._error = "Error trying to run update"
-				updater._error_msg = str(expt)
-				updater.print_trace()
-				atr = AddonUpdaterInstallManually.bl_idname.split(".")
-				getattr(getattr(bpy.ops, atr[0]), atr[1])('INVOKE_DEFAULT')
-		elif updater.update_ready is None:
-			(update_ready, version, link) = updater.check_for_update(now=True)
-			# Re-launch this dialog.
-			atr = AddonUpdaterInstallPopup.bl_idname.split(".")
-			getattr(getattr(bpy.ops, atr[0]), atr[1])('INVOKE_DEFAULT')
+                # Should return 0, if not something happened.
+                if updater.verbose:
+                    if res == 0:
+                        print("Updater returned successful")
+                    else:
+                        print("Updater error response: {}".format(res))
+            except Exception as expt:
+                updater._error = "Error trying to run update"
+                updater._error_msg = str(expt)
+                updater.print_trace()
+                atr = AddonUpdaterInstallManually.bl_idname.split(".")
+                getattr(getattr(bpy.ops, atr[0]), atr[1])("INVOKE_DEFAULT")
+        elif updater.update_ready is None:
+            (update_ready, version, link) = updater.check_for_update(now=True)
+            # Re-launch this dialog.
+            atr = AddonUpdaterInstallPopup.bl_idname.split(".")
+            getattr(getattr(bpy.ops, atr[0]), atr[1])("INVOKE_DEFAULT")
 
-		elif not updater.update_ready:
-			self.report({'INFO'}, "Nothing to update")
-			return {'CANCELLED'}
-		else:
-			self.report(
-				{'ERROR'}, "Encountered a problem while trying to update")
-			return {'CANCELLED'}
+        elif not updater.update_ready:
+            self.report({"INFO"}, "Nothing to update")
+            return {"CANCELLED"}
+        else:
+            self.report({"ERROR"}, "Encountered a problem while trying to update")
+            return {"CANCELLED"}
 
-		return {'FINISHED'}
+        return {"FINISHED"}
 
 
 class AddonUpdaterUpdateTarget(bpy.types.Operator):
-	bl_label = updater.addon + " version target"
-	bl_idname = updater.addon + ".updater_update_target"
-	bl_description = "Install a targeted version of the {x} addon".format(
-		x=updater.addon)
-	bl_options = {'REGISTER', 'INTERNAL'}
+    bl_label = updater.addon + " version target"
+    bl_idname = updater.addon + ".updater_update_target"
+    bl_description = "Install a targeted version of the {x} addon".format(
+        x=updater.addon
+    )
+    bl_options = {"REGISTER", "INTERNAL"}
 
-	def target_version(self, context):
-		# In case of error importing updater.
-		if updater.invalid_updater:
-			ret = []
+    def target_version(self, context):
+        # In case of error importing updater.
+        if updater.invalid_updater:
+            ret = []
 
-		ret = []
-		i = 0
-		for tag in updater.tags:
-			ret.append((tag, tag, "Select to install " + tag))
-			i += 1
-		return ret
+        ret = []
+        i = 0
+        for tag in updater.tags:
+            ret.append((tag, tag, "Select to install " + tag))
+            i += 1
+        return ret
 
-	target = bpy.props.EnumProperty(
-		name="Target version to install",
-		description="Select the version to install",
-		items=target_version
-	)
+    target = bpy.props.EnumProperty(
+        name="Target version to install",
+        description="Select the version to install",
+        items=target_version,
+    )
 
-	# If true, run clean install - ie remove all files before adding new
-	# equivalent to deleting the addon and reinstalling, except the
-	# updater folder/backup folder remains.
-	clean_install = bpy.props.BoolProperty(
-		name="Clean install",
-		description=("If enabled, completely clear the addon's folder before "
-					 "installing new update, creating a fresh install"),
-		default=False,
-		options={'HIDDEN'}
-	)
+    # If true, run clean install - ie remove all files before adding new
+    # equivalent to deleting the addon and reinstalling, except the
+    # updater folder/backup folder remains.
+    clean_install = bpy.props.BoolProperty(
+        name="Clean install",
+        description=(
+            "If enabled, completely clear the addon's folder before "
+            "installing new update, creating a fresh install"
+        ),
+        default=False,
+        options={"HIDDEN"},
+    )
 
-	@classmethod
-	def poll(cls, context):
-		if updater.invalid_updater:
-			return False
-		return updater.update_ready is not None and len(updater.tags) > 0
+    @classmethod
+    def poll(cls, context):
+        if updater.invalid_updater:
+            return False
+        return updater.update_ready is not None and len(updater.tags) > 0
 
-	def invoke(self, context, event):
-		return context.window_manager.invoke_props_dialog(self)
+    def invoke(self, context, event):
+        return context.window_manager.invoke_props_dialog(self)
 
-	def draw(self, context):
-		layout = self.layout
-		if updater.invalid_updater:
-			layout.label(text="Updater error")
-			return
-		split = layout_split(layout, factor=0.5)
-		sub_col = split.column()
-		sub_col.label(text="Select install version")
-		sub_col = split.column()
-		sub_col.prop(self, "target", text="")
+    def draw(self, context):
+        layout = self.layout
+        if updater.invalid_updater:
+            layout.label(text="Updater error")
+            return
+        split = layout_split(layout, factor=0.5)
+        sub_col = split.column()
+        sub_col.label(text="Select install version")
+        sub_col = split.column()
+        sub_col.prop(self, "target", text="")
 
-	track_function = "install_update_target"
-	track_param = None
-	@tracking.report_error
-	def execute(self, context):
-		# In case of error importing updater.
-		if updater.invalid_updater:
-			return {'CANCELLED'}
+    track_function = "install_update_target"
+    track_param = None
 
-		self.track_param = str(self.target)
-		if len(self.track_param) > 13:
-			self.track_param = self.track_param[:13]
+    @tracking.report_error
+    def execute(self, context):
+        # In case of error importing updater.
+        if updater.invalid_updater:
+            return {"CANCELLED"}
 
-		res = updater.run_update(
-			force=False,
-			revert_tag=self.target,
-			callback=post_update_callback,
-			clean=self.clean_install)
+        self.track_param = str(self.target)
+        if len(self.track_param) > 13:
+            self.track_param = self.track_param[:13]
 
-		# Should return 0, if not something happened.
-		if res == 0:
-			updater.print_verbose("Updater returned successful")
-		else:
-			updater.print_verbose(
-				"Updater returned {}, , error occurred".format(res))
-			return {'CANCELLED'}
+        res = updater.run_update(
+            force=False,
+            revert_tag=self.target,
+            callback=post_update_callback,
+            clean=self.clean_install,
+        )
 
-		self.track_param = str(self.target)
-		if len(self.track_param) > 13:
-			self.track_param = self.track_param[:13]
+        # Should return 0, if not something happened.
+        if res == 0:
+            updater.print_verbose("Updater returned successful")
+        else:
+            updater.print_verbose("Updater returned {}, , error occurred".format(res))
+            return {"CANCELLED"}
 
-		return {'FINISHED'}
+        self.track_param = str(self.target)
+        if len(self.track_param) > 13:
+            self.track_param = self.track_param[:13]
+
+        return {"FINISHED"}
 
 
 class AddonUpdaterInstallManually(bpy.types.Operator):
-	"""As a fallback, direct the user to download the addon manually"""
-	bl_label = "Install update manually"
-	bl_idname = updater.addon + ".updater_install_manually"
-	bl_description = "Proceed to manually install update"
-	bl_options = {'REGISTER', 'INTERNAL'}
+    """As a fallback, direct the user to download the addon manually"""
 
-	error = bpy.props.StringProperty(
-		name="Error Occurred",
-		default="",
-		options={'HIDDEN'}
-	)
+    bl_label = "Install update manually"
+    bl_idname = updater.addon + ".updater_install_manually"
+    bl_description = "Proceed to manually install update"
+    bl_options = {"REGISTER", "INTERNAL"}
 
-	def invoke(self, context, event):
-		return context.window_manager.invoke_popup(self)
+    error = bpy.props.StringProperty(
+        name="Error Occurred", default="", options={"HIDDEN"}
+    )
 
-	def draw(self, context):
-		layout = self.layout
+    def invoke(self, context, event):
+        return context.window_manager.invoke_popup(self)
 
-		if updater.invalid_updater:
-			layout.label(text="Updater error")
-			return
+    def draw(self, context):
+        layout = self.layout
 
-		# Display error if a prior autoamted install failed.
-		if self.error != "":
-			col = layout.column()
-			col.scale_y = 0.7
-			col.label(text="There was an issue trying to auto-install",
-					  icon="ERROR")
-			col.label(text="Press the download button below and install",
-					  icon="BLANK1")
-			col.label(text="the zip file like a normal addon.", icon="BLANK1")
-		else:
-			col = layout.column()
-			col.scale_y = 0.7
-			col.label(text="Install the addon manually")
-			col.label(text="Press the download button below and install")
-			col.label(text="the zip file like a normal addon.")
+        if updater.invalid_updater:
+            layout.label(text="Updater error")
+            return
 
-		# If check hasn't happened, i.e. accidentally called this menu,
-		# allow to check here.
+        # Display error if a prior autoamted install failed.
+        if self.error != "":
+            col = layout.column()
+            col.scale_y = 0.7
+            col.label(text="There was an issue trying to auto-install", icon="ERROR")
+            col.label(text="Press the download button below and install", icon="BLANK1")
+            col.label(text="the zip file like a normal addon.", icon="BLANK1")
+        else:
+            col = layout.column()
+            col.scale_y = 0.7
+            col.label(text="Install the addon manually")
+            col.label(text="Press the download button below and install")
+            col.label(text="the zip file like a normal addon.")
 
-		row = layout.row()
+        # If check hasn't happened, i.e. accidentally called this menu,
+        # allow to check here.
 
-		if updater.update_link is not None:
-			row.operator(
-				"wm.url_open",
-				text="Direct download").url = updater.update_link
-		else:
-			row.operator(
-				"wm.url_open",
-				text="(failed to retrieve direct download)")
-			row.enabled = False
+        row = layout.row()
 
-			if updater.website is not None:
-				row = layout.row()
-				ops = row.operator("wm.url_open", text="Open website")
-				ops.url = updater.website
-			else:
-				row = layout.row()
-				row.label(text="See source website to download the update")
+        if updater.update_link is not None:
+            row.operator(
+                "wm.url_open", text="Direct download"
+            ).url = updater.update_link
+        else:
+            row.operator("wm.url_open", text="(failed to retrieve direct download)")
+            row.enabled = False
 
-	def execute(self, context):
-		return {'FINISHED'}
+            if updater.website is not None:
+                row = layout.row()
+                ops = row.operator("wm.url_open", text="Open website")
+                ops.url = updater.website
+            else:
+                row = layout.row()
+                row.label(text="See source website to download the update")
+
+    def execute(self, context):
+        return {"FINISHED"}
 
 
 class AddonUpdaterUpdatedSuccessful(bpy.types.Operator):
-	"""Addon in place, popup telling user it completed or what went wrong"""
-	bl_label = "Installation Report"
-	bl_idname = updater.addon + ".updater_update_successful"
-	bl_description = "Update installation response"
-	bl_options = {'REGISTER', 'INTERNAL', 'UNDO'}
+    """Addon in place, popup telling user it completed or what went wrong"""
 
-	error = bpy.props.StringProperty(
-		name="Error Occurred",
-		default="",
-		options={'HIDDEN'}
-	)
+    bl_label = "Installation Report"
+    bl_idname = updater.addon + ".updater_update_successful"
+    bl_description = "Update installation response"
+    bl_options = {"REGISTER", "INTERNAL", "UNDO"}
 
-	def invoke(self, context, event):
-		return context.window_manager.invoke_props_popup(self, event)
+    error = bpy.props.StringProperty(
+        name="Error Occurred", default="", options={"HIDDEN"}
+    )
 
-	def draw(self, context):
-		layout = self.layout
+    def invoke(self, context, event):
+        return context.window_manager.invoke_props_popup(self, event)
 
-		if updater.invalid_updater:
-			layout.label(text="Updater error")
-			return
+    def draw(self, context):
+        layout = self.layout
 
-		saved = updater.json
-		if self.error != "":
-			col = layout.column()
-			col.scale_y = 0.7
-			col.label(text="Error occurred, did not install", icon="ERROR")
-			if updater.error_msg:
-				msg = updater.error_msg
-			else:
-				msg = self.error
-			col.label(text=str(msg), icon="BLANK1")
-			rw = col.row()
-			rw.scale_y = 2
-			rw.operator(
-				"wm.url_open",
-				text="Click for manual download.",
-				icon="BLANK1").url = updater.website
-		elif not updater.auto_reload_post_update:
-			# Tell user to restart blender after an update/restore!
-			if "just_restored" in saved and saved["just_restored"]:
-				col = layout.column()
-				col.label(text="Addon restored", icon="RECOVER_LAST")
-				alert_row = col.row()
-				alert_row.alert = True
-				alert_row.operator(
-					"wm.quit_blender",
-					text="Restart blender to reload",
-					icon="BLANK1")
-				updater.json_reset_restore()
-			else:
-				col = layout.column()
-				col.label(
-					text="Addon successfully installed", icon="FILE_TICK")
-				alert_row = col.row()
-				alert_row.alert = True
-				alert_row.operator(
-					"wm.quit_blender",
-					text="Restart blender to reload",
-					icon="BLANK1")
+        if updater.invalid_updater:
+            layout.label(text="Updater error")
+            return
 
-		else:
-			# reload addon, but still recommend they restart blender
-			if "just_restored" in saved and saved["just_restored"]:
-				col = layout.column()
-				col.scale_y = 0.7
-				col.label(text="Addon restored", icon="RECOVER_LAST")
-				col.label(
-					text="Consider restarting blender to fully reload.",
-					icon="BLANK1")
-				updater.json_reset_restore()
-			else:
-				col = layout.column()
-				col.scale_y = 0.7
-				col.label(
-					text="Addon successfully installed", icon="FILE_TICK")
-				col.label(
-					text="Consider restarting blender to fully reload.",
-					icon="BLANK1")
+        saved = updater.json
+        if self.error != "":
+            col = layout.column()
+            col.scale_y = 0.7
+            col.label(text="Error occurred, did not install", icon="ERROR")
+            if updater.error_msg:
+                msg = updater.error_msg
+            else:
+                msg = self.error
+            col.label(text=str(msg), icon="BLANK1")
+            rw = col.row()
+            rw.scale_y = 2
+            rw.operator(
+                "wm.url_open", text="Click for manual download.", icon="BLANK1"
+            ).url = updater.website
+        elif not updater.auto_reload_post_update:
+            # Tell user to restart blender after an update/restore!
+            if "just_restored" in saved and saved["just_restored"]:
+                col = layout.column()
+                col.label(text="Addon restored", icon="RECOVER_LAST")
+                alert_row = col.row()
+                alert_row.alert = True
+                alert_row.operator(
+                    "wm.quit_blender", text="Restart blender to reload", icon="BLANK1"
+                )
+                updater.json_reset_restore()
+            else:
+                col = layout.column()
+                col.label(text="Addon successfully installed", icon="FILE_TICK")
+                alert_row = col.row()
+                alert_row.alert = True
+                alert_row.operator(
+                    "wm.quit_blender", text="Restart blender to reload", icon="BLANK1"
+                )
 
-	def execute(self, context):
-		return {'FINISHED'}
+        else:
+            # reload addon, but still recommend they restart blender
+            if "just_restored" in saved and saved["just_restored"]:
+                col = layout.column()
+                col.scale_y = 0.7
+                col.label(text="Addon restored", icon="RECOVER_LAST")
+                col.label(
+                    text="Consider restarting blender to fully reload.", icon="BLANK1"
+                )
+                updater.json_reset_restore()
+            else:
+                col = layout.column()
+                col.scale_y = 0.7
+                col.label(text="Addon successfully installed", icon="FILE_TICK")
+                col.label(
+                    text="Consider restarting blender to fully reload.", icon="BLANK1"
+                )
+
+    def execute(self, context):
+        return {"FINISHED"}
 
 
 class AddonUpdaterRestoreBackup(bpy.types.Operator):
-	"""Restore addon from backup"""
-	bl_label = "Restore backup"
-	bl_idname = updater.addon + ".updater_restore_backup"
-	bl_description = "Restore addon from backup"
-	bl_options = {'REGISTER', 'INTERNAL'}
+    """Restore addon from backup"""
 
-	@classmethod
-	def poll(cls, context):
-		try:
-			return os.path.isdir(os.path.join(updater.stage_path, "backup"))
-		except:
-			return False
+    bl_label = "Restore backup"
+    bl_idname = updater.addon + ".updater_restore_backup"
+    bl_description = "Restore addon from backup"
+    bl_options = {"REGISTER", "INTERNAL"}
 
-	@tracking.report_error
-	def execute(self, context):
-		# in case of error importing updater
-		if updater.invalid_updater:
-			return {'CANCELLED'}
-		updater.restore_backup()
-		return {'FINISHED'}
+    @classmethod
+    def poll(cls, context):
+        try:
+            return os.path.isdir(os.path.join(updater.stage_path, "backup"))
+        except:
+            return False
+
+    @tracking.report_error
+    def execute(self, context):
+        # in case of error importing updater
+        if updater.invalid_updater:
+            return {"CANCELLED"}
+        updater.restore_backup()
+        return {"FINISHED"}
 
 
 class AddonUpdaterIgnore(bpy.types.Operator):
-	"""Ignore update to prevent future popups"""
-	bl_label = "Ignore update"
-	bl_idname = updater.addon + ".updater_ignore"
-	bl_description = "Ignore update to prevent future popups"
-	bl_options = {'REGISTER', 'INTERNAL'}
+    """Ignore update to prevent future popups"""
 
-	@classmethod
-	def poll(cls, context):
-		if updater.invalid_updater:
-			return False
-		elif updater.update_ready:
-			return True
-		else:
-			return False
+    bl_label = "Ignore update"
+    bl_idname = updater.addon + ".updater_ignore"
+    bl_description = "Ignore update to prevent future popups"
+    bl_options = {"REGISTER", "INTERNAL"}
 
-	@tracking.report_error
-	def execute(self, context):
-		# in case of error importing updater
-		if updater.invalid_updater:
-			return {'CANCELLED'}
-		updater.ignore_update()
-		self.report({"INFO"}, "Open addon preferences for updater options")
-		return {'FINISHED'}
+    @classmethod
+    def poll(cls, context):
+        if updater.invalid_updater:
+            return False
+        elif updater.update_ready:
+            return True
+        else:
+            return False
+
+    @tracking.report_error
+    def execute(self, context):
+        # in case of error importing updater
+        if updater.invalid_updater:
+            return {"CANCELLED"}
+        updater.ignore_update()
+        self.report({"INFO"}, "Open addon preferences for updater options")
+        return {"FINISHED"}
 
 
 class AddonUpdaterEndBackground(bpy.types.Operator):
-	"""Stop checking for update in the background"""
-	bl_label = "End background check"
-	bl_idname = updater.addon + ".end_background_check"
-	bl_description = "Stop checking for update in the background"
-	bl_options = {'REGISTER', 'INTERNAL'}
+    """Stop checking for update in the background"""
 
-	def execute(self, context):
-		# in case of error importing updater
-		if updater.invalid_updater:
-			return {'CANCELLED'}
-		updater.stop_async_check_update()
-		return {'FINISHED'}
+    bl_label = "End background check"
+    bl_idname = updater.addon + ".end_background_check"
+    bl_description = "Stop checking for update in the background"
+    bl_options = {"REGISTER", "INTERNAL"}
+
+    def execute(self, context):
+        # in case of error importing updater
+        if updater.invalid_updater:
+            return {"CANCELLED"}
+        updater.stop_async_check_update()
+        return {"FINISHED"}
 
 
 # -----------------------------------------------------------------------------
@@ -662,769 +666,770 @@ ran_background_check = False
 
 @persistent
 def updater_run_success_popup_handler(scene):
-	global ran_update_success_popup
-	ran_update_success_popup = True
+    global ran_update_success_popup
+    ran_update_success_popup = True
 
-	# in case of error importing updater
-	if updater.invalid_updater:
-		return
+    # in case of error importing updater
+    if updater.invalid_updater:
+        return
 
-	try:
-		if "scene_update_post" in dir(bpy.app.handlers):
-			bpy.app.handlers.scene_update_post.remove(
-				updater_run_success_popup_handler)
-		else:
-			bpy.app.handlers.depsgraph_update_post.remove(
-				updater_run_success_popup_handler)
-	except:
-		pass
+    try:
+        if "scene_update_post" in dir(bpy.app.handlers):
+            bpy.app.handlers.scene_update_post.remove(updater_run_success_popup_handler)
+        else:
+            bpy.app.handlers.depsgraph_update_post.remove(
+                updater_run_success_popup_handler
+            )
+    except:
+        pass
 
-	atr = AddonUpdaterUpdatedSuccessful.bl_idname.split(".")
-	getattr(getattr(bpy.ops, atr[0]), atr[1])('INVOKE_DEFAULT')
+    atr = AddonUpdaterUpdatedSuccessful.bl_idname.split(".")
+    getattr(getattr(bpy.ops, atr[0]), atr[1])("INVOKE_DEFAULT")
 
 
 @persistent
 def updater_run_install_popup_handler(scene):
-	global ran_auto_check_install_popup
-	ran_auto_check_install_popup = True
-	updater.print_verbose("Running the install popup handler.")
+    global ran_auto_check_install_popup
+    ran_auto_check_install_popup = True
+    updater.print_verbose("Running the install popup handler.")
 
-	# in case of error importing updater
-	if updater.invalid_updater:
-		return
+    # in case of error importing updater
+    if updater.invalid_updater:
+        return
 
-	try:
-		if "scene_update_post" in dir(bpy.app.handlers):
-			bpy.app.handlers.scene_update_post.remove(
-				updater_run_install_popup_handler)
-		else:
-			bpy.app.handlers.depsgraph_update_post.remove(
-				updater_run_install_popup_handler)
-	except:
-		pass
+    try:
+        if "scene_update_post" in dir(bpy.app.handlers):
+            bpy.app.handlers.scene_update_post.remove(updater_run_install_popup_handler)
+        else:
+            bpy.app.handlers.depsgraph_update_post.remove(
+                updater_run_install_popup_handler
+            )
+    except:
+        pass
 
-	if "ignore" in updater.json and updater.json["ignore"]:
-		return  # Don't do popup if ignore pressed.
-	elif "version_text" in updater.json and updater.json["version_text"].get("version"):
-		version = updater.json["version_text"]["version"]
-		ver_tuple = updater.version_tuple_from_text(version)
+    if "ignore" in updater.json and updater.json["ignore"]:
+        return  # Don't do popup if ignore pressed.
+    elif "version_text" in updater.json and updater.json["version_text"].get("version"):
+        version = updater.json["version_text"]["version"]
+        ver_tuple = updater.version_tuple_from_text(version)
 
-		if ver_tuple < updater.current_version:
-			# User probably manually installed to get the up to date addon
-			# in here. Clear out the update flag using this function.
-			updater.print_verbose(
-				"{} updater: appears user updated, clearing flag".format(
-					updater.addon))
-			updater.json_reset_restore()
-			return
-	atr = AddonUpdaterInstallPopup.bl_idname.split(".")
-	getattr(getattr(bpy.ops, atr[0]), atr[1])('INVOKE_DEFAULT')
+        if ver_tuple < updater.current_version:
+            # User probably manually installed to get the up to date addon
+            # in here. Clear out the update flag using this function.
+            updater.print_verbose(
+                "{} updater: appears user updated, clearing flag".format(updater.addon)
+            )
+            updater.json_reset_restore()
+            return
+    atr = AddonUpdaterInstallPopup.bl_idname.split(".")
+    getattr(getattr(bpy.ops, atr[0]), atr[1])("INVOKE_DEFAULT")
 
 
 def background_update_callback(update_ready):
-	"""Passed into the updater, background thread updater"""
-	global ran_auto_check_install_popup
-	updater.print_verbose("Running background update callback")
+    """Passed into the updater, background thread updater"""
+    global ran_auto_check_install_popup
+    updater.print_verbose("Running background update callback")
 
-	# In case of error importing updater.
-	if updater.invalid_updater:
-		return
-	if not updater.show_popups:
-		return
-	if not update_ready:
-		return
+    # In case of error importing updater.
+    if updater.invalid_updater:
+        return
+    if not updater.show_popups:
+        return
+    if not update_ready:
+        return
 
-	# See if we need add to the update handler to trigger the popup.
-	handlers = []
-	if "scene_update_post" in dir(bpy.app.handlers):  # 2.7x
-		handlers = bpy.app.handlers.scene_update_post
-	else:  # 2.8+
-		handlers = bpy.app.handlers.depsgraph_update_post
-	in_handles = updater_run_install_popup_handler in handlers
+    # See if we need add to the update handler to trigger the popup.
+    handlers = []
+    if "scene_update_post" in dir(bpy.app.handlers):  # 2.7x
+        handlers = bpy.app.handlers.scene_update_post
+    else:  # 2.8+
+        handlers = bpy.app.handlers.depsgraph_update_post
+    in_handles = updater_run_install_popup_handler in handlers
 
-	if in_handles or ran_auto_check_install_popup:
-		return
+    if in_handles or ran_auto_check_install_popup:
+        return
 
-	if "scene_update_post" in dir(bpy.app.handlers):  # 2.7x
-		bpy.app.handlers.scene_update_post.append(
-			updater_run_install_popup_handler)
-	else:  # 2.8+
-		bpy.app.handlers.depsgraph_update_post.append(
-			updater_run_install_popup_handler)
-	ran_auto_check_install_popup = True
-	updater.print_verbose("Attempted popup prompt")
+    if "scene_update_post" in dir(bpy.app.handlers):  # 2.7x
+        bpy.app.handlers.scene_update_post.append(updater_run_install_popup_handler)
+    else:  # 2.8+
+        bpy.app.handlers.depsgraph_update_post.append(updater_run_install_popup_handler)
+    ran_auto_check_install_popup = True
+    updater.print_verbose("Attempted popup prompt")
 
 
 def post_update_callback(module_name, res=None):
-	"""Callback for once the run_update function has completed.
+    """Callback for once the run_update function has completed.
 
-	Only makes sense to use this if "auto_reload_post_update" == False,
-	i.e. don't auto-restart the addon.
+    Only makes sense to use this if "auto_reload_post_update" == False,
+    i.e. don't auto-restart the addon.
 
-	Arguments:
-		module_name: returns the module name from updater, but unused here.
-		res: If an error occurred, this is the detail string.
-	"""
+    Arguments:
+            module_name: returns the module name from updater, but unused here.
+            res: If an error occurred, this is the detail string.
+    """
 
-	# In case of error importing updater.
-	if updater.invalid_updater:
-		return
+    # In case of error importing updater.
+    if updater.invalid_updater:
+        return
 
-	if res is None:
-		# This is the same code as in conditional at the end of the register
-		# function, ie if "auto_reload_post_update" == True, skip code.
-		updater.print_verbose(
-			"{} updater: Running post update callback".format(updater.addon))
+    if res is None:
+        # This is the same code as in conditional at the end of the register
+        # function, ie if "auto_reload_post_update" == True, skip code.
+        updater.print_verbose(
+            "{} updater: Running post update callback".format(updater.addon)
+        )
 
-		atr = AddonUpdaterUpdatedSuccessful.bl_idname.split(".")
-		getattr(getattr(bpy.ops, atr[0]), atr[1])('INVOKE_DEFAULT')
-		global ran_update_success_popup
-		ran_update_success_popup = True
-	else:
-		# Some kind of error occurred and it was unable to install, offer
-		# manual download instead.
-		atr = AddonUpdaterUpdatedSuccessful.bl_idname.split(".")
-		getattr(getattr(bpy.ops, atr[0]), atr[1])('INVOKE_DEFAULT', error=res)
-	return
+        atr = AddonUpdaterUpdatedSuccessful.bl_idname.split(".")
+        getattr(getattr(bpy.ops, atr[0]), atr[1])("INVOKE_DEFAULT")
+        global ran_update_success_popup
+        ran_update_success_popup = True
+    else:
+        # Some kind of error occurred and it was unable to install, offer
+        # manual download instead.
+        atr = AddonUpdaterUpdatedSuccessful.bl_idname.split(".")
+        getattr(getattr(bpy.ops, atr[0]), atr[1])("INVOKE_DEFAULT", error=res)
+    return
 
 
 def ui_refresh(update_status):
-	"""Redraw the ui once an async thread has completed"""
-	for windowManager in bpy.data.window_managers:
-		for window in windowManager.windows:
-			for area in window.screen.areas:
-				area.tag_redraw()
+    """Redraw the ui once an async thread has completed"""
+    for windowManager in bpy.data.window_managers:
+        for window in windowManager.windows:
+            for area in window.screen.areas:
+                area.tag_redraw()
 
 
 def check_for_update_background():
-	"""Function for asynchronous background check.
+    """Function for asynchronous background check.
 
-	*Could* be called on register, but would be bad practice as the bare
-	minimum code should run at the moment of registration (addon ticked).
-	"""
-	if updater.invalid_updater:
-		return
-	global ran_background_check
-	if ran_background_check:
-		# Global var ensures check only happens once.
-		return
-	elif updater.update_ready is not None or updater.async_checking:
-		# Check already happened.
-		# Used here to just avoid constant applying settings below.
-		return
+    *Could* be called on register, but would be bad practice as the bare
+    minimum code should run at the moment of registration (addon ticked).
+    """
+    if updater.invalid_updater:
+        return
+    global ran_background_check
+    if ran_background_check:
+        # Global var ensures check only happens once.
+        return
+    elif updater.update_ready is not None or updater.async_checking:
+        # Check already happened.
+        # Used here to just avoid constant applying settings below.
+        return
 
-	# Apply the UI settings.
-	settings = get_user_preferences(bpy.context)
-	if not settings:
-		return
-	updater.set_check_interval(enabled=settings.auto_check_update,
-							   months=settings.updater_interval_months,
-							   days=settings.updater_interval_days,
-							   hours=settings.updater_interval_hours,
-							   minutes=settings.updater_interval_minutes)
+    # Apply the UI settings.
+    settings = get_user_preferences(bpy.context)
+    if not settings:
+        return
+    updater.set_check_interval(
+        enabled=settings.auto_check_update,
+        months=settings.updater_interval_months,
+        days=settings.updater_interval_days,
+        hours=settings.updater_interval_hours,
+        minutes=settings.updater_interval_minutes,
+    )
 
-	# Input is an optional callback function. This function should take a bool
-	# input, if true: update ready, if false: no update ready.
-	updater.check_for_update_async(background_update_callback)
-	ran_background_check = True
+    # Input is an optional callback function. This function should take a bool
+    # input, if true: update ready, if false: no update ready.
+    updater.check_for_update_async(background_update_callback)
+    ran_background_check = True
 
 
 def check_for_update_nonthreaded(self, context):
-	"""Can be placed in front of other operators to launch when pressed"""
-	if updater.invalid_updater:
-		return
+    """Can be placed in front of other operators to launch when pressed"""
+    if updater.invalid_updater:
+        return
 
-	# Only check if it's ready, ie after the time interval specified should
-	# be the async wrapper call here.
-	settings = get_user_preferences(bpy.context)
-	if not settings:
-		if updater.verbose:
-			print("Could not get {} preferences, update check skipped".format(
-				__package__))
-		return
-	updater.set_check_interval(enabled=settings.auto_check_update,
-							   months=settings.updater_interval_months,
-							   days=settings.updater_interval_days,
-							   hours=settings.updater_interval_hours,
-							   minutes=settings.updater_interval_minutes)
+    # Only check if it's ready, ie after the time interval specified should
+    # be the async wrapper call here.
+    settings = get_user_preferences(bpy.context)
+    if not settings:
+        if updater.verbose:
+            print(
+                "Could not get {} preferences, update check skipped".format(__package__)
+            )
+        return
+    updater.set_check_interval(
+        enabled=settings.auto_check_update,
+        months=settings.updater_interval_months,
+        days=settings.updater_interval_days,
+        hours=settings.updater_interval_hours,
+        minutes=settings.updater_interval_minutes,
+    )
 
-	(update_ready, version, link) = updater.check_for_update(now=False)
-	if update_ready:
-		atr = AddonUpdaterInstallPopup.bl_idname.split(".")
-		getattr(getattr(bpy.ops, atr[0]), atr[1])('INVOKE_DEFAULT')
-	else:
-		updater.print_verbose("No update ready")
-		self.report({'INFO'}, "No update ready")
+    (update_ready, version, link) = updater.check_for_update(now=False)
+    if update_ready:
+        atr = AddonUpdaterInstallPopup.bl_idname.split(".")
+        getattr(getattr(bpy.ops, atr[0]), atr[1])("INVOKE_DEFAULT")
+    else:
+        updater.print_verbose("No update ready")
+        self.report({"INFO"}, "No update ready")
 
 
 def show_reload_popup():
-	"""For use in register only, to show popup after re-enabling the addon.
+    """For use in register only, to show popup after re-enabling the addon.
 
-	Must be enabled by developer.
-	"""
-	if updater.invalid_updater:
-		return
-	saved_state = updater.json
-	global ran_update_success_popup
+    Must be enabled by developer.
+    """
+    if updater.invalid_updater:
+        return
+    saved_state = updater.json
+    global ran_update_success_popup
 
-	has_state = saved_state is not None
-	just_updated = "just_updated" in saved_state
-	updated_info = saved_state["just_updated"]
+    has_state = saved_state is not None
+    just_updated = "just_updated" in saved_state
+    updated_info = saved_state["just_updated"]
 
-	if not (has_state and just_updated and updated_info):
-		return
+    if not (has_state and just_updated and updated_info):
+        return
 
-	updater.json_reset_postupdate()  # So this only runs once.
+    updater.json_reset_postupdate()  # So this only runs once.
 
-	# No handlers in this case.
-	if not updater.auto_reload_post_update:
-		return
+    # No handlers in this case.
+    if not updater.auto_reload_post_update:
+        return
 
-	# See if we need add to the update handler to trigger the popup.
-	handlers = []
-	if "scene_update_post" in dir(bpy.app.handlers):  # 2.7x
-		handlers = bpy.app.handlers.scene_update_post
-	else:  # 2.8+
-		handlers = bpy.app.handlers.depsgraph_update_post
-	in_handles = updater_run_success_popup_handler in handlers
+    # See if we need add to the update handler to trigger the popup.
+    handlers = []
+    if "scene_update_post" in dir(bpy.app.handlers):  # 2.7x
+        handlers = bpy.app.handlers.scene_update_post
+    else:  # 2.8+
+        handlers = bpy.app.handlers.depsgraph_update_post
+    in_handles = updater_run_success_popup_handler in handlers
 
-	if in_handles or ran_update_success_popup:
-		return
+    if in_handles or ran_update_success_popup:
+        return
 
-	if "scene_update_post" in dir(bpy.app.handlers):  # 2.7x
-		bpy.app.handlers.scene_update_post.append(
-			updater_run_success_popup_handler)
-	else:  # 2.8+
-		bpy.app.handlers.depsgraph_update_post.append(
-			updater_run_success_popup_handler)
-	ran_update_success_popup = True
+    if "scene_update_post" in dir(bpy.app.handlers):  # 2.7x
+        bpy.app.handlers.scene_update_post.append(updater_run_success_popup_handler)
+    else:  # 2.8+
+        bpy.app.handlers.depsgraph_update_post.append(updater_run_success_popup_handler)
+    ran_update_success_popup = True
 
 
 # -----------------------------------------------------------------------------
 # Example UI integrations
 # -----------------------------------------------------------------------------
 def update_notice_box_ui(self, context):
-	"""Update notice draw, to add to the end or beginning of a panel.
+    """Update notice draw, to add to the end or beginning of a panel.
 
-	After a check for update has occurred, this function will draw a box
-	saying an update is ready, and give a button for: update now, open website,
-	or ignore popup. Ideal to be placed at the end / beginning of a panel.
-	"""
+    After a check for update has occurred, this function will draw a box
+    saying an update is ready, and give a button for: update now, open website,
+    or ignore popup. Ideal to be placed at the end / beginning of a panel.
+    """
 
-	if updater.invalid_updater:
-		return
+    if updater.invalid_updater:
+        return
 
-	saved_state = updater.json
-	if not updater.auto_reload_post_update:
-		if "just_updated" in saved_state and saved_state["just_updated"]:
-			layout = self.layout
-			box = layout.box()
-			col = box.column()
-			alert_row = col.row()
-			alert_row.alert = True
-			alert_row.operator(
-				"wm.quit_blender",
-				text="Restart blender",
-				icon="ERROR")
-			col.label(text="to complete update")
-			return
+    saved_state = updater.json
+    if not updater.auto_reload_post_update:
+        if "just_updated" in saved_state and saved_state["just_updated"]:
+            layout = self.layout
+            box = layout.box()
+            col = box.column()
+            alert_row = col.row()
+            alert_row.alert = True
+            alert_row.operator("wm.quit_blender", text="Restart blender", icon="ERROR")
+            col.label(text="to complete update")
+            return
 
-	# If user pressed ignore, don't draw the box.
-	if "ignore" in updater.json and updater.json["ignore"]:
-		return
-	if not updater.update_ready:
-		return
+    # If user pressed ignore, don't draw the box.
+    if "ignore" in updater.json and updater.json["ignore"]:
+        return
+    if not updater.update_ready:
+        return
 
-	layout = self.layout
-	box = layout.box()
-	col = box.column(align=True)
-	col.alert = True
-	col.label(text="Update ready!", icon="ERROR")
-	col.alert = False
-	col.separator()
-	row = col.row(align=True)
-	split = row.split(align=True)
-	colL = split.column(align=True)
-	colL.scale_y = 1.5
-	colL.operator(AddonUpdaterIgnore.bl_idname, icon="X", text="Ignore")
-	colR = split.column(align=True)
-	colR.scale_y = 1.5
-	if not updater.manual_only:
-		colR.operator(AddonUpdaterUpdateNow.bl_idname,
-					  text="Update", icon="LOOP_FORWARDS")
-		col.operator("wm.url_open", text="Open website").url = updater.website
-		# ops = col.operator("wm.url_open",text="Direct download")
-		# ops.url=updater.update_link
-		col.operator(AddonUpdaterInstallManually.bl_idname,
-					 text="Install manually")
-	else:
-		# ops = col.operator("wm.url_open", text="Direct download")
-		# ops.url=updater.update_link
-		col.operator("wm.url_open", text="Get it now").url = updater.website
+    layout = self.layout
+    box = layout.box()
+    col = box.column(align=True)
+    col.alert = True
+    col.label(text="Update ready!", icon="ERROR")
+    col.alert = False
+    col.separator()
+    row = col.row(align=True)
+    split = row.split(align=True)
+    colL = split.column(align=True)
+    colL.scale_y = 1.5
+    colL.operator(AddonUpdaterIgnore.bl_idname, icon="X", text="Ignore")
+    colR = split.column(align=True)
+    colR.scale_y = 1.5
+    if not updater.manual_only:
+        colR.operator(
+            AddonUpdaterUpdateNow.bl_idname, text="Update", icon="LOOP_FORWARDS"
+        )
+        col.operator("wm.url_open", text="Open website").url = updater.website
+        # ops = col.operator("wm.url_open",text="Direct download")
+        # ops.url=updater.update_link
+        col.operator(AddonUpdaterInstallManually.bl_idname, text="Install manually")
+    else:
+        # ops = col.operator("wm.url_open", text="Direct download")
+        # ops.url=updater.update_link
+        col.operator("wm.url_open", text="Get it now").url = updater.website
 
 
 def update_settings_ui(self, context, element=None):
-	"""Preferences - for drawing with full width inside user preferences
+    """Preferences - for drawing with full width inside user preferences
 
-	A function that can be run inside user preferences panel for prefs UI.
-	Place inside UI draw using:
-		addon_updater_ops.update_settings_ui(self, context)
-	or by:
-		addon_updater_ops.update_settings_ui(context)
-	"""
+    A function that can be run inside user preferences panel for prefs UI.
+    Place inside UI draw using:
+            addon_updater_ops.update_settings_ui(self, context)
+    or by:
+            addon_updater_ops.update_settings_ui(context)
+    """
 
-	# Element is a UI element, such as layout, a row, column, or box.
-	if element is None:
-		element = self.layout
-	box = element.box()
+    # Element is a UI element, such as layout, a row, column, or box.
+    if element is None:
+        element = self.layout
+    box = element.box()
 
-	# In case of error importing updater.
-	if updater.invalid_updater:
-		box.label(text="Error initializing updater code:")
-		box.label(text=updater.error_msg)
-		return
-	settings = get_user_preferences(context)
-	if not settings:
-		box.label(text="Error getting updater preferences", icon='ERROR')
-		return
+    # In case of error importing updater.
+    if updater.invalid_updater:
+        box.label(text="Error initializing updater code:")
+        box.label(text=updater.error_msg)
+        return
+    settings = get_user_preferences(context)
+    if not settings:
+        box.label(text="Error getting updater preferences", icon="ERROR")
+        return
 
-	# auto-update settings
-	box.label(text="Updater Settings")
-	row = box.row()
+    # auto-update settings
+    box.label(text="Updater Settings")
+    row = box.row()
 
-	# special case to tell user to restart blender, if set that way
-	if not updater.auto_reload_post_update:
-		saved_state = updater.json
-		if "just_updated" in saved_state and saved_state["just_updated"]:
-			row.alert = True
-			row.operator("wm.quit_blender",
-						 text="Restart blender to complete update",
-						 icon="ERROR")
-			return
+    # special case to tell user to restart blender, if set that way
+    if not updater.auto_reload_post_update:
+        saved_state = updater.json
+        if "just_updated" in saved_state and saved_state["just_updated"]:
+            row.alert = True
+            row.operator(
+                "wm.quit_blender",
+                text="Restart blender to complete update",
+                icon="ERROR",
+            )
+            return
 
-	split = layout_split(row, factor=0.4)
-	sub_col = split.column()
-	sub_col.prop(settings, "auto_check_update")
-	sub_col = split.column()
+    split = layout_split(row, factor=0.4)
+    sub_col = split.column()
+    sub_col.prop(settings, "auto_check_update")
+    sub_col = split.column()
 
-	if not settings.auto_check_update:
-		sub_col.enabled = False
-	sub_row = sub_col.row()
-	sub_row.label(text="Interval between checks")
-	sub_row = sub_col.row(align=True)
-	check_col = sub_row.column(align=True)
-	check_col.prop(settings, "updater_interval_months")
-	check_col = sub_row.column(align=True)
-	check_col.prop(settings, "updater_interval_days")
-	check_col = sub_row.column(align=True)
+    if not settings.auto_check_update:
+        sub_col.enabled = False
+    sub_row = sub_col.row()
+    sub_row.label(text="Interval between checks")
+    sub_row = sub_col.row(align=True)
+    check_col = sub_row.column(align=True)
+    check_col.prop(settings, "updater_interval_months")
+    check_col = sub_row.column(align=True)
+    check_col.prop(settings, "updater_interval_days")
+    check_col = sub_row.column(align=True)
 
-	# Consider un-commenting for local dev (e.g. to set shorter intervals)
-	# check_col.prop(settings,"updater_interval_hours")
-	# check_col = sub_row.column(align=True)
-	# check_col.prop(settings,"updater_interval_minutes")
+    # Consider un-commenting for local dev (e.g. to set shorter intervals)
+    # check_col.prop(settings,"updater_interval_hours")
+    # check_col = sub_row.column(align=True)
+    # check_col.prop(settings,"updater_interval_minutes")
 
-	# Checking / managing updates.
-	row = box.row()
-	col = row.column()
-	if updater.error is not None:
-		sub_col = col.row(align=True)
-		sub_col.scale_y = 1
-		split = sub_col.split(align=True)
-		split.scale_y = 2
-		if "ssl" in updater.error_msg.lower():
-			split.enabled = True
-			split.operator(AddonUpdaterInstallManually.bl_idname,
-						   text=updater.error)
-		else:
-			split.enabled = False
-			split.operator(AddonUpdaterCheckNow.bl_idname,
-						   text=updater.error)
-		split = sub_col.split(align=True)
-		split.scale_y = 2
-		split.operator(AddonUpdaterCheckNow.bl_idname,
-					   text="", icon="FILE_REFRESH")
+    # Checking / managing updates.
+    row = box.row()
+    col = row.column()
+    if updater.error is not None:
+        sub_col = col.row(align=True)
+        sub_col.scale_y = 1
+        split = sub_col.split(align=True)
+        split.scale_y = 2
+        if "ssl" in updater.error_msg.lower():
+            split.enabled = True
+            split.operator(AddonUpdaterInstallManually.bl_idname, text=updater.error)
+        else:
+            split.enabled = False
+            split.operator(AddonUpdaterCheckNow.bl_idname, text=updater.error)
+        split = sub_col.split(align=True)
+        split.scale_y = 2
+        split.operator(AddonUpdaterCheckNow.bl_idname, text="", icon="FILE_REFRESH")
 
-	elif updater.update_ready is None and not updater.async_checking:
-		col.scale_y = 2
-		col.operator(AddonUpdaterCheckNow.bl_idname)
-	elif updater.update_ready is None:  # async is running
-		sub_col = col.row(align=True)
-		sub_col.scale_y = 1
-		split = sub_col.split(align=True)
-		split.enabled = False
-		split.scale_y = 2
-		split.operator(AddonUpdaterCheckNow.bl_idname, text="Checking...")
-		split = sub_col.split(align=True)
-		split.scale_y = 2
-		split.operator(AddonUpdaterEndBackground.bl_idname, text="", icon="X")
+    elif updater.update_ready is None and not updater.async_checking:
+        col.scale_y = 2
+        col.operator(AddonUpdaterCheckNow.bl_idname)
+    elif updater.update_ready is None:  # async is running
+        sub_col = col.row(align=True)
+        sub_col.scale_y = 1
+        split = sub_col.split(align=True)
+        split.enabled = False
+        split.scale_y = 2
+        split.operator(AddonUpdaterCheckNow.bl_idname, text="Checking...")
+        split = sub_col.split(align=True)
+        split.scale_y = 2
+        split.operator(AddonUpdaterEndBackground.bl_idname, text="", icon="X")
 
-	elif updater.include_branches and \
-			len(updater.tags) == len(updater.include_branch_list) and not \
-			updater.manual_only:
-		# No releases found, but still show the appropriate branch.
-		sub_col = col.row(align=True)
-		sub_col.scale_y = 1
-		split = sub_col.split(align=True)
-		split.scale_y = 2
-		update_now_txt = "Update directly to {}".format(
-			updater.include_branch_list[0])
-		split.operator(AddonUpdaterUpdateNow.bl_idname, text=update_now_txt)
-		split = sub_col.split(align=True)
-		split.scale_y = 2
-		split.operator(AddonUpdaterCheckNow.bl_idname,
-					   text="", icon="FILE_REFRESH")
+    elif (
+        updater.include_branches
+        and len(updater.tags) == len(updater.include_branch_list)
+        and not updater.manual_only
+    ):
+        # No releases found, but still show the appropriate branch.
+        sub_col = col.row(align=True)
+        sub_col.scale_y = 1
+        split = sub_col.split(align=True)
+        split.scale_y = 2
+        update_now_txt = "Update directly to {}".format(updater.include_branch_list[0])
+        split.operator(AddonUpdaterUpdateNow.bl_idname, text=update_now_txt)
+        split = sub_col.split(align=True)
+        split.scale_y = 2
+        split.operator(AddonUpdaterCheckNow.bl_idname, text="", icon="FILE_REFRESH")
 
-	elif updater.update_ready and not updater.manual_only:
-		sub_col = col.row(align=True)
-		sub_col.scale_y = 1
-		split = sub_col.split(align=True)
-		split.scale_y = 2
-		split.operator(AddonUpdaterUpdateNow.bl_idname,
-					   text="Update now to " + str(updater.update_version))
-		split = sub_col.split(align=True)
-		split.scale_y = 2
-		split.operator(AddonUpdaterCheckNow.bl_idname,
-					   text="", icon="FILE_REFRESH")
+    elif updater.update_ready and not updater.manual_only:
+        sub_col = col.row(align=True)
+        sub_col.scale_y = 1
+        split = sub_col.split(align=True)
+        split.scale_y = 2
+        split.operator(
+            AddonUpdaterUpdateNow.bl_idname,
+            text="Update now to " + str(updater.update_version),
+        )
+        split = sub_col.split(align=True)
+        split.scale_y = 2
+        split.operator(AddonUpdaterCheckNow.bl_idname, text="", icon="FILE_REFRESH")
 
-	elif updater.update_ready and updater.manual_only:
-		col.scale_y = 2
-		dl_now_txt = "Download " + str(updater.update_version)
-		col.operator("wm.url_open",
-					 text=dl_now_txt).url = updater.website
-	else:  # i.e. that updater.update_ready == False.
-		sub_col = col.row(align=True)
-		sub_col.scale_y = 1
-		split = sub_col.split(align=True)
-		split.enabled = False
-		split.scale_y = 2
-		split.operator(AddonUpdaterCheckNow.bl_idname,
-					   text="Addon is up to date")
-		split = sub_col.split(align=True)
-		split.scale_y = 2
-		split.operator(AddonUpdaterCheckNow.bl_idname,
-					   text="", icon="FILE_REFRESH")
+    elif updater.update_ready and updater.manual_only:
+        col.scale_y = 2
+        dl_now_txt = "Download " + str(updater.update_version)
+        col.operator("wm.url_open", text=dl_now_txt).url = updater.website
+    else:  # i.e. that updater.update_ready == False.
+        sub_col = col.row(align=True)
+        sub_col.scale_y = 1
+        split = sub_col.split(align=True)
+        split.enabled = False
+        split.scale_y = 2
+        split.operator(AddonUpdaterCheckNow.bl_idname, text="Addon is up to date")
+        split = sub_col.split(align=True)
+        split.scale_y = 2
+        split.operator(AddonUpdaterCheckNow.bl_idname, text="", icon="FILE_REFRESH")
 
-	if not updater.manual_only:
-		col = row.column(align=True)
-		if updater.include_branches and len(updater.include_branch_list) > 0:
-			branch = updater.include_branch_list[0]
-			col.operator(AddonUpdaterUpdateTarget.bl_idname,
-						 text="Install {} / old version".format(branch))
-		else:
-			col.operator(AddonUpdaterUpdateTarget.bl_idname,
-						 text="(Re)install addon version")
-		last_date = "none found"
-		backup_path = os.path.join(updater.stage_path, "backup")
-		if "backup_date" in updater.json and os.path.isdir(backup_path):
-			if updater.json["backup_date"] == "":
-				last_date = "Date not found"
-			else:
-				last_date = updater.json["backup_date"]
-		backup_text = "Restore addon backup ({})".format(last_date)
-		col.operator(AddonUpdaterRestoreBackup.bl_idname, text=backup_text)
+    if not updater.manual_only:
+        col = row.column(align=True)
+        if updater.include_branches and len(updater.include_branch_list) > 0:
+            branch = updater.include_branch_list[0]
+            col.operator(
+                AddonUpdaterUpdateTarget.bl_idname,
+                text="Install {} / old version".format(branch),
+            )
+        else:
+            col.operator(
+                AddonUpdaterUpdateTarget.bl_idname, text="(Re)install addon version"
+            )
+        last_date = "none found"
+        backup_path = os.path.join(updater.stage_path, "backup")
+        if "backup_date" in updater.json and os.path.isdir(backup_path):
+            if updater.json["backup_date"] == "":
+                last_date = "Date not found"
+            else:
+                last_date = updater.json["backup_date"]
+        backup_text = "Restore addon backup ({})".format(last_date)
+        col.operator(AddonUpdaterRestoreBackup.bl_idname, text=backup_text)
 
-	row = box.row()
-	row.scale_y = 0.7
-	last_check = updater.json["last_check"]
-	if updater.error is not None and updater.error_msg is not None:
-		row.label(text=updater.error_msg)
-	elif last_check:
-		last_check = last_check[0: last_check.index(".")]
-		row.label(text="Last update check: " + last_check)
-	else:
-		row.label(text="Last update check: Never")
+    row = box.row()
+    row.scale_y = 0.7
+    last_check = updater.json["last_check"]
+    if updater.error is not None and updater.error_msg is not None:
+        row.label(text=updater.error_msg)
+    elif last_check:
+        last_check = last_check[0 : last_check.index(".")]
+        row.label(text="Last update check: " + last_check)
+    else:
+        row.label(text="Last update check: Never")
 
 
 def update_settings_ui_condensed(self, context, element=None):
-	"""Preferences - Condensed drawing within preferences.
+    """Preferences - Condensed drawing within preferences.
 
-	Alternate draw for user preferences or other places, does not draw a box.
-	"""
+    Alternate draw for user preferences or other places, does not draw a box.
+    """
 
-	# Element is a UI element, such as layout, a row, column, or box.
-	if element is None:
-		element = self.layout
-	row = element.row()
+    # Element is a UI element, such as layout, a row, column, or box.
+    if element is None:
+        element = self.layout
+    row = element.row()
 
-	# In case of error importing updater.
-	if updater.invalid_updater:
-		row.label(text="Error initializing updater code:")
-		row.label(text=updater.error_msg)
-		return
-	settings = get_user_preferences(context)
-	if not settings:
-		row.label(text="Error getting updater preferences", icon='ERROR')
-		return
+    # In case of error importing updater.
+    if updater.invalid_updater:
+        row.label(text="Error initializing updater code:")
+        row.label(text=updater.error_msg)
+        return
+    settings = get_user_preferences(context)
+    if not settings:
+        row.label(text="Error getting updater preferences", icon="ERROR")
+        return
 
-	# Special case to tell user to restart blender, if set that way.
-	if not updater.auto_reload_post_update:
-		saved_state = updater.json
-		if "just_updated" in saved_state and saved_state["just_updated"]:
-			row.alert = True  # mark red
-			row.operator(
-				"wm.quit_blender",
-				text="Restart blender to complete update",
-				icon="ERROR")
-			return
+    # Special case to tell user to restart blender, if set that way.
+    if not updater.auto_reload_post_update:
+        saved_state = updater.json
+        if "just_updated" in saved_state and saved_state["just_updated"]:
+            row.alert = True  # mark red
+            row.operator(
+                "wm.quit_blender",
+                text="Restart blender to complete update",
+                icon="ERROR",
+            )
+            return
 
-	col = row.column()
-	if updater.error is not None:
-		sub_col = col.row(align=True)
-		sub_col.scale_y = 1
-		split = sub_col.split(align=True)
-		split.scale_y = 2
-		if "ssl" in updater.error_msg.lower():
-			split.enabled = True
-			split.operator(AddonUpdaterInstallManually.bl_idname,
-						   text=updater.error)
-		else:
-			split.enabled = False
-			split.operator(AddonUpdaterCheckNow.bl_idname,
-						   text=updater.error)
-		split = sub_col.split(align=True)
-		split.scale_y = 2
-		split.operator(AddonUpdaterCheckNow.bl_idname,
-					   text="", icon="FILE_REFRESH")
+    col = row.column()
+    if updater.error is not None:
+        sub_col = col.row(align=True)
+        sub_col.scale_y = 1
+        split = sub_col.split(align=True)
+        split.scale_y = 2
+        if "ssl" in updater.error_msg.lower():
+            split.enabled = True
+            split.operator(AddonUpdaterInstallManually.bl_idname, text=updater.error)
+        else:
+            split.enabled = False
+            split.operator(AddonUpdaterCheckNow.bl_idname, text=updater.error)
+        split = sub_col.split(align=True)
+        split.scale_y = 2
+        split.operator(AddonUpdaterCheckNow.bl_idname, text="", icon="FILE_REFRESH")
 
-	elif updater.update_ready is None and not updater.async_checking:
-		col.scale_y = 2
-		col.operator(AddonUpdaterCheckNow.bl_idname)
-	elif updater.update_ready is None:  # Async is running.
-		sub_col = col.row(align=True)
-		sub_col.scale_y = 1
-		split = sub_col.split(align=True)
-		split.enabled = False
-		split.scale_y = 2
-		split.operator(AddonUpdaterCheckNow.bl_idname, text="Checking...")
-		split = sub_col.split(align=True)
-		split.scale_y = 2
-		split.operator(AddonUpdaterEndBackground.bl_idname, text="", icon="X")
+    elif updater.update_ready is None and not updater.async_checking:
+        col.scale_y = 2
+        col.operator(AddonUpdaterCheckNow.bl_idname)
+    elif updater.update_ready is None:  # Async is running.
+        sub_col = col.row(align=True)
+        sub_col.scale_y = 1
+        split = sub_col.split(align=True)
+        split.enabled = False
+        split.scale_y = 2
+        split.operator(AddonUpdaterCheckNow.bl_idname, text="Checking...")
+        split = sub_col.split(align=True)
+        split.scale_y = 2
+        split.operator(AddonUpdaterEndBackground.bl_idname, text="", icon="X")
 
-	elif updater.include_branches and \
-			len(updater.tags) == len(updater.include_branch_list) and not \
-			updater.manual_only:
-		# No releases found, but still show the appropriate branch.
-		sub_col = col.row(align=True)
-		sub_col.scale_y = 1
-		split = sub_col.split(align=True)
-		split.scale_y = 2
-		now_txt = "Update directly to " + str(updater.include_branch_list[0])
-		split.operator(AddonUpdaterUpdateNow.bl_idname, text=now_txt)
-		split = sub_col.split(align=True)
-		split.scale_y = 2
-		split.operator(AddonUpdaterCheckNow.bl_idname,
-					   text="", icon="FILE_REFRESH")
+    elif (
+        updater.include_branches
+        and len(updater.tags) == len(updater.include_branch_list)
+        and not updater.manual_only
+    ):
+        # No releases found, but still show the appropriate branch.
+        sub_col = col.row(align=True)
+        sub_col.scale_y = 1
+        split = sub_col.split(align=True)
+        split.scale_y = 2
+        now_txt = "Update directly to " + str(updater.include_branch_list[0])
+        split.operator(AddonUpdaterUpdateNow.bl_idname, text=now_txt)
+        split = sub_col.split(align=True)
+        split.scale_y = 2
+        split.operator(AddonUpdaterCheckNow.bl_idname, text="", icon="FILE_REFRESH")
 
-	elif updater.update_ready and not updater.manual_only:
-		sub_col = col.row(align=True)
-		sub_col.scale_y = 1
-		split = sub_col.split(align=True)
-		split.scale_y = 2
-		split.operator(AddonUpdaterUpdateNow.bl_idname,
-					   text="Update now to " + str(updater.update_version))
-		split = sub_col.split(align=True)
-		split.scale_y = 2
-		split.operator(AddonUpdaterCheckNow.bl_idname,
-					   text="", icon="FILE_REFRESH")
+    elif updater.update_ready and not updater.manual_only:
+        sub_col = col.row(align=True)
+        sub_col.scale_y = 1
+        split = sub_col.split(align=True)
+        split.scale_y = 2
+        split.operator(
+            AddonUpdaterUpdateNow.bl_idname,
+            text="Update now to " + str(updater.update_version),
+        )
+        split = sub_col.split(align=True)
+        split.scale_y = 2
+        split.operator(AddonUpdaterCheckNow.bl_idname, text="", icon="FILE_REFRESH")
 
-	elif updater.update_ready and updater.manual_only:
-		col.scale_y = 2
-		dl_txt = "Download " + str(updater.update_version)
-		col.operator("wm.url_open", text=dl_txt).url = updater.website
-	else:  # i.e. that updater.update_ready == False.
-		sub_col = col.row(align=True)
-		sub_col.scale_y = 1
-		split = sub_col.split(align=True)
-		split.enabled = False
-		split.scale_y = 2
-		split.operator(AddonUpdaterCheckNow.bl_idname,
-					   text="Addon is up to date")
-		split = sub_col.split(align=True)
-		split.scale_y = 2
-		split.operator(AddonUpdaterCheckNow.bl_idname,
-					   text="", icon="FILE_REFRESH")
+    elif updater.update_ready and updater.manual_only:
+        col.scale_y = 2
+        dl_txt = "Download " + str(updater.update_version)
+        col.operator("wm.url_open", text=dl_txt).url = updater.website
+    else:  # i.e. that updater.update_ready == False.
+        sub_col = col.row(align=True)
+        sub_col.scale_y = 1
+        split = sub_col.split(align=True)
+        split.enabled = False
+        split.scale_y = 2
+        split.operator(AddonUpdaterCheckNow.bl_idname, text="Addon is up to date")
+        split = sub_col.split(align=True)
+        split.scale_y = 2
+        split.operator(AddonUpdaterCheckNow.bl_idname, text="", icon="FILE_REFRESH")
 
-	row = element.row()
-	row.prop(settings, "auto_check_update")
+    row = element.row()
+    row.prop(settings, "auto_check_update")
 
-	row = element.row()
-	row.scale_y = 0.7
-	last_check = updater.json["last_check"]
-	if updater.error is not None and updater.error_msg is not None:
-		row.label(text=updater.error_msg)
-	elif last_check != "" and last_check is not None:
-		last_check = last_check[0: last_check.index(".")]
-		row.label(text="Last check: " + last_check)
-	else:
-		row.label(text="Last check: Never")
+    row = element.row()
+    row.scale_y = 0.7
+    last_check = updater.json["last_check"]
+    if updater.error is not None and updater.error_msg is not None:
+        row.label(text=updater.error_msg)
+    elif last_check != "" and last_check is not None:
+        last_check = last_check[0 : last_check.index(".")]
+        row.label(text="Last check: " + last_check)
+    else:
+        row.label(text="Last check: Never")
 
 
 def skip_tag_function(self, tag):
-	"""A global function for tag skipping.
+    """A global function for tag skipping.
 
-	A way to filter which tags are displayed, e.g. to limit downgrading too
-	long ago.
+    A way to filter which tags are displayed, e.g. to limit downgrading too
+    long ago.
 
-	Args:
-		self: The instance of the singleton addon update.
-		tag: the text content of a tag from the repo, e.g. "v1.2.3".
+    Args:
+            self: The instance of the singleton addon update.
+            tag: the text content of a tag from the repo, e.g. "v1.2.3".
 
-	Returns:
-		bool: True to skip this tag name (ie don't allow for downloading this
-			version), or False if the tag is allowed.
-	"""
+    Returns:
+            bool: True to skip this tag name (ie don't allow for downloading this
+                    version), or False if the tag is allowed.
+    """
 
-	# In case of error importing updater.
-	if self.invalid_updater:
-		return False
+    # In case of error importing updater.
+    if self.invalid_updater:
+        return False
 
-	# ---- write any custom code here, return true to disallow version ---- #
-	#
-	# # Filter out e.g. if 'beta' is in name of release
-	# if 'beta' in tag.lower():
-	# 	return True
-	# ---- write any custom code above, return true to disallow version --- #
+    # ---- write any custom code here, return true to disallow version ---- #
+    #
+    # # Filter out e.g. if 'beta' is in name of release
+    # if 'beta' in tag.lower():
+    # 	return True
+    # ---- write any custom code above, return true to disallow version --- #
 
-	if self.include_branches:
-		for branch in self.include_branch_list:
-			if tag["name"].lower() == branch:
-				return False
+    if self.include_branches:
+        for branch in self.include_branch_list:
+            if tag["name"].lower() == branch:
+                return False
 
-	# Function converting string to tuple, ignoring e.g. leading 'v'.
-	# Be aware that this strips out other text that you might otherwise
-	# want to be kept and accounted for when checking tags (e.g. v1.1a vs 1.1b)
-	tupled = self.version_tuple_from_text(tag["name"])
-	if not isinstance(tupled, tuple):
-		return True
+    # Function converting string to tuple, ignoring e.g. leading 'v'.
+    # Be aware that this strips out other text that you might otherwise
+    # want to be kept and accounted for when checking tags (e.g. v1.1a vs 1.1b)
+    tupled = self.version_tuple_from_text(tag["name"])
+    if not isinstance(tupled, tuple):
+        return True
 
-	# Select the min tag version - change tuple accordingly.
-	if self.version_min_update is not None:
-		if tupled < self.version_min_update:
-			return True  # Skip if current version below this.
+    # Select the min tag version - change tuple accordingly.
+    if self.version_min_update is not None:
+        if tupled < self.version_min_update:
+            return True  # Skip if current version below this.
 
-	# Select the max tag version.
-	if self.version_max_update is not None:
-		if tupled >= self.version_max_update:
-			return True  # Skip if current version at or above this.
+    # Select the max tag version.
+    if self.version_max_update is not None:
+        if tupled >= self.version_max_update:
+            return True  # Skip if current version at or above this.
 
-	# In all other cases, allow showing the tag for updating/reverting.
-	# To simply and always show all tags, this return False could be moved
-	# to the start of the function definition so all tags are allowed.
-	return False
+    # In all other cases, allow showing the tag for updating/reverting.
+    # To simply and always show all tags, this return False could be moved
+    # to the start of the function definition so all tags are allowed.
+    return False
 
 
 def select_link_function(self, tag):
-	"""Only customize if trying to leverage "attachments" in *GitHub* releases.
+    """Only customize if trying to leverage "attachments" in *GitHub* releases.
 
-	A way to select from one or multiple attached downloadable files from the
-	server, instead of downloading the default release/tag source code.
-	"""
+    A way to select from one or multiple attached downloadable files from the
+    server, instead of downloading the default release/tag source code.
+    """
 
-	# -- Default, universal case (and is the only option for GitLab/Bitbucket)
-	link = tag["zipball_url"]
+    # -- Default, universal case (and is the only option for GitLab/Bitbucket)
+    link = tag["zipball_url"]
 
-	# -- Example: select the first (or only) asset instead source code --
-	# if "assets" in tag and "browser_download_url" in tag["assets"][0]:
-	# 	link = tag["assets"][0]["browser_download_url"]
+    # -- Example: select the first (or only) asset instead source code --
+    # if "assets" in tag and "browser_download_url" in tag["assets"][0]:
+    # 	link = tag["assets"][0]["browser_download_url"]
 
-	# -- Example: select asset based on OS, where multiple builds exist --
-	# # not tested/no error checking, modify to fit your own needs!
-	# # assume each release has three attached builds:
-	# #		release_windows.zip, release_OSX.zip, release_linux.zip
-	# # This also would logically not be used with "branches" enabled
-	# if platform.system() == "Darwin": # ie OSX
-	# 	link = [asset for asset in tag["assets"] if 'OSX' in asset][0]
-	# elif platform.system() == "Windows":
-	# 	link = [asset for asset in tag["assets"] if 'windows' in asset][0]
-	# elif platform.system() == "Linux":
-	# 	link = [asset for asset in tag["assets"] if 'linux' in asset][0]
+    # -- Example: select asset based on OS, where multiple builds exist --
+    # # not tested/no error checking, modify to fit your own needs!
+    # # assume each release has three attached builds:
+    # #		release_windows.zip, release_OSX.zip, release_linux.zip
+    # # This also would logically not be used with "branches" enabled
+    # if platform.system() == "Darwin": # ie OSX
+    # 	link = [asset for asset in tag["assets"] if 'OSX' in asset][0]
+    # elif platform.system() == "Windows":
+    # 	link = [asset for asset in tag["assets"] if 'windows' in asset][0]
+    # elif platform.system() == "Linux":
+    # 	link = [asset for asset in tag["assets"] if 'linux' in asset][0]
 
-	return link
+    return link
 
 
 # -----------------------------------------------------------------------------
 # Register, should be run in the register module itself
 # -----------------------------------------------------------------------------
 classes = (
-	AddonUpdaterInstallPopup,
-	AddonUpdaterCheckNow,
-	AddonUpdaterUpdateNow,
-	AddonUpdaterUpdateTarget,
-	AddonUpdaterInstallManually,
-	AddonUpdaterUpdatedSuccessful,
-	AddonUpdaterRestoreBackup,
-	AddonUpdaterIgnore,
-	AddonUpdaterEndBackground
+    AddonUpdaterInstallPopup,
+    AddonUpdaterCheckNow,
+    AddonUpdaterUpdateNow,
+    AddonUpdaterUpdateTarget,
+    AddonUpdaterInstallManually,
+    AddonUpdaterUpdatedSuccessful,
+    AddonUpdaterRestoreBackup,
+    AddonUpdaterIgnore,
+    AddonUpdaterEndBackground,
 )
 
 
 def register(bl_info):
-	"""Registering the operators in this module"""
-	from . import conf
-	updater.verbose = conf.env.verbose
+    """Registering the operators in this module"""
+    from . import conf
 
-	# safer failure in case of issue loading module
-	if updater.error != None:
-		print("Exiting updater registration, error return")
-		return
-	if updater.update_ready is None:  # Force clear out after blender restart.
-		saved_state = updater.json
-		if saved_state.get("just_updated") is True:
-			updater.json_reset_postupdate()
-	updater.clear_state()  # Clear internal vars, avoids reloading oddities.
+    updater.verbose = conf.env.verbose
 
-	updater.engine = "Github"
-	updater.user = "theduckcow"
-	updater.repo = "mcprep"
-	updater.website = "https://theduckcow.com/dev/blender/mcprep-download/"
-	updater.subfolder_path = "MCprep_addon/"
-	updater.current_version = bl_info["version"]
-	updater.backup_current = True
-	updater.backup_ignore_patterns = ["__pycache__"]
-	updater.overwrite_patterns = ["*.png", "README.md", "*.txt", "*.blend"]
-	updater.remove_pre_update_patterns = [
-		"*.py", "*.pyc", "mcprep_addon_tracker.json", "mcprep_data.json"]
-	updater.include_branches = False
-	updater.include_branch_list = None  # is the equivalent to setting ['master']
-	updater.manual_only = False # used to be True
-	updater.fake_install = False # Set to true to test callback/reloading
+    # safer failure in case of issue loading module
+    if updater.error != None:
+        print("Exiting updater registration, error return")
+        return
+    if updater.update_ready is None:  # Force clear out after blender restart.
+        saved_state = updater.json
+        if saved_state.get("just_updated") is True:
+            updater.json_reset_postupdate()
+    updater.clear_state()  # Clear internal vars, avoids reloading oddities.
 
-	min_ver = (3,0,0)
-	if hasattr(bpy.app, "version") and bpy.app.version >= (2, 80):
-		min_ver = (3,2,0)
-	updater.version_min_update = min_ver
-	updater.version_max_update = None
-	updater.version_max_update = None  # if not wanting to define a max
-	updater.skip_tag = skip_tag_function # min and max used in this function
-	updater.use_releases = True
-	updater.select_link = select_link_function # will select asset
+    updater.engine = "Github"
+    updater.user = "theduckcow"
+    updater.repo = "mcprep"
+    updater.website = "https://theduckcow.com/dev/blender/mcprep-download/"
+    updater.subfolder_path = "MCprep_addon/"
+    updater.current_version = bl_info["version"]
+    updater.backup_current = True
+    updater.backup_ignore_patterns = ["__pycache__"]
+    updater.overwrite_patterns = ["*.png", "README.md", "*.txt", "*.blend"]
+    updater.remove_pre_update_patterns = [
+        "*.py",
+        "*.pyc",
+        "mcprep_addon_tracker.json",
+        "mcprep_data.json",
+    ]
+    updater.include_branches = False
+    updater.include_branch_list = None  # is the equivalent to setting ['master']
+    updater.manual_only = False  # used to be True
+    updater.fake_install = False  # Set to true to test callback/reloading
 
+    min_ver = (3, 0, 0)
+    if hasattr(bpy.app, "version") and bpy.app.version >= (2, 80):
+        min_ver = (3, 2, 0)
+    updater.version_min_update = min_ver
+    updater.version_max_update = None
+    updater.version_max_update = None  # if not wanting to define a max
+    updater.skip_tag = skip_tag_function  # min and max used in this function
+    updater.use_releases = True
+    updater.select_link = select_link_function  # will select asset
 
-	# The register line items for all operators/panels
-	# If using bpy.utils.register_module(__name__) to register elsewhere
-	# in the addon, delete these lines (also from unregister)
-	for cls in classes:
-		# apply annotations to remove Blender 2.8 warnings, no effect on 2.7
-		make_annotations(cls)
-		# comment out this line if using bpy.utils.register_module(__name__)
-		bpy.utils.register_class(cls)
+    # The register line items for all operators/panels
+    # If using bpy.utils.register_module(__name__) to register elsewhere
+    # in the addon, delete these lines (also from unregister)
+    for cls in classes:
+        # apply annotations to remove Blender 2.8 warnings, no effect on 2.7
+        make_annotations(cls)
+        # comment out this line if using bpy.utils.register_module(__name__)
+        bpy.utils.register_class(cls)
 
-	# showReloadPopup()
+    # showReloadPopup()
 
 
 def unregister():
-	for cls in reversed(classes):
-		# Comment out this line if using bpy.utils.unregister_module(__name__).
-		bpy.utils.unregister_class(cls)
+    for cls in reversed(classes):
+        # Comment out this line if using bpy.utils.unregister_module(__name__).
+        bpy.utils.unregister_class(cls)
 
-	# Clear global vars since they may persist if not restarting blender.
-	updater.clear_state()  # Clear internal vars, avoids reloading oddities.
+    # Clear global vars since they may persist if not restarting blender.
+    updater.clear_state()  # Clear internal vars, avoids reloading oddities.
 
-	global ran_auto_check_install_popup
-	ran_auto_check_install_popup = False
+    global ran_auto_check_install_popup
+    ran_auto_check_install_popup = False
 
-	global ran_update_success_popup
-	ran_update_success_popup = False
+    global ran_update_success_popup
+    ran_update_success_popup = False
 
-	global ran_background_check
-	ran_background_check = False
+    global ran_background_check
+    ran_background_check = False

--- a/MCprep_addon/conf.py
+++ b/MCprep_addon/conf.py
@@ -22,10 +22,10 @@ import bpy
 
 # check if custom preview icons available
 try:
-	import bpy.utils.previews
+    import bpy.utils.previews
 except:
-	print("MCprep: No custom icons in this blender instance")
-	pass
+    print("MCprep: No custom icons in this blender instance")
+    pass
 
 # -----------------------------------------------------------------------------
 # ADDON GLOBAL VARIABLES AND INITIAL SETTINGS
@@ -33,130 +33,135 @@ except:
 
 
 class MCprepEnv:
-	def __init__(self):
-		self.data = None
-		self.json_data = None
-		self.json_path: Path = Path(os.path.dirname(__file__), "MCprep_resources", "mcprep_data.json")
-		self.json_path_update: Path = Path(os.path.dirname(__file__), "MCprep_resources", "mcprep_data_update.json")
+    def __init__(self):
+        self.data = None
+        self.json_data = None
+        self.json_path: Path = Path(
+            os.path.dirname(__file__), "MCprep_resources", "mcprep_data.json"
+        )
+        self.json_path_update: Path = Path(
+            os.path.dirname(__file__), "MCprep_resources", "mcprep_data_update.json"
+        )
 
-		self.dev_file: Path = Path(os.path.dirname(__file__), "mcprep_dev.txt")
+        self.dev_file: Path = Path(os.path.dirname(__file__), "mcprep_dev.txt")
 
-		# if new update file found from install, replace old one with new
-		if self.json_path_update.exists():
-			self.json_path_update.replace(self.json_path)
+        # if new update file found from install, replace old one with new
+        if self.json_path_update.exists():
+            self.json_path_update.replace(self.json_path)
 
-		self.last_check_for_updated = 0
+        self.last_check_for_updated = 0
 
-		# Check to see if there's a text file for a dev build. If so,
-		if self.dev_file.exists():
-			self.dev_build = True
-			self.verbose = True
-			self.very_verbose = True
-			self.log("Dev Build!")
+        # Check to see if there's a text file for a dev build. If so,
+        if self.dev_file.exists():
+            self.dev_build = True
+            self.verbose = True
+            self.very_verbose = True
+            self.log("Dev Build!")
 
-		else:
-			self.dev_build = False
-			self.verbose = False
-			self.very_verbose = False
+        else:
+            self.dev_build = False
+            self.verbose = False
+            self.very_verbose = False
 
-		# lazy load json, ie only load it when needed (util function defined)
+        # lazy load json, ie only load it when needed (util function defined)
 
-		# -----------------------------------------------
-		# For preview icons
-		# -----------------------------------------------
+        # -----------------------------------------------
+        # For preview icons
+        # -----------------------------------------------
 
-		self.use_icons: bool = True
-		self.preview_collections: dict = {}
+        self.use_icons: bool = True
+        self.preview_collections: dict = {}
 
-		# -----------------------------------------------
-		# For initializing the custom icons
-		# -----------------------------------------------
-		self.icons_init()
+        # -----------------------------------------------
+        # For initializing the custom icons
+        # -----------------------------------------------
+        self.icons_init()
 
-		# -----------------------------------------------
-		# For cross-addon lists
-		# -----------------------------------------------
+        # -----------------------------------------------
+        # For cross-addon lists
+        # -----------------------------------------------
 
-		# To ensure shift-A starts drawing sub menus after pressing load all spawns
-		# as without this, if any one of the spawners loads nothing (invalid folder,
-		# no blend files etc), then it would continue to ask to reload spanwers.
-		self.loaded_all_spawners: bool = False
+        # To ensure shift-A starts drawing sub menus after pressing load all spawns
+        # as without this, if any one of the spawners loads nothing (invalid folder,
+        # no blend files etc), then it would continue to ask to reload spanwers.
+        self.loaded_all_spawners: bool = False
 
-		self.skin_list: list = []  # each is: [ basename, path ]
-		self.rig_categories: list = []  # simple list of directory names
-		self.entity_list: list = []
+        self.skin_list: list = []  # each is: [ basename, path ]
+        self.rig_categories: list = []  # simple list of directory names
+        self.entity_list: list = []
 
-		# -----------------------------------------------
-		# Matieral sync cahce, to avoid repeat lib reads
-		# -----------------------------------------------
+        # -----------------------------------------------
+        # Matieral sync cahce, to avoid repeat lib reads
+        # -----------------------------------------------
 
-		# list of material names, each is a string. None by default to indicate
-		# that no reading has occurred. If lib not found, will update to [].
-		# If ever changing the resource pack, should also reset to None.
-		self.material_sync_cache = []
+        # list of material names, each is a string. None by default to indicate
+        # that no reading has occurred. If lib not found, will update to [].
+        # If ever changing the resource pack, should also reset to None.
+        self.material_sync_cache = []
 
-	# -----------------------------------------------------------------------------
-	# ICONS INIT
-	# -----------------------------------------------------------------------------
+    # -----------------------------------------------------------------------------
+    # ICONS INIT
+    # -----------------------------------------------------------------------------
 
+    def icons_init(self):
+        collection_sets = [
+            "main",
+            "skins",
+            "mobs",
+            "entities",
+            "blocks",
+            "items",
+            "effects",
+            "materials",
+        ]
 
-	def icons_init(self):
-		collection_sets = [
-			"main", "skins", "mobs", "entities", "blocks", "items", "effects", "materials"]
+        try:
+            for iconset in collection_sets:
+                self.preview_collections[iconset] = bpy.utils.previews.new()
 
-		try:
-			for iconset in collection_sets:
-				self.preview_collections[iconset] = bpy.utils.previews.new()
+            script_path = bpy.path.abspath(os.path.dirname(__file__))
+            icons_dir = os.path.join(script_path, "icons")
+            self.preview_collections["main"].load(
+                "crafting_icon", os.path.join(icons_dir, "crafting_icon.png"), "IMAGE"
+            )
+            self.preview_collections["main"].load(
+                "meshswap_icon", os.path.join(icons_dir, "meshswap_icon.png"), "IMAGE"
+            )
+            self.preview_collections["main"].load(
+                "spawner_icon", os.path.join(icons_dir, "spawner_icon.png"), "IMAGE"
+            )
+            self.preview_collections["main"].load(
+                "sword_icon", os.path.join(icons_dir, "sword_icon.png"), "IMAGE"
+            )
+            self.preview_collections["main"].load(
+                "effects_icon", os.path.join(icons_dir, "effects_icon.png"), "IMAGE"
+            )
+            self.preview_collections["main"].load(
+                "entity_icon", os.path.join(icons_dir, "entity_icon.png"), "IMAGE"
+            )
+            self.preview_collections["main"].load(
+                "model_icon", os.path.join(icons_dir, "model_icon.png"), "IMAGE"
+            )
+        except Exception as e:
+            self.log("Old verison of blender, no custom icons available")
+            self.log("\t" + str(e))
+            global use_icons
+            self.use_icons = False
+            for iconset in collection_sets:
+                self.preview_collections[iconset] = ""
 
-			script_path = bpy.path.abspath(os.path.dirname(__file__))
-			icons_dir = os.path.join(script_path, 'icons')
-			self.preview_collections["main"].load(
-				"crafting_icon",
-				os.path.join(icons_dir, "crafting_icon.png"),
-				'IMAGE')
-			self.preview_collections["main"].load(
-				"meshswap_icon",
-				os.path.join(icons_dir, "meshswap_icon.png"),
-				'IMAGE')
-			self.preview_collections["main"].load(
-				"spawner_icon",
-				os.path.join(icons_dir, "spawner_icon.png"),
-				'IMAGE')
-			self.preview_collections["main"].load(
-				"sword_icon",
-				os.path.join(icons_dir, "sword_icon.png"),
-				'IMAGE')
-			self.preview_collections["main"].load(
-				"effects_icon",
-				os.path.join(icons_dir, "effects_icon.png"),
-				'IMAGE')
-			self.preview_collections["main"].load(
-				"entity_icon",
-				os.path.join(icons_dir, "entity_icon.png"),
-				'IMAGE')
-			self.preview_collections["main"].load(
-				"model_icon",
-				os.path.join(icons_dir, "model_icon.png"),
-				'IMAGE')
-		except Exception as e:
-			self.log("Old verison of blender, no custom icons available")
-			self.log("\t" + str(e))
-			global use_icons
-			self.use_icons = False
-			for iconset in collection_sets:
-				self.preview_collections[iconset] = ""
-    
-	def log(self, statement: str, vv_only: bool=False):
-		if self.verbose and vv_only and self.very_verbose:
-			print(statement)
-		elif self.verbose:
-			print(statement)
+    def log(self, statement: str, vv_only: bool = False):
+        if self.verbose and vv_only and self.very_verbose:
+            print(statement)
+        elif self.verbose:
+            print(statement)
 
-	def deprecation_warning(self):
-		if self.dev_build:
-			import traceback
-			self.log("Deprecation Warning: This will be removed in MCprep 3.5.1!")
-			traceback.print_stack()
+    def deprecation_warning(self):
+        if self.dev_build:
+            import traceback
+
+            self.log("Deprecation Warning: This will be removed in MCprep 3.5.1!")
+            traceback.print_stack()
 
 
 env = MCprepEnv()
@@ -164,111 +169,109 @@ env = MCprepEnv()
 
 # ! Deprecated as of MCprep 3.4.2
 def init():
-	env.deprecation_warning()
-	# -----------------------------------------------
-	# Verbose, use as env.verbose
-	# Used to print out extra information, set false with distribution
-	# -----------------------------------------------
-	# ! Deprecated as of MCprep 3.4.2
-	global dev
-	dev = True
+    env.deprecation_warning()
+    # -----------------------------------------------
+    # Verbose, use as env.verbose
+    # Used to print out extra information, set false with distribution
+    # -----------------------------------------------
+    # ! Deprecated as of MCprep 3.4.2
+    global dev
+    dev = True
 
-	# ! Deprecated as of MCprep 3.4.2
-	global v
-	v = True  # $VERBOSE, UI setting
+    # ! Deprecated as of MCprep 3.4.2
+    global v
+    v = True  # $VERBOSE, UI setting
 
-	# ! Deprecated as of MCprep 3.4.2
-	global vv
-	vv = dev  # $VERYVERBOSE
+    # ! Deprecated as of MCprep 3.4.2
+    global vv
+    vv = dev  # $VERYVERBOSE
 
-	# -----------------------------------------------
-	# JSON attributes
-	# -----------------------------------------------
+    # -----------------------------------------------
+    # JSON attributes
+    # -----------------------------------------------
 
-	# shouldn't load here, just globalize any json data?
+    # shouldn't load here, just globalize any json data?
 
-	# ! Deprecated as of MCprep 3.4.2
-	global data
-	# import json
+    # ! Deprecated as of MCprep 3.4.2
+    global data
+    # import json
 
-	# ! Deprecated as of MCprep 3.4.2
-	global json_data  # mcprep_data.json
-	json_data = None  # later will load addon information etc
+    # ! Deprecated as of MCprep 3.4.2
+    global json_data  # mcprep_data.json
+    json_data = None  # later will load addon information etc
 
-	# if existing json_data_update exists, overwrite it
-	# ! Deprecated as of MCprep 3.4.2
-	global json_path
-	json_path = os.path.join(
-		os.path.dirname(__file__),
-		"MCprep_resources",
-		"mcprep_data.json")
-	global json_path_update
-	json_path_update = os.path.join(
-		os.path.dirname(__file__),
-		"MCprep_resources",
-		"mcprep_data_update.json")
+    # if existing json_data_update exists, overwrite it
+    # ! Deprecated as of MCprep 3.4.2
+    global json_path
+    json_path = os.path.join(
+        os.path.dirname(__file__), "MCprep_resources", "mcprep_data.json"
+    )
+    global json_path_update
+    json_path_update = os.path.join(
+        os.path.dirname(__file__), "MCprep_resources", "mcprep_data_update.json"
+    )
 
-	# Used to avoid checking for update file on disk too frequently.
-	global last_check_for_updated
-	last_check_for_updated = 0
+    # Used to avoid checking for update file on disk too frequently.
+    global last_check_for_updated
+    last_check_for_updated = 0
 
-	# if new update file found from install, replace old one with new
-	if os.path.isfile(json_path_update):
-		if os.path.isfile(json_path) is True:
-			os.remove(json_path)
-		os.rename(json_path_update, json_path)
+    # if new update file found from install, replace old one with new
+    if os.path.isfile(json_path_update):
+        if os.path.isfile(json_path) is True:
+            os.remove(json_path)
+        os.rename(json_path_update, json_path)
 
-	# lazy load json, ie only load it when needed (util function defined)
+    # lazy load json, ie only load it when needed (util function defined)
 
-	# -----------------------------------------------
-	# For preview icons
-	# -----------------------------------------------
+    # -----------------------------------------------
+    # For preview icons
+    # -----------------------------------------------
 
-	# ! Deprecated as of MCprep 3.4.2
-	global use_icons
-	use_icons = True
-	# ! Deprecated as of MCprep 3.4.2
-	global preview_collections
-	preview_collections = {}
+    # ! Deprecated as of MCprep 3.4.2
+    global use_icons
+    use_icons = True
+    # ! Deprecated as of MCprep 3.4.2
+    global preview_collections
+    preview_collections = {}
 
-	# -----------------------------------------------
-	# For initializing the custom icons
-	# -----------------------------------------------
-	icons_init()
+    # -----------------------------------------------
+    # For initializing the custom icons
+    # -----------------------------------------------
+    icons_init()
 
-	# -----------------------------------------------
-	# For cross-addon lists
-	# -----------------------------------------------
+    # -----------------------------------------------
+    # For cross-addon lists
+    # -----------------------------------------------
 
-	# To ensure shift-A starts drawing sub menus after pressing load all spawns
-	# as without this, if any one of the spawners loads nothing (invalid folder,
-	# no blend files etc), then it would continue to ask to reload spanwers.
-	# ! Deprecated as of MCprep 3.4.2
-	global loaded_all_spawners
-	loaded_all_spawners = False
+    # To ensure shift-A starts drawing sub menus after pressing load all spawns
+    # as without this, if any one of the spawners loads nothing (invalid folder,
+    # no blend files etc), then it would continue to ask to reload spanwers.
+    # ! Deprecated as of MCprep 3.4.2
+    global loaded_all_spawners
+    loaded_all_spawners = False
 
-	# ! Deprecated as of MCprep 3.4.2
-	global skin_list
-	skin_list = []  # each is: [ basename, path ]
+    # ! Deprecated as of MCprep 3.4.2
+    global skin_list
+    skin_list = []  # each is: [ basename, path ]
 
-	# ! Deprecated as of MCprep 3.4.2
-	global rig_categories
-	rig_categories = []  # simple list of directory names
+    # ! Deprecated as of MCprep 3.4.2
+    global rig_categories
+    rig_categories = []  # simple list of directory names
 
-	# ! Deprecated as of MCprep 3.4.2
-	global entity_list
-	entity_list = []
+    # ! Deprecated as of MCprep 3.4.2
+    global entity_list
+    entity_list = []
 
-	# -----------------------------------------------
-	# Matieral sync cahce, to avoid repeat lib reads
-	# -----------------------------------------------
+    # -----------------------------------------------
+    # Matieral sync cahce, to avoid repeat lib reads
+    # -----------------------------------------------
 
-	# list of material names, each is a string. None by default to indicate
-	# that no reading has occurred. If lib not found, will update to [].
-	# If ever changing the resource pack, should also reset to None.
-	# ! Deprecated as of MCprep 3.4.2
-	global material_sync_cache
-	material_sync_cache = None
+    # list of material names, each is a string. None by default to indicate
+    # that no reading has occurred. If lib not found, will update to [].
+    # If ever changing the resource pack, should also reset to None.
+    # ! Deprecated as of MCprep 3.4.2
+    global material_sync_cache
+    material_sync_cache = None
 
 
 # ! Deprecated as of MCprep 3.4.2
@@ -276,103 +279,106 @@ def init():
 # ICONS INIT
 # -----------------------------------------------------------------------------
 
+
 def icons_init():
-	env.deprecation_warning()
-	# start with custom icons
-	# put into a try statement in case older blender version!
-	global preview_collections
-	global v
+    env.deprecation_warning()
+    # start with custom icons
+    # put into a try statement in case older blender version!
+    global preview_collections
+    global v
 
-	collection_sets = [
-		"main", "skins", "mobs", "entities", "blocks", "items", "effects", "materials"]
+    collection_sets = [
+        "main",
+        "skins",
+        "mobs",
+        "entities",
+        "blocks",
+        "items",
+        "effects",
+        "materials",
+    ]
 
-	try:
-		for iconset in collection_sets:
-			preview_collections[iconset] = bpy.utils.previews.new()
+    try:
+        for iconset in collection_sets:
+            preview_collections[iconset] = bpy.utils.previews.new()
 
-		script_path = bpy.path.abspath(os.path.dirname(__file__))
-		icons_dir = os.path.join(script_path, 'icons')
-		preview_collections["main"].load(
-			"crafting_icon",
-			os.path.join(icons_dir, "crafting_icon.png"),
-			'IMAGE')
-		preview_collections["main"].load(
-			"meshswap_icon",
-			os.path.join(icons_dir, "meshswap_icon.png"),
-			'IMAGE')
-		preview_collections["main"].load(
-			"spawner_icon",
-			os.path.join(icons_dir, "spawner_icon.png"),
-			'IMAGE')
-		preview_collections["main"].load(
-			"sword_icon",
-			os.path.join(icons_dir, "sword_icon.png"),
-			'IMAGE')
-		preview_collections["main"].load(
-			"effects_icon",
-			os.path.join(icons_dir, "effects_icon.png"),
-			'IMAGE')
-		preview_collections["main"].load(
-			"entity_icon",
-			os.path.join(icons_dir, "entity_icon.png"),
-			'IMAGE')
-		preview_collections["main"].load(
-			"model_icon",
-			os.path.join(icons_dir, "model_icon.png"),
-			'IMAGE')
-	except Exception as e:
-		log("Old verison of blender, no custom icons available")
-		log("\t" + str(e))
-		global use_icons
-		use_icons = False
-		for iconset in collection_sets:
-			preview_collections[iconset] = ""
+        script_path = bpy.path.abspath(os.path.dirname(__file__))
+        icons_dir = os.path.join(script_path, "icons")
+        preview_collections["main"].load(
+            "crafting_icon", os.path.join(icons_dir, "crafting_icon.png"), "IMAGE"
+        )
+        preview_collections["main"].load(
+            "meshswap_icon", os.path.join(icons_dir, "meshswap_icon.png"), "IMAGE"
+        )
+        preview_collections["main"].load(
+            "spawner_icon", os.path.join(icons_dir, "spawner_icon.png"), "IMAGE"
+        )
+        preview_collections["main"].load(
+            "sword_icon", os.path.join(icons_dir, "sword_icon.png"), "IMAGE"
+        )
+        preview_collections["main"].load(
+            "effects_icon", os.path.join(icons_dir, "effects_icon.png"), "IMAGE"
+        )
+        preview_collections["main"].load(
+            "entity_icon", os.path.join(icons_dir, "entity_icon.png"), "IMAGE"
+        )
+        preview_collections["main"].load(
+            "model_icon", os.path.join(icons_dir, "model_icon.png"), "IMAGE"
+        )
+    except Exception as e:
+        log("Old verison of blender, no custom icons available")
+        log("\t" + str(e))
+        global use_icons
+        use_icons = False
+        for iconset in collection_sets:
+            preview_collections[iconset] = ""
 
 
 # ! Deprecated as of MCprep 3.4.2
 def log(statement, vv_only=False):
-	env.deprecation_warning()
-	if env.verbose and vv_only and env.very_verbose:
-		print(statement)
-	elif env.verbose:
-		print(statement)
+    env.deprecation_warning()
+    if env.verbose and vv_only and env.very_verbose:
+        print(statement)
+    elif env.verbose:
+        print(statement)
 
 
 def updater_select_link_function(self, tag):
-	"""Indicates what zip file to use for updating from a tag structure.
+    """Indicates what zip file to use for updating from a tag structure.
 
-	Injected function to avoid being overwritten in future updates.
-	"""
-	link = tag["zipball_url"]  # Fallback is full source code.
+    Injected function to avoid being overwritten in future updates.
+    """
+    link = tag["zipball_url"]  # Fallback is full source code.
 
-	# However, prefer puling the uploaded addon zip build.
-	if "assets" in tag and "browser_download_url" in tag["assets"][0]:
-		link = tag["assets"][0]["browser_download_url"]
-	return link
+    # However, prefer puling the uploaded addon zip build.
+    if "assets" in tag and "browser_download_url" in tag["assets"][0]:
+        link = tag["assets"][0]["browser_download_url"]
+    return link
 
 
 # -----------------------------------------------------------------------------
 # GLOBAL REGISTRATOR INIT
 # -----------------------------------------------------------------------------
 
+
 # ! Deprecated as of MCprep 3.4.2
 def register():
-	env.deprecation_warning()
-	init()
+    env.deprecation_warning()
+    init()
 
 
 def unregister():
-	if env.use_icons:
-		for pcoll in env.preview_collections.values():
-			try:
-				bpy.utils.previews.remove(pcoll)
-			except:
-				env.log('Issue clearing preview set ' + str(pcoll))
-	env.preview_collections.clear()
+    if env.use_icons:
+        for pcoll in env.preview_collections.values():
+            try:
+                bpy.utils.previews.remove(pcoll)
+            except:
+                env.log("Issue clearing preview set " + str(pcoll))
+    env.preview_collections.clear()
 
-	env.json_data = None  # actively clearing out json data for next open
+    env.json_data = None  # actively clearing out json data for next open
 
-	env.loaded_all_spawners = False
-	env.skin_list = []
-	env.rig_categories = []
-	env.material_sync_cache = []
+    env.loaded_all_spawners = False
+    env.skin_list = []
+    env.rig_categories = []
+    env.material_sync_cache = []

--- a/MCprep_addon/import_bridge/bridge.py
+++ b/MCprep_addon/import_bridge/bridge.py
@@ -31,48 +31,47 @@ from .. import tracking
 
 
 # -----------------------------------------------------------------------------
-#	General functions
+# 	General functions
 # -----------------------------------------------------------------------------
 
 connector = None  # global reference to persistent connector obj
-world_saves = [] # save enum UI list to memory
-exec_exists_cache = None # cache OS filecheck
+world_saves = []  # save enum UI list to memory
+exec_exists_cache = None  # cache OS filecheck
 
 
 def initialize_connector(context):
-	"""Setup the global connector and load some initial values"""
-	global connector
+    """Setup the global connector and load some initial values"""
+    global connector
 
-	prefs = util.get_user_preferences(context)
-	#if prefs.MCprep_exporter_type ==
+    prefs = util.get_user_preferences(context)
+    # if prefs.MCprep_exporter_type ==
 
-	if connector:
-		return
-	addon_prefs = util.get_user_preferences(context)
-	mineways_exec = addon_prefs.open_mineways_path
-	saves = context.scene.mcprep_props.save_folder
-	connector = MinewaysConnector(mineways_exec, saves)
-	if context.scene.mcprep_props.bridge_world:
-		connector.set_world(context.scene.mcprep_props.bridge_world)
+    if connector:
+        return
+    addon_prefs = util.get_user_preferences(context)
+    mineways_exec = addon_prefs.open_mineways_path
+    saves = context.scene.mcprep_props.save_folder
+    connector = MinewaysConnector(mineways_exec, saves)
+    if context.scene.mcprep_props.bridge_world:
+        connector.set_world(context.scene.mcprep_props.bridge_world)
 
 
 def world_saves_enum(self, context):
-	"""Generate and cache enum list of world saves"""
-	global world_saves
-	if world_saves:
-		return world_saves
+    """Generate and cache enum list of world saves"""
+    global world_saves
+    if world_saves:
+        return world_saves
 
-	world_saves = [("", "(Select world)", "Select a world save file to bridge")]
-	saves = context.scene.mcprep_props.save_folder
-	saves_folders = [world for world in os.listdir(saves)
-		if os.path.isdir(os.path.join(saves, world))]
-	for world in sorted(saves_folders):
-		world_saves.append((
-			world,
-			world,
-			"Set active world to save folder "+world
-			))
-	return world_saves
+    world_saves = [("", "(Select world)", "Select a world save file to bridge")]
+    saves = context.scene.mcprep_props.save_folder
+    saves_folders = [
+        world
+        for world in os.listdir(saves)
+        if os.path.isdir(os.path.join(saves, world))
+    ]
+    for world in sorted(saves_folders):
+        world_saves.append((world, world, "Set active world to save folder " + world))
+    return world_saves
 
 
 # def world_save_update(self, context):
@@ -82,288 +81,285 @@ def world_saves_enum(self, context):
 
 
 def exec_exists(exec_path):
-	"""Check path and cache to limit recalls"""
-	global exec_exists_cache
-	exec_exists_cache = os.path.isfile(exec_path)
-	return exec_exists_cache
+    """Check path and cache to limit recalls"""
+    global exec_exists_cache
+    exec_exists_cache = os.path.isfile(exec_path)
+    return exec_exists_cache
 
 
 # -----------------------------------------------------------------------------
-#	Operators and panels
+# 	Operators and panels
 # -----------------------------------------------------------------------------
 
 
 def panel_draw(self, context):
-	"""Panel draw function for UI"""
-	layout = self.layout
+    """Panel draw function for UI"""
+    layout = self.layout
 
-	addon_prefs = util.get_user_preferences(context)
-	mineways_exec = addon_prefs.open_mineways_path
-	if not exec_exists(mineways_exec):
-		box = layout.box()
-		col = box.column(align=True)
-		col.scale_y = 0.8
-		col.label(text="Mineways executable not set!")
-		col.label(text="Install and set path in preferences to use bridge.")
-		box.operator("mcprep.install_mineways")
+    addon_prefs = util.get_user_preferences(context)
+    mineways_exec = addon_prefs.open_mineways_path
+    if not exec_exists(mineways_exec):
+        box = layout.box()
+        col = box.column(align=True)
+        col.scale_y = 0.8
+        col.label(text="Mineways executable not set!")
+        col.label(text="Install and set path in preferences to use bridge.")
+        box.operator("mcprep.install_mineways")
 
-	# preview image
-	layout.label(text="Select world")
-	layout.prop(context.scene.mcprep_props, "bridge_world", text="")
-	layout.label(text="")
-	col = layout.column(align=True)
-	col.operator("mcprep.bridge_world_import_reference")
-	col.operator("mcprep.bridge_world_import")
-	col.operator("mcprep.bridge_world_refresh")
-	col.operator("mcprep.bridge_world_extend")
-	# preferences to change world path etc
+    # preview image
+    layout.label(text="Select world")
+    layout.prop(context.scene.mcprep_props, "bridge_world", text="")
+    layout.label(text="")
+    col = layout.column(align=True)
+    col.operator("mcprep.bridge_world_import_reference")
+    col.operator("mcprep.bridge_world_import")
+    col.operator("mcprep.bridge_world_refresh")
+    col.operator("mcprep.bridge_world_extend")
+    # preferences to change world path etc
 
 
 class MCPREP_OT_preview_import(bpy.types.Operator):
-	"""Load and place a preview image of the world to be imported."""
-	bl_idname = "mcprep.bridge_world_preview"
-	bl_label = "Preview World Import"
-	bl_options = {'REGISTER', 'UNDO'}
+    """Load and place a preview image of the world to be imported."""
+
+    bl_idname = "mcprep.bridge_world_preview"
+    bl_label = "Preview World Import"
+    bl_options = {"REGISTER", "UNDO"}
+
 
 class MCPREP_OT_import_world_from_objmeta(bpy.types.Operator, ImportHelper):
-	"""Loads a Minecraft world into Blender using same settings as referenced OBJ file exported from Mineways"""
-	bl_idname = "mcprep.bridge_world_import_reference"
-	bl_label = "Import World from Reference"
-	bl_options = {'REGISTER', 'UNDO'}
+    """Loads a Minecraft world into Blender using same settings as referenced OBJ file exported from Mineways"""
 
-	filter_glob: bpy.props.StringProperty(
-		default=".obj",  # verify this works
-		options={'HIDDEN'})
-	fileselectparams = "use_filter_blender"
-	files: bpy.props.CollectionProperty(
-		type=bpy.types.PropertyGroup,
-		options={'HIDDEN', 'SKIP_SAVE'})
-	# filter_image: bpy.props.BoolProperty(
-	# 	default=True,
-	# 	options={'HIDDEN', 'SKIP_SAVE'})
+    bl_idname = "mcprep.bridge_world_import_reference"
+    bl_label = "Import World from Reference"
+    bl_options = {"REGISTER", "UNDO"}
 
-	track_function = "bridge_import_ref"
-	# track_param = ""
-	@tracking.report_error
-	def execute(self, context):
+    filter_glob: bpy.props.StringProperty(
+        default=".obj", options={"HIDDEN"}  # verify this works
+    )
+    fileselectparams = "use_filter_blender"
+    files: bpy.props.CollectionProperty(
+        type=bpy.types.PropertyGroup, options={"HIDDEN", "SKIP_SAVE"}
+    )
+    # filter_image: bpy.props.BoolProperty(
+    # 	default=True,
+    # 	options={'HIDDEN', 'SKIP_SAVE'})
 
-		if not self.filepath:
-			raise Exception
+    track_function = "bridge_import_ref"
 
-		# read obj file, extract the settings
-		# save settings to [empty object? Collection itself?]
+    # track_param = ""
+    @tracking.report_error
+    def execute(self, context):
+        if not self.filepath:
+            raise Exception
 
+        # read obj file, extract the settings
+        # save settings to [empty object? Collection itself?]
 
-		bpy.ops.mcprep.bridge_world_import('INVOKE_DEFAULT') # and add the props as just-read
-		return {'FINISHED'}
-
+        bpy.ops.mcprep.bridge_world_import(
+            "INVOKE_DEFAULT"
+        )  # and add the props as just-read
+        return {"FINISHED"}
 
 
 class MCPREP_OT_import_new_world(bpy.types.Operator):
-	"""Loads a Minecraft world into Blender from a save file (via a Mineways bridge)"""
-	bl_idname = "mcprep.bridge_world_import"
-	bl_label = "Import World"
-	bl_options = {'REGISTER', 'UNDO'}
+    """Loads a Minecraft world into Blender from a save file (via a Mineways bridge)"""
 
-	world_center: bpy.props.IntVectorProperty(
-		name = "World center",
-		description = "Select the X-Z center of import from the Minecraft save",
-		default = (0, 0),
-		subtype = 'XZ',
-		size = 2,
-		)
-	import_center: bpy.props.IntVectorProperty(
-		name = "Import location",
-		description = "Move the center of the imported world to this location",
-		default = (0, 0, 0),
-		subtype = 'XYZ',
-		size = 3,
-		)
-	import_height_offset: bpy.props.IntProperty(
-		name = "Height offset",
-		description = "Lower or raise the imported world by this amount",
-		default = 0,
-		)
-	block_radius: bpy.props.IntProperty(
-		name = "Block radius",
-		description = "Radius of export, from World Center to all directions around",
-		default = 100,
-		min = 1
-		)
-	ceiling: bpy.props.IntProperty(
-		name = "Height/ceiling",
-		description = "The top level of the world to import",
-		default = 256,
-		min = 1,
-		max = 512
-		)
-	floor: bpy.props.IntProperty(
-		name = "Depth/floor",
-		description = "The bottom level of the world to import",
-		default = 0,
-		min = 1,
-		max = 512
-		)
-	use_chunks: bpy.props.BoolProperty(
-		name = "Use chunks",
-		description = "Export the world with separate sections per chunk. In the background, each chunk is one export from Mineways",
-		default = True
-		)
-	chunk_size: bpy.props.IntProperty(
-		name = "Chunk size",
-		description = "Custom size of chunks to import",
-		default = 16,
-		min = 8
-		)
-	separate_blocks: bpy.props.BoolProperty(
-		name = "Object per block",
-		description = "Create one object per each block in the world (warning: will be slow, make exports larger, and make Blender slower!!)",
-		default = False
-		)
-	prep_materials: bpy.props.BoolProperty(
-		name = "Prep materials",
-		default = True
-		)
-	animate_textures: bpy.props.BoolProperty(
-		name = "Animate textures",
-		default = False
-		)
-	single_texture: bpy.props.BoolProperty(
-		name = "Single texture file",
-		description = "Export the world with a single texture. Cannot use with animate textures",
-		default = False
-		)
-	skipUsage: bpy.props.BoolProperty(
-		default = False,
-		options={'HIDDEN'}
-		)
+    bl_idname = "mcprep.bridge_world_import"
+    bl_label = "Import World"
+    bl_options = {"REGISTER", "UNDO"}
 
-	def invoke(self, context, event):
-		return context.window_manager.invoke_props_dialog(
-			self, width=300*util.ui_scale())
+    world_center: bpy.props.IntVectorProperty(
+        name="World center",
+        description="Select the X-Z center of import from the Minecraft save",
+        default=(0, 0),
+        subtype="XZ",
+        size=2,
+    )
+    import_center: bpy.props.IntVectorProperty(
+        name="Import location",
+        description="Move the center of the imported world to this location",
+        default=(0, 0, 0),
+        subtype="XYZ",
+        size=3,
+    )
+    import_height_offset: bpy.props.IntProperty(
+        name="Height offset",
+        description="Lower or raise the imported world by this amount",
+        default=0,
+    )
+    block_radius: bpy.props.IntProperty(
+        name="Block radius",
+        description="Radius of export, from World Center to all directions around",
+        default=100,
+        min=1,
+    )
+    ceiling: bpy.props.IntProperty(
+        name="Height/ceiling",
+        description="The top level of the world to import",
+        default=256,
+        min=1,
+        max=512,
+    )
+    floor: bpy.props.IntProperty(
+        name="Depth/floor",
+        description="The bottom level of the world to import",
+        default=0,
+        min=1,
+        max=512,
+    )
+    use_chunks: bpy.props.BoolProperty(
+        name="Use chunks",
+        description="Export the world with separate sections per chunk. In the background, each chunk is one export from Mineways",
+        default=True,
+    )
+    chunk_size: bpy.props.IntProperty(
+        name="Chunk size",
+        description="Custom size of chunks to import",
+        default=16,
+        min=8,
+    )
+    separate_blocks: bpy.props.BoolProperty(
+        name="Object per block",
+        description="Create one object per each block in the world (warning: will be slow, make exports larger, and make Blender slower!!)",
+        default=False,
+    )
+    prep_materials: bpy.props.BoolProperty(name="Prep materials", default=True)
+    animate_textures: bpy.props.BoolProperty(name="Animate textures", default=False)
+    single_texture: bpy.props.BoolProperty(
+        name="Single texture file",
+        description="Export the world with a single texture. Cannot use with animate textures",
+        default=False,
+    )
+    skipUsage: bpy.props.BoolProperty(default=False, options={"HIDDEN"})
 
-	def draw(self, context):
-		self.layout.prop(self, "first_corner")  # maybe use height max and min separately?
-		self.layout.prop(self, "second_corner")
-		row = self.layout.row()
-		row.prop(self, "use_chunks")
-		subcol = row.column()
-		# subcol.enabled = self.use_chunks # use if can redraw tag
-		subcol.prop(self, "chunk_size")
+    def invoke(self, context, event):
+        return context.window_manager.invoke_props_dialog(
+            self, width=300 * util.ui_scale()
+        )
 
-		col = self.layout.column(align=True)
-		col.scale_y = 0.8
-		col.label(text="Press OK to import/bridge world.", icon='TRIA_DOWN')
-		col.label(text="This will launch Mineways in background.")
-		col.label(text="The program may pop up or show dialogs,")
-		col.label(text="Blender will hang until Mineways closes or is closed.")
+    def draw(self, context):
+        self.layout.prop(
+            self, "first_corner"
+        )  # maybe use height max and min separately?
+        self.layout.prop(self, "second_corner")
+        row = self.layout.row()
+        row.prop(self, "use_chunks")
+        subcol = row.column()
+        # subcol.enabled = self.use_chunks # use if can redraw tag
+        subcol.prop(self, "chunk_size")
 
-	track_function = "bridge_import"
-	track_param = ""
-	@tracking.report_error
-	def execute(self, context):
-		initialize_connector(context)
+        col = self.layout.column(align=True)
+        col.scale_y = 0.8
+        col.label(text="Press OK to import/bridge world.", icon="TRIA_DOWN")
+        col.label(text="This will launch Mineways in background.")
+        col.label(text="The program may pop up or show dialogs,")
+        col.label(text="Blender will hang until Mineways closes or is closed.")
 
-		if not bpy.data.filepath:
-			self.report({"ERROR"},
-				"Must save blend file before bridging world save")
-			return {'CANCELLED'}
-		if not connector.world:
-			self.report({"ERROR"},
-				"No world set/found")
-			return {'CANCELLED'}
+    track_function = "bridge_import"
+    track_param = ""
 
-		# take coordinates and convert to batch list; for now, single export
-		t0 = time.time()
+    @tracking.report_error
+    def execute(self, context):
+        initialize_connector(context)
 
-		# create world bridge path
-		obj_path = os.path.join(
-			os.path.dirname(bpy.data.filepath),
-			"_" + connector.world + "_exp.obj"
-			)
-		mat_path = os.path.join(
-			os.path.dirname(bpy.data.filepath),
-			"_" + connector.world + "_exp.mtl"
-			)
+        if not bpy.data.filepath:
+            self.report({"ERROR"}, "Must save blend file before bridging world save")
+            return {"CANCELLED"}
+        if not connector.world:
+            self.report({"ERROR"}, "No world set/found")
+            return {"CANCELLED"}
 
-		env.log("Running Mineways bridge to import world "+ connector.world)
-		connector.run_export_single(
-			obj_path,
-			list(self.first_corner),
-			list(self.second_corner)
-			)
-		t1 = time.time()
+        # take coordinates and convert to batch list; for now, single export
+        t0 = time.time()
 
-		# TODO: Implement check/connector class check for success, not just file existing
-		if not os.path.isfile(obj_path):
-			self.report({"ERROR"}, "OBJ file not exported, try using Mineways on its own to export OBJ")
-			env.log("OBJ file not found to import: "+obj_path)
-			return {"CANCELLED"}
-		env.log("Now importing the exported obj into blender")
-		bpy.ops.import_scene.obj(filepath=obj_path)
-		# consider removing old world obj's?
+        # create world bridge path
+        obj_path = os.path.join(
+            os.path.dirname(bpy.data.filepath), "_" + connector.world + "_exp.obj"
+        )
+        mat_path = os.path.join(
+            os.path.dirname(bpy.data.filepath), "_" + connector.world + "_exp.mtl"
+        )
 
-		t2 = time.time()
-		env.log("Mineways bridge completed in: {}s (Mineways: {}s, obj import: {}s".format(
-			int(t2-t0), int(t1-t0), int(t2-t1)))
+        env.log("Running Mineways bridge to import world " + connector.world)
+        connector.run_export_single(
+            obj_path, list(self.first_corner), list(self.second_corner)
+        )
+        t1 = time.time()
 
-		self.report({'INFO'}, "Bridge completed finished")
-		return {'FINISHED'}
+        # TODO: Implement check/connector class check for success, not just file existing
+        if not os.path.isfile(obj_path):
+            self.report(
+                {"ERROR"},
+                "OBJ file not exported, try using Mineways on its own to export OBJ",
+            )
+            env.log("OBJ file not found to import: " + obj_path)
+            return {"CANCELLED"}
+        env.log("Now importing the exported obj into blender")
+        bpy.ops.import_scene.obj(filepath=obj_path)
+        # consider removing old world obj's?
+
+        t2 = time.time()
+        env.log(
+            "Mineways bridge completed in: {}s (Mineways: {}s, obj import: {}s".format(
+                int(t2 - t0), int(t1 - t0), int(t2 - t1)
+            )
+        )
+
+        self.report({"INFO"}, "Bridge completed finished")
+        return {"FINISHED"}
 
 
 class MCPREP_OT_refresh_world(bpy.types.Operator):
-	"""Refresh an already loaded Minecraft world from latest save file"""
-	bl_idname = "mcprep.bridge_world_refresh"
-	bl_label = "Refresh World"
-	bl_options = {'REGISTER', 'UNDO'}
+    """Refresh an already loaded Minecraft world from latest save file"""
 
-	skipUsage: bpy.props.BoolProperty(
-		default = False,
-		options={'HIDDEN'}
-		)
+    bl_idname = "mcprep.bridge_world_refresh"
+    bl_label = "Refresh World"
+    bl_options = {"REGISTER", "UNDO"}
 
-	track_function = "bridge_refresh"
-	@tracking.report_error
-	def execute(self, context):
-		self.report({'ERROR'}, "Not yet implemented")
-		return {'CANCELLED'}
+    skipUsage: bpy.props.BoolProperty(default=False, options={"HIDDEN"})
+
+    track_function = "bridge_refresh"
+
+    @tracking.report_error
+    def execute(self, context):
+        self.report({"ERROR"}, "Not yet implemented")
+        return {"CANCELLED"}
 
 
 class MCPREP_OT_extend_world(bpy.types.Operator):
-	"""Extend the size of the world by adding more world chunk handlers"""
-	bl_idname = "mcprep.bridge_world_extend"
-	bl_label = "Extend World"
+    """Extend the size of the world by adding more world chunk handlers"""
 
-	skipUsage: bpy.props.BoolProperty(
-		default = False,
-		options={'HIDDEN'}
-		)
+    bl_idname = "mcprep.bridge_world_extend"
+    bl_label = "Extend World"
 
-	track_function = "bridge_refresh"
-	@tracking.report_error
-	def execute(self, context):
-		self.report({'ERROR'}, "Not yet implemented")
-		return {'CANCELLED'}
+    skipUsage: bpy.props.BoolProperty(default=False, options={"HIDDEN"})
+
+    track_function = "bridge_refresh"
+
+    @tracking.report_error
+    def execute(self, context):
+        self.report({"ERROR"}, "Not yet implemented")
+        return {"CANCELLED"}
 
 
 # -----------------------------------------------------------------------------
-#	Register
+# 	Register
 # -----------------------------------------------------------------------------
 
 
 classes = (
-	MCPREP_OT_import_world_from_objmeta,
-	MCPREP_OT_import_new_world,
-	MCPREP_OT_refresh_world,
-	MCPREP_OT_extend_world
+    MCPREP_OT_import_world_from_objmeta,
+    MCPREP_OT_import_new_world,
+    MCPREP_OT_refresh_world,
+    MCPREP_OT_extend_world,
 )
 
 
 def register():
-	for cls in classes:
-		bpy.utils.register_class(cls)
+    for cls in classes:
+        bpy.utils.register_class(cls)
 
 
 def unregister():
-	for cls in reversed(classes):
-		bpy.utils.unregister_class(cls)
+    for cls in reversed(classes):
+        bpy.utils.unregister_class(cls)

--- a/MCprep_addon/import_bridge/connector_common.py
+++ b/MCprep_addon/import_bridge/connector_common.py
@@ -26,260 +26,262 @@ any importer executables (including Mineways and jmc2obj).
 import os
 from . import nbt
 
+
 class Common(object):
+    def __init__(self, exec_path, saves, open_ui=False):
+        self.exec_path = exec_path  # path to mineways/Jmc2Obj executable
+        self.saves_path = saves  # path to folder of world saves (directories)
+        self.open_ui = open_ui  # If true, opens UI; if not, minimized & closes
+        self.world = None  # folder name of save, child of saves_path above
+        self.layer = None  # one of Overworld, Nether, The End
 
-	def __init__(self, exec_path, saves, open_ui=False):
-		self.exec_path = exec_path # path to mineways/Jmc2Obj executable
-		self.saves_path = saves # path to folder of world saves (directories)
-		self.open_ui = open_ui # If true, opens UI; if not, minimized & closes
-		self.world = None  # folder name of save, child of saves_path above
-		self.layer = None  # one of Overworld, Nether, The End
+        self.player_loc = None
 
-		self.player_loc = None
+    def set_world(self, world, layer="Overworld"):
+        """Set the world save and region."""
+        if layer not in ["Overworld", "Nether", "The End"]:
+            raise Exception("layer")
+        self.world = world
+        self.layer = layer
 
-	def set_world(self, world, layer='Overworld'):
-		"""Set the world save and region."""
-		if layer not in ['Overworld', 'Nether', 'The End']:
-			raise Exception("layer")
-		self.world = world
-		self.layer = layer
+    def list_worlds(self):
+        """Get the list of MC worlds on this machine"""
+        worlds = [
+            fold
+            for fold in os.listdir(self.saves_path)
+            if os.path.isdir(os.path.join(self.saves_path, fold))
+        ]
+        return worlds
 
-	def list_worlds(self):
-		"""Get the list of MC worlds on this machine"""
-		worlds = [fold for fold in os.listdir(self.saves_path)
-			if os.path.isdir(os.path.join(self.saves_path, fold))]
-		return worlds
+    def world_path(self):
+        """Returns the complete world path"""
+        if not self.saves_path or not self.world:
+            return None
+        else:
+            return os.path.join(self.saves_path, self.world)
 
-	def world_path(self):
-		"""Returns the complete world path"""
-		if not self.saves_path or not self.world:
-			return None
-		else:
-			return os.path.join(self.saves_path, self.world)
+    def get_player_location(self):
+        """Looks at level file and returns last player location"""
+        path = None
+        uuid = None
+        location = None
+        for root, dirs, files in os.walk(self.world_path()):
+            for file in files:
+                if file.endswith(".dat") and len(file) == 40:
+                    uuid = file[0:36]
+                    path = os.path.join(root, file)
+                    break
+            if path:
+                break
+                # player(uuid, os.path.join(root, file))
 
-	def get_player_location(self):
-		"""Looks at level file and returns last player location"""
-		path = None
-		uuid = None
-		location = None
-		for root, dirs, files in os.walk(self.world_path()):
-			for file in files:
-				if file.endswith(".dat") and len(file) == 40:
-					uuid = file[0:36]
-					path = os.path.join(root, file)
-					break
-			if path:
-				break
-					# player(uuid, os.path.join(root, file))
+        nbtfile = nbt.nbt.NBTFile(path, "rb")
+        if "Pos" in nbtfile:
+            location = list(nbtfile["Pos"])
+        # elif "bukkit" in nbtfile and "lastPlayed" in nbtfile["bukkit"]:
+        # 	location = "{},{},{}".format(
+        # 		nbtfile["bukkit"]["lastKnownName"],
+        # 		uuid,
+        # 		nbtfile["bukkit"]["lastPlayed"])
+        # 	location = location.split(',')
 
-		nbtfile = nbt.nbt.NBTFile(path,'rb')
-		if 'Pos' in nbtfile:
-			location = list(nbtfile['Pos'])
-		# elif "bukkit" in nbtfile and "lastPlayed" in nbtfile["bukkit"]:
-		# 	location = "{},{},{}".format(
-		# 		nbtfile["bukkit"]["lastKnownName"],
-		# 		uuid,
-		# 		nbtfile["bukkit"]["lastPlayed"])
-		# 	location = location.split(',')
+        return location
 
-		return location
+    def get_map_pixels(self, coord_list):
+        """Returns a list of pixels top-down for the given world selection
 
+        Arguments:
+                coord_list: list/tuple of coordinate pairs, each defining a chunk
+        Returns:
+                list of a list of hsl tuples for the given coordinates
+        """
 
-	def get_map_pixels(self, coord_list):
-		"""Returns a list of pixels top-down for the given world selection
+        # config settings for mapping blocks to top-down pixel rendering
 
-		Arguments:
-			coord_list: list/tuple of coordinate pairs, each defining a chunk
-		Returns:
-			list of a list of hsl tuples for the given coordinates
-		"""
+        world = WorldFolder(world_folder)
+        bb = world.get_boundingbox()
+        world_map = Image.new("RGB", (16 * bb.lenx(), 16 * bb.lenz()))
+        t = world.chunk_count()
+        try:
+            i = 0.0
+            for chunk in world.iter_chunks():
+                if i % 50 == 0:
+                    sys.stdout.write("Rendering image")
+                elif i % 2 == 0:
+                    sys.stdout.write(".")
+                    sys.stdout.flush()
+                elif i % 50 == 49:
+                    sys.stdout.write("%5.1f%%\n" % (100 * i / t))
+                i += 1
+                chunkmap = self.get_map_chunk(chunk)
+                x, z = chunk.get_coords()
+                world_map.paste(chunkmap, (16 * (x - bb.minx), 16 * (z - bb.minz)))
+            print(" done\n")
+            filename = os.path.basename(world_folder) + ".png"
+            world_map.save(filename, "PNG")
+            print("Saved map as %s" % filename)
+        except KeyboardInterrupt:
+            print(" aborted\n")
+            filename = os.path.basename(world_folder) + ".partial.png"
+            world_map.save(filename, "PNG")
+            print("Saved map as %s" % filename)
+            return 75  # EX_TEMPFAIL
+        if show:
+            world_map.show()
 
-		# config settings for mapping blocks to top-down pixel rendering
+    def get_map_chunk(self, chunk):
+        """Returns image array for given input chunk"""
 
-		world = WorldFolder(world_folder)
-		bb = world.get_boundingbox()
-		world_map = Image.new('RGB', (16*bb.lenx(),16*bb.lenz()))
-		t = world.chunk_count()
-		try:
-		    i =0.0
-		    for chunk in world.iter_chunks():
-		        if i % 50 ==0:
-		            sys.stdout.write("Rendering image")
-		        elif i % 2 == 0:
-		            sys.stdout.write(".")
-		            sys.stdout.flush()
-		        elif i % 50 == 49:
-		            sys.stdout.write("%5.1f%%\n" % (100*i/t))
-		        i +=1
-		        chunkmap = self.get_map_chunk(chunk)
-		        x,z = chunk.get_coords()
-		        world_map.paste(chunkmap, (16*(x-bb.minx),16*(z-bb.minz)))
-		    print(" done\n")
-		    filename = os.path.basename(world_folder)+".png"
-		    world_map.save(filename,"PNG")
-		    print("Saved map as %s" % filename)
-		except KeyboardInterrupt:
-		    print(" aborted\n")
-		    filename = os.path.basename(world_folder)+".partial.png"
-		    world_map.save(filename,"PNG")
-		    print("Saved map as %s" % filename)
-		    return 75 # EX_TEMPFAIL
-		if show:
-		    world_map.show()
+        block_ignore = ["air"]
+        block_colors = {
+            "acacia_leaves": {"h": 114, "s": 64, "l": 22},
+            "acacia_log": {"h": 35, "s": 93, "l": 30},
+            "air": {"h": 0, "s": 0, "l": 0},
+            "andesite": {"h": 0, "s": 0, "l": 32},
+            "azure_bluet": {"h": 0, "s": 0, "l": 100},
+            "bedrock": {"h": 0, "s": 0, "l": 10},
+            "birch_leaves": {"h": 114, "s": 64, "l": 22},
+            "birch_log": {"h": 35, "s": 93, "l": 30},
+            "blue_orchid": {"h": 0, "s": 0, "l": 100},
+            "bookshelf": {"h": 0, "s": 0, "l": 100},
+            "brown_mushroom": {"h": 0, "s": 0, "l": 100},
+            "brown_mushroom_block": {"h": 0, "s": 0, "l": 100},
+            "cactus": {"h": 126, "s": 61, "l": 20},
+            "cave_air": {"h": 0, "s": 0, "l": 0},
+            "chest": {"h": 0, "s": 100, "l": 50},
+            "clay": {"h": 7, "s": 62, "l": 23},
+            "coal_ore": {"h": 0, "s": 0, "l": 10},
+            "cobblestone": {"h": 0, "s": 0, "l": 25},
+            "cobblestone_stairs": {"h": 0, "s": 0, "l": 25},
+            "crafting_table": {"h": 0, "s": 0, "l": 100},
+            "dandelion": {"h": 60, "s": 100, "l": 60},
+            "dark_oak_leaves": {"h": 114, "s": 64, "l": 22},
+            "dark_oak_log": {"h": 35, "s": 93, "l": 30},
+            "dark_oak_planks": {"h": 35, "s": 93, "l": 30},
+            "dead_bush": {"h": 0, "s": 0, "l": 100},
+            "diorite": {"h": 0, "s": 0, "l": 32},
+            "dirt": {"h": 27, "s": 51, "l": 15},
+            "end_portal_frame": {"h": 0, "s": 100, "l": 50},
+            "farmland": {"h": 35, "s": 93, "l": 15},
+            "fire": {"h": 55, "s": 100, "l": 50},
+            "flowing_lava": {"h": 16, "s": 100, "l": 48},
+            "flowing_water": {"h": 228, "s": 50, "l": 23},
+            "glass_pane": {"h": 0, "s": 0, "l": 100},
+            "granite": {"h": 0, "s": 0, "l": 32},
+            "grass": {"h": 94, "s": 42, "l": 25},
+            "grass_block": {"h": 94, "s": 42, "l": 32},
+            "gravel": {"h": 21, "s": 18, "l": 20},
+            "ice": {"h": 240, "s": 10, "l": 95},
+            "infested_stone": {"h": 320, "s": 100, "l": 50},
+            "iron_ore": {"h": 22, "s": 65, "l": 61},
+            "iron_bars": {"h": 22, "s": 65, "l": 61},
+            "ladder": {"h": 35, "s": 93, "l": 30},
+            "lava": {"h": 16, "s": 100, "l": 48},
+            "lilac": {"h": 0, "s": 0, "l": 100},
+            "lily_pad": {"h": 114, "s": 64, "l": 18},
+            "lit_pumpkin": {"h": 24, "s": 100, "l": 45},
+            "mossy_cobblestone": {"h": 115, "s": 30, "l": 50},
+            "mushroom_stem": {"h": 0, "s": 0, "l": 100},
+            "oak_door": {"h": 35, "s": 93, "l": 30},
+            "oak_fence": {"h": 35, "s": 93, "l": 30},
+            "oak_fence_gate": {"h": 35, "s": 93, "l": 30},
+            "oak_leaves": {"h": 114, "s": 64, "l": 22},
+            "oak_log": {"h": 35, "s": 93, "l": 30},
+            "oak_planks": {"h": 35, "s": 93, "l": 30},
+            "oak_pressure_plate": {"h": 35, "s": 93, "l": 30},
+            "oak_stairs": {"h": 114, "s": 64, "l": 22},
+            "peony": {"h": 0, "s": 0, "l": 100},
+            "pink_tulip": {"h": 0, "s": 0, "l": 0},
+            "poppy": {"h": 0, "s": 100, "l": 50},
+            "pumpkin": {"h": 24, "s": 100, "l": 45},
+            "rail": {"h": 33, "s": 81, "l": 50},
+            "red_mushroom": {"h": 0, "s": 50, "l": 20},
+            "red_mushroom_block": {"h": 0, "s": 50, "l": 20},
+            "rose_bush": {"h": 0, "s": 0, "l": 100},
+            "sugar_cane": {"h": 123, "s": 70, "l": 50},
+            "sand": {"h": 53, "s": 22, "l": 58},
+            "sandstone": {"h": 48, "s": 31, "l": 40},
+            "seagrass": {"h": 94, "s": 42, "l": 25},
+            "sign": {"h": 114, "s": 64, "l": 22},
+            "spruce_leaves": {"h": 114, "s": 64, "l": 22},
+            "spruce_log": {"h": 35, "s": 93, "l": 30},
+            "stone": {"h": 0, "s": 0, "l": 32},
+            "stone_slab": {"h": 0, "s": 0, "l": 32},
+            "tall_grass": {"h": 94, "s": 42, "l": 25},
+            "tall_seagrass": {"h": 94, "s": 42, "l": 25},
+            "torch": {"h": 60, "s": 100, "l": 50},
+            "snow": {"h": 240, "s": 10, "l": 85},
+            "spawner": {"h": 180, "s": 100, "l": 50},
+            "vine": {"h": 114, "s": 64, "l": 18},
+            "wall_torch": {"h": 60, "s": 100, "l": 50},
+            "water": {"h": 228, "s": 50, "l": 23},
+            "wheat": {"h": 123, "s": 60, "l": 50},
+            "white_wool": {"h": 0, "s": 0, "l": 100},
+        }
 
+        pixels = b""
 
-	def get_map_chunk(self, chunk):
-		"""Returns image array for given input chunk"""
+        for z in range(16):
+            for x in range(16):
+                # Find the highest block in this column
+                max_height = chunk.get_max_height()
+                ground_height = max_height
+                tints = []
+                for y in range(max_height, -1, -1):
+                    block_id = chunk.get_block(x, y, z)
+                    if block_id != None:
+                        if block_id not in block_ignore or y == 0:
+                            # Here is ground level
+                            ground_height = y
+                            break
 
-		block_ignore = ['air']
-		block_colors = {
-			'acacia_leaves':        {'h':114, 's':64,  'l':22 },
-			'acacia_log':           {'h':35,  's':93,  'l':30 },
-			'air':                  {'h':0,   's':0,   'l':0  },
-			'andesite':             {'h':0,   's':0,   'l':32 },
-			'azure_bluet':          {'h':0,   's':0,   'l':100},
-			'bedrock':              {'h':0,   's':0,   'l':10 },
-			'birch_leaves':         {'h':114, 's':64,  'l':22 },
-			'birch_log':            {'h':35,  's':93,  'l':30 },
-			'blue_orchid':          {'h':0,   's':0,   'l':100},
-			'bookshelf':            {'h':0,   's':0,   'l':100},
-			'brown_mushroom':       {'h':0,   's':0,   'l':100},
-			'brown_mushroom_block': {'h':0,   's':0,   'l':100},
-			'cactus':               {'h':126, 's':61,  'l':20 },
-			'cave_air':             {'h':0,   's':0,   'l':0  },
-			'chest':                {'h':0,   's':100, 'l':50 },
-			'clay':                 {'h':7,   's':62,  'l':23 },
-			'coal_ore':             {'h':0,   's':0,   'l':10 },
-			'cobblestone':          {'h':0,   's':0,   'l':25 },
-			'cobblestone_stairs':   {'h':0,   's':0,   'l':25 },
-			'crafting_table':       {'h':0,   's':0,   'l':100},
-			'dandelion':            {'h':60,  's':100, 'l':60 },
-			'dark_oak_leaves':      {'h':114, 's':64,  'l':22 },
-			'dark_oak_log':         {'h':35,  's':93,  'l':30 },
-			'dark_oak_planks':      {'h':35,  's':93,  'l':30 },
-			'dead_bush':            {'h':0,   's':0,   'l':100},
-			'diorite':              {'h':0,   's':0,   'l':32 },
-			'dirt':                 {'h':27,  's':51,  'l':15 },
-			'end_portal_frame':     {'h':0,   's':100, 'l':50 },
-			'farmland':             {'h':35,  's':93,  'l':15 },
-			'fire':                 {'h':55,  's':100, 'l':50 },
-			'flowing_lava':         {'h':16,  's':100, 'l':48 },
-			'flowing_water':        {'h':228, 's':50,  'l':23 },
-			'glass_pane':           {'h':0,   's':0,   'l':100},
-			'granite':              {'h':0,   's':0,   'l':32 },
-			'grass':                {'h':94,  's':42,  'l':25 },
-			'grass_block':          {'h':94,  's':42,  'l':32 },
-			'gravel':               {'h':21,  's':18,  'l':20 },
-			'ice':                  {'h':240, 's':10,  'l':95 },
-			'infested_stone':       {'h':320, 's':100, 'l':50 },
-			'iron_ore':             {'h':22,  's':65,  'l':61 },
-			'iron_bars':            {'h':22,  's':65,  'l':61 },
-			'ladder':               {'h':35,  's':93,  'l':30 },
-			'lava':                 {'h':16,  's':100, 'l':48 },
-			'lilac':                {'h':0,   's':0,   'l':100},
-			'lily_pad':             {'h':114, 's':64,  'l':18 },
-			'lit_pumpkin':          {'h':24,  's':100, 'l':45 },
-			'mossy_cobblestone':    {'h':115, 's':30,  'l':50 },
-			'mushroom_stem':        {'h':0,   's':0,   'l':100},
-			'oak_door':             {'h':35,  's':93,  'l':30 },
-			'oak_fence':            {'h':35,  's':93,  'l':30 },
-			'oak_fence_gate':       {'h':35,  's':93,  'l':30 },
-			'oak_leaves':           {'h':114, 's':64,  'l':22 },
-			'oak_log':              {'h':35,  's':93,  'l':30 },
-			'oak_planks':           {'h':35,  's':93,  'l':30 },
-			'oak_pressure_plate':   {'h':35,  's':93,  'l':30 },
-			'oak_stairs':           {'h':114, 's':64,  'l':22 },
-			'peony':                {'h':0,   's':0,   'l':100},
-			'pink_tulip':           {'h':0,   's':0,   'l':0  },
-			'poppy':                {'h':0,   's':100, 'l':50 },
-			'pumpkin':              {'h':24,  's':100, 'l':45 },
-			'rail':                 {'h':33,  's':81,  'l':50 },
-			'red_mushroom':         {'h':0,   's':50,  'l':20 },
-			'red_mushroom_block':   {'h':0,   's':50,  'l':20 },
-			'rose_bush':            {'h':0,   's':0,   'l':100},
-			'sugar_cane':           {'h':123, 's':70,  'l':50 },
-			'sand':                 {'h':53,  's':22,  'l':58 },
-			'sandstone':            {'h':48,  's':31,  'l':40 },
-			'seagrass':             {'h':94,  's':42,  'l':25 },
-			'sign':                 {'h':114, 's':64,  'l':22 },
-			'spruce_leaves':        {'h':114, 's':64,  'l':22 },
-			'spruce_log':           {'h':35,  's':93,  'l':30 },
-			'stone':                {'h':0,   's':0,   'l':32 },
-			'stone_slab':           {'h':0,   's':0,   'l':32 },
-			'tall_grass':           {'h':94,  's':42,  'l':25 },
-			'tall_seagrass':        {'h':94,  's':42,  'l':25 },
-			'torch':                {'h':60,  's':100, 'l':50 },
-			'snow':                 {'h':240, 's':10,  'l':85 },
-			'spawner':              {'h':180, 's':100, 'l':50 },
-			'vine':                 {'h':114, 's':64,  'l':18 },
-			'wall_torch':           {'h':60,  's':100, 'l':50 },
-			'water':                {'h':228, 's':50,  'l':23 },
-			'wheat':                {'h':123, 's':60,  'l':50 },
-			'white_wool':           {'h':0,   's':0,   'l':100},
-			}
+                if block_id != None:
+                    if block_id in block_colors:
+                        color = block_colors[block_id]
+                    else:
+                        color = {"h": 0, "s": 0, "l": 100}
+                        print("warning: unknown color for block id: %s" % block_id)
+                        print("hint: add that block to the 'block_colors' map")
+                else:
+                    color = {"h": 0, "s": 0, "l": 0}
 
-		pixels = b""
+                height_shift = 0  # (ground_height-64)*0.25
 
-		for z in range(16):
-		    for x in range(16):
-		        # Find the highest block in this column
-		        max_height = chunk.get_max_height()
-		        ground_height = max_height
-		        tints = []
-		        for y in range(max_height,-1,-1):
-		            block_id = chunk.get_block(x, y, z)
-		            if block_id != None:
-		                if (block_id not in block_ignore or y == 0):
-		                    # Here is ground level
-		                    ground_height = y
-		                    break
+                final_color = {
+                    "h": color["h"],
+                    "s": color["s"],
+                    "l": color["l"] + height_shift,
+                }
+                if final_color["l"] > 100:
+                    final_color["l"] = 100
+                if final_color["l"] < 0:
+                    final_color["l"] = 0
 
-		        if block_id != None:
-		            if block_id in block_colors:
-		                color = block_colors[block_id]
-		            else:
-		                color = {'h':0, 's':0, 'l':100}
-		                print("warning: unknown color for block id: %s" % block_id)
-		                print("hint: add that block to the 'block_colors' map")
-		        else:
-		            color = {'h':0, 's':0, 'l':0}
+                # Apply tints from translucent blocks
+                for tint in reversed(tints):
+                    final_color = hsl_slide(final_color, tint, 0.4)
 
-		        height_shift = 0 #(ground_height-64)*0.25
+                rgb = hsl2rgb(final_color["h"], final_color["s"], final_color["l"])
 
-		        final_color = {'h':color['h'], 's':color['s'], 'l':color['l'] + height_shift}
-		        if final_color['l'] > 100: final_color['l'] = 100
-		        if final_color['l'] < 0: final_color['l'] = 0
+                pixels += pack("BBB", rgb[0], rgb[1], rgb[2])
 
-		        # Apply tints from translucent blocks
-		        for tint in reversed(tints):
-		            final_color = hsl_slide(final_color, tint, 0.4)
+        im = Image.frombytes("RGB", (16, 16), pixels)
 
-		        rgb = hsl2rgb(final_color['h'], final_color['s'], final_color['l'])
+    def run_export_single(self, obj_path, coord_a, coord_b):
+        """Run export based on world name and coordinates."""
+        return self.run_export_multiple(obj_path, [[coord_a, coord_b]])
 
-		        pixels += pack("BBB", rgb[0], rgb[1], rgb[2])
+    def run_export_multiple(self, export_path, coord_list):
+        """Run export based on world name and coordinates.
 
-		im = Image.frombytes('RGB', (16,16), pixels)
+        Arguments:
+                world: Name of the world matching folder in save folder
+                min_corner: First coordinate for volume
+                max_corner: Second coordinate for volume
+        Returns:
+                List of intended obj files, may not exist yet
+        """
+        return []
 
-
-
-	def run_export_single(self, obj_path, coord_a, coord_b):
-		"""Run export based on world name and coordinates."""
-		return self.run_export_multiple(obj_path, [[coord_a, coord_b]])
-
-	def run_export_multiple(self, export_path, coord_list):
-		"""Run export based on world name and coordinates.
-
-		Arguments:
-			world: Name of the world matching folder in save folder
-			min_corner: First coordinate for volume
-			max_corner: Second coordinate for volume
-		Returns:
-			List of intended obj files, may not exist yet
-		"""
-		return []
-
-	def run_async_proc(self, func, args):
-		"""Run a function execution in another thread"""
-
-
-
+    def run_async_proc(self, func, args):
+        """Run a function execution in another thread"""

--- a/MCprep_addon/import_bridge/mineways_connector.py
+++ b/MCprep_addon/import_bridge/mineways_connector.py
@@ -27,158 +27,164 @@ import platform
 from subprocess import Popen, PIPE
 
 from . import connector_common as common
+
 # import connector_common as common
 
 
 class MinewaysConnector(common.Common):
-	"""Pure python bridge class for calling and controlling Mineways sans UI"""
+    """Pure python bridge class for calling and controlling Mineways sans UI"""
 
-	def save_script(self, cmds):
-		"""Save script commands to temp file, returning the path"""
-		fd, path = tempfile.mkstemp(suffix='.mwscript')
-		try:
-			with os.fdopen(fd, 'w') as tmp:
-				tmp.write('\n'.join(cmds)+'\n')
-		except Exception as err:
-			print("Error occured:", err)
-		return path
+    def save_script(self, cmds):
+        """Save script commands to temp file, returning the path"""
+        fd, path = tempfile.mkstemp(suffix=".mwscript")
+        try:
+            with os.fdopen(fd, "w") as tmp:
+                tmp.write("\n".join(cmds) + "\n")
+        except Exception as err:
+            print("Error occured:", err)
+        return path
 
-	def run_mineways_command(self, cmd_file):
-		"""Open mineways exec, with file if relevant"""
+    def run_mineways_command(self, cmd_file):
+        """Open mineways exec, with file if relevant"""
 
-		# TMP, create log output file
-		# logout = 'Z:\\Users\\patrickcrawford\\Desktop\\mineways_logging.text'
-		# logout = '/Users/patrickcrawford/Desktop/mineways_logging.text'
+        # TMP, create log output file
+        # logout = 'Z:\\Users\\patrickcrawford\\Desktop\\mineways_logging.text'
+        # logout = '/Users/patrickcrawford/Desktop/mineways_logging.text'
 
-		if platform.system() == "Darwin": # ie OSX
-			# if OSX, include wine in command (assumes installed)
-			cmd = ['wine', self.exec_path, cmd_file] # , '-l', logout
-		else:
-			cmd = [self.exec_path, cmd_file]
+        if platform.system() == "Darwin":  # ie OSX
+            # if OSX, include wine in command (assumes installed)
+            cmd = ["wine", self.exec_path, cmd_file]  # , '-l', logout
+        else:
+            cmd = [self.exec_path, cmd_file]
 
-		if self.open_ui is False:
-			cmd.append('-m')
+        if self.open_ui is False:
+            cmd.append("-m")
 
-		print("Commands sent to mineways:")
-		print(cmd)
-		p = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE)
-		stdout, err = p.communicate(b"")
-		print(str(stdout))
+        print("Commands sent to mineways:")
+        print(cmd)
+        p = Popen(cmd, stdin=PIPE, stdout=PIPE, stderr=PIPE)
+        stdout, err = p.communicate(b"")
+        print(str(stdout))
 
-		if err != b"":
-			return "Error occured while running command: "+str(err)
-		return [False, []]
+        if err != b"":
+            return "Error occured while running command: " + str(err)
+        return [False, []]
 
-	def default_mcprep_obj(self):
-		"""Decent default commands to set for output"""
-		cmds = [
-			"Set render type: Wavefront OBJ absolute indices",
-			"Units for the model vertex data itself: meters",
-			"File type: Export full color texture patterns",
-			"Texture output RGB: YES",
-			"Texture output A: no", # default was YES, matters?
-			"Texture output RGBA: YES",
-			"Export separate objects: YES",
-			"Individual blocks: no",
-			"Material per object: YES",
-			"Split by block type: YES",
-			"G3D full material: no",
-			"Make Z the up direction instead of Y: no",
-			"Create composite overlay faces: no",
-			"Center model: no",  # default YES
-			"Export lesser blocks: YES",
-			"Fatten lesser blocks: no",
-			"Create block faces at the borders: no", # default YES
-			"Make tree leaves solid: no",
-			"Use biomes: no",
-			"Rotate model 0.000000 degrees",
-			"Scale model by making each block 1000 mm high",
-			"Fill air bubbles: no; Seal off entrances: no; Fill in isolated tunnels in base of model: no",
-			"Connect parts sharing an edge: no; Connect corner tips: no; Weld all shared edges: no",
-			"Delete floating objects: trees and parts smaller than 16 blocks: no",
-			"Hollow out bottom of model, making the walls 1000 mm thick: no; Superhollow: no",
-			"Melt snow blocks: no"
-		]
-		return cmds
+    def default_mcprep_obj(self):
+        """Decent default commands to set for output"""
+        cmds = [
+            "Set render type: Wavefront OBJ absolute indices",
+            "Units for the model vertex data itself: meters",
+            "File type: Export full color texture patterns",
+            "Texture output RGB: YES",
+            "Texture output A: no",  # default was YES, matters?
+            "Texture output RGBA: YES",
+            "Export separate objects: YES",
+            "Individual blocks: no",
+            "Material per object: YES",
+            "Split by block type: YES",
+            "G3D full material: no",
+            "Make Z the up direction instead of Y: no",
+            "Create composite overlay faces: no",
+            "Center model: no",  # default YES
+            "Export lesser blocks: YES",
+            "Fatten lesser blocks: no",
+            "Create block faces at the borders: no",  # default YES
+            "Make tree leaves solid: no",
+            "Use biomes: no",
+            "Rotate model 0.000000 degrees",
+            "Scale model by making each block 1000 mm high",
+            "Fill air bubbles: no; Seal off entrances: no; Fill in isolated tunnels in base of model: no",
+            "Connect parts sharing an edge: no; Connect corner tips: no; Weld all shared edges: no",
+            "Delete floating objects: trees and parts smaller than 16 blocks: no",
+            "Hollow out bottom of model, making the walls 1000 mm thick: no; Superhollow: no",
+            "Melt snow blocks: no",
+        ]
+        return cmds
 
-	def run_export_multiple(self, export_path, coord_list):
-		"""Run mineways export based on world name and coordinates.
+    def run_export_multiple(self, export_path, coord_list):
+        """Run mineways export based on world name and coordinates.
 
-		Arguments:
-			world: Name of the world matching folder in save folder
-			min_corner: First coordinate for volume
-			max_corner: Second coordinate for volume
-		Returns:
-			List of intended obj files, may not exist yet
-		"""
+        Arguments:
+                world: Name of the world matching folder in save folder
+                min_corner: First coordinate for volume
+                max_corner: Second coordinate for volume
+        Returns:
+                List of intended obj files, may not exist yet
+        """
 
-		cmds = []
-		cmds.append("Minecraft world: " + str(self.world))
-		if self.layer:
-			cmds.append("View "+self.layer)
+        cmds = []
+        cmds.append("Minecraft world: " + str(self.world))
+        if self.layer:
+            cmds.append("View " + self.layer)
 
-		# Add all default world options relevant for 3D rendering
-		cmds += self.default_mcprep_obj()
+        # Add all default world options relevant for 3D rendering
+        cmds += self.default_mcprep_obj()
 
-		for coord_a, coord_b in coord_list:
-			if len(coord_a) != 3 or len(coord_b) != 3:
-				raise Exception("Coordinates must be length 3")
-			for point in coord_a+coord_b:
-				if not isinstance(point, int):
-					raise Exception("Coordinates must be integers")
+        for coord_a, coord_b in coord_list:
+            if len(coord_a) != 3 or len(coord_b) != 3:
+                raise Exception("Coordinates must be length 3")
+            for point in coord_a + coord_b:
+                if not isinstance(point, int):
+                    raise Exception("Coordinates must be integers")
 
-			cmds.append(
-				"Selection location min to max: {}, {}, {} to {}, {}, {}".format(
-					min(coord_a[0], coord_b[0]),
-					min(coord_a[1], coord_b[1]),
-					min(coord_a[2], coord_b[2]),
-					max(coord_a[0], coord_b[0]),
-					max(coord_a[1], coord_b[1]),
-					max(coord_a[2], coord_b[2])
-					))
+            cmds.append(
+                "Selection location min to max: {}, {}, {} to {}, {}, {}".format(
+                    min(coord_a[0], coord_b[0]),
+                    min(coord_a[1], coord_b[1]),
+                    min(coord_a[2], coord_b[2]),
+                    max(coord_a[0], coord_b[0]),
+                    max(coord_a[1], coord_b[1]),
+                    max(coord_a[2], coord_b[2]),
+                )
+            )
 
-			# backslash paths for both OSX via wine and Windows
-			if not self.open_ui:
-				outfile = export_path.replace('/', '\\')
-				# outfile = export_path + '\\out_file_test.obj'
-				# e.g. Z:\Users\...\out_file_test.obj
-				cmds.append('Export for rendering: '+outfile)
+            # backslash paths for both OSX via wine and Windows
+            if not self.open_ui:
+                outfile = export_path.replace("/", "\\")
+                # outfile = export_path + '\\out_file_test.obj'
+                # e.g. Z:\Users\...\out_file_test.obj
+                cmds.append("Export for rendering: " + outfile)
 
-		if not self.open_ui:
-			cmds.append('Close') # ensures Mineways closes at the end
+        if not self.open_ui:
+            cmds.append("Close")  # ensures Mineways closes at the end
 
-		cmd_file = self.save_script(cmds)
-		print(cmd_file)
-		res = self.run_mineways_command(cmd_file)
-		print("Success?", res)
-		os.remove(cmd_file)
-		# if os.path.isfile(outfile): # also check time
+        cmd_file = self.save_script(cmds)
+        print(cmd_file)
+        res = self.run_mineways_command(cmd_file)
+        print("Success?", res)
+        os.remove(cmd_file)
+        # if os.path.isfile(outfile): # also check time
 
 
 def run_test():
-	"""Run default test open and export."""
+    """Run default test open and export."""
 
-	exec_path = '/Users/patrickcrawford/Documents/blender/minecraft/mineways/Mineways.exe'
-	saves_path = '/Users/patrickcrawford/Library/Application Support/minecraft/saves/'
+    exec_path = (
+        "/Users/patrickcrawford/Documents/blender/minecraft/mineways/Mineways.exe"
+    )
+    saves_path = "/Users/patrickcrawford/Library/Application Support/minecraft/saves/"
 
-	connector = MinewaysConnector(exec_path, saves_path)
-	print("Running Mineways - MCprep bridge test")
-	worlds = connector.list_worlds()
-	print(worlds)
+    connector = MinewaysConnector(exec_path, saves_path)
+    print("Running Mineways - MCprep bridge test")
+    worlds = connector.list_worlds()
+    print(worlds)
 
-	world = "QMAGNET's Test Map [1.12.1] mod"
-	print("using hard-coded world: ", world)
-	coord_a = [198, 43, 197] # same as the "Selection", vs non-empty selection
-	coord_b = [237, 255, 235] #
+    world = "QMAGNET's Test Map [1.12.1] mod"
+    print("using hard-coded world: ", world)
+    coord_a = [198, 43, 197]  # same as the "Selection", vs non-empty selection
+    coord_b = [237, 255, 235]  #
 
-	# takes single set of coordinate inputs,
-	# the multi version would have a list of 2-coords
-	print("Running export")
-	obj_path = 'C:\\Users\\patrickcrawford\\Desktop\\temp\\out_file_test.obj'  # also works
-	# out_path = 'Z:\\Users\\patrickcrawford\\Desktop\\temp'  # def. works
-	connector.set_world(world)
-	connector.run_export_single(obj_path, coord_a, coord_b)
+    # takes single set of coordinate inputs,
+    # the multi version would have a list of 2-coords
+    print("Running export")
+    obj_path = (
+        "C:\\Users\\patrickcrawford\\Desktop\\temp\\out_file_test.obj"  # also works
+    )
+    # out_path = 'Z:\\Users\\patrickcrawford\\Desktop\\temp'  # def. works
+    connector.set_world(world)
+    connector.run_export_single(obj_path, coord_a, coord_b)
 
 
 if __name__ == "__main__":
-	run_test()
+    run_test()

--- a/MCprep_addon/load_modules.py
+++ b/MCprep_addon/load_modules.py
@@ -23,94 +23,94 @@ import bpy
 
 # Per module loading for stable, in-session updates, even if new files are added
 if "conf" in locals():
-	importlib.reload(conf)
+    importlib.reload(conf)
 else:
-	from . import conf
+    from . import conf
 
 if "tracking" in locals():
-	importlib.reload(tracking)
+    importlib.reload(tracking)
 else:
-	from . import tracking
+    from . import tracking
 
 if "util_operators" in locals():
-	importlib.reload(util_operators)
+    importlib.reload(util_operators)
 else:
-	from . import util_operators
+    from . import util_operators
 
 if "material_manager" in locals():
-	importlib.reload(material_manager)
+    importlib.reload(material_manager)
 else:
-	from .materials import material_manager
+    from .materials import material_manager
 
 if "prep" in locals():
-	importlib.reload(prep)
+    importlib.reload(prep)
 else:
-	from .materials import prep
+    from .materials import prep
 
 if "optimize_scene" in locals():
-	importlib.reload(optimize_scene)
+    importlib.reload(optimize_scene)
 else:
-	from . import optimize_scene
+    from . import optimize_scene
 
 if "sequences" in locals():
-	importlib.reload(sequences)
+    importlib.reload(sequences)
 else:
-	from .materials import sequences
+    from .materials import sequences
 
 if "skin" in locals():
-	importlib.reload(skin)
+    importlib.reload(skin)
 else:
-	from .materials import skin
+    from .materials import skin
 
 if "sync" in locals():
-	importlib.reload(sync)
+    importlib.reload(sync)
 else:
-	from .materials import sync
+    from .materials import sync
 
 if "uv_tools" in locals():
-	importlib.reload(uv_tools)
+    importlib.reload(uv_tools)
 else:
-	from .materials import uv_tools
+    from .materials import uv_tools
 
 if "spawn_util" in locals():
-	importlib.reload(spawn_util)
+    importlib.reload(spawn_util)
 else:
-	from .spawner import spawn_util
+    from .spawner import spawn_util
 
 if "meshswap" in locals():
-	importlib.reload(meshswap)
+    importlib.reload(meshswap)
 else:
-	from .spawner import meshswap
+    from .spawner import meshswap
 
 if "mcmodel" in locals():
-	importlib.reload(mcmodel)
+    importlib.reload(mcmodel)
 else:
-	from .spawner import mcmodel
+    from .spawner import mcmodel
 
 if "mobs" in locals():
-	importlib.reload(mobs)
+    importlib.reload(mobs)
 else:
-	from .spawner import mobs
+    from .spawner import mobs
 
 if "entities" in locals():
-	importlib.reload(entities)
+    importlib.reload(entities)
 else:
-	from .spawner import entities
+    from .spawner import entities
 
 if "world_tools" in locals():
-	importlib.reload(world_tools)
+    importlib.reload(world_tools)
 else:
-	from . import world_tools
+    from . import world_tools
 
 if "item" in locals():
-	importlib.reload(item)
+    importlib.reload(item)
 else:
-	from .spawner import item
+    from .spawner import item
 
 if "effects" in locals():
-	importlib.reload(effects)
+    importlib.reload(effects)
 else:
-	from .spawner import effects
+    from .spawner import effects
 
 # if "bridge" in locals():
 # 	importlib.reload(bridge)
@@ -118,80 +118,80 @@ else:
 # 	from .mineways_bridge import bridge
 
 if "mcprep_ui" in locals():
-	importlib.reload(mcprep_ui)
+    importlib.reload(mcprep_ui)
 else:
-	from . import mcprep_ui
+    from . import mcprep_ui
 
 if "util" in locals():
-	importlib.reload(util)
+    importlib.reload(util)
 else:
-	from . import util
+    from . import util
 
 if "tracking" in locals():
-	importlib.reload(tracking)
+    importlib.reload(tracking)
 else:
-	from . import tracking
+    from . import tracking
 
 if "addon_updater" in locals():
-	importlib.reload(addon_updater)
+    importlib.reload(addon_updater)
 else:
-	from . import addon_updater
+    from . import addon_updater
 
 if "addon_updater_ops" in locals():
-	importlib.reload(addon_updater_ops)
+    importlib.reload(addon_updater_ops)
 else:
-	from . import addon_updater_ops
+    from . import addon_updater_ops
 
 if "generate" in locals():
-	importlib.reload(generate)
+    importlib.reload(generate)
 else:
-	from .materials import generate
+    from .materials import generate
 
 
 # Only include those with a register function, which is not all
 module_list = (
-	util_operators,
-	material_manager,
-	prep,
-	skin,
-	sequences,
-	sync,
-	uv_tools,
-	spawn_util,
-	meshswap,
-	mobs,
-	entities,
-	mcmodel,
-	item,
-	effects,
-	world_tools,
-	# bridge,
-	mcprep_ui,
-	optimize_scene
+    util_operators,
+    material_manager,
+    prep,
+    skin,
+    sequences,
+    sync,
+    uv_tools,
+    spawn_util,
+    meshswap,
+    mobs,
+    entities,
+    mcmodel,
+    item,
+    effects,
+    world_tools,
+    # bridge,
+    mcprep_ui,
+    optimize_scene,
 )
 
 
 def register(bl_info):
-	tracking.register(bl_info)
-	for mod in module_list:
-		mod.register()
+    tracking.register(bl_info)
+    for mod in module_list:
+        mod.register()
 
-	# addon updater code and configurations
-	addon_updater_ops.register(bl_info)
+    # addon updater code and configurations
+    addon_updater_ops.register(bl_info)
 
-	# Inject the custom updater function, to use release zip instead src.
-	addon_updater_ops.updater.select_link = conf.updater_select_link_function
+    # Inject the custom updater function, to use release zip instead src.
+    addon_updater_ops.updater.select_link = conf.updater_select_link_function
 
-	conf.env.log("MCprep: Verbose is enabled")
-	conf.env.log("MCprep: Very Verbose is enabled", vv_only=True)
+    conf.env.log("MCprep: Verbose is enabled")
+    conf.env.log("MCprep: Very Verbose is enabled", vv_only=True)
 
 
 def unregister(bl_info):
-	for mod in reversed(module_list):
-		mod.unregister()
+    for mod in reversed(module_list):
+        mod.unregister()
 
-	tracking.unregister()
-	conf.unregister()
+    tracking.unregister()
+    conf.unregister()
 
-	# addon updater code and configurations
-	addon_updater_ops.unregister()
+    # addon updater code and configurations
+    addon_updater_ops.unregister()

--- a/MCprep_addon/materials/generate.py
+++ b/MCprep_addon/materials/generate.py
@@ -30,717 +30,729 @@ from ..conf import env
 
 
 def update_mcprep_texturepack_path(self, context):
-	"""Triggered if the scene-level resource pack path is updated."""
-	bpy.ops.mcprep.reload_items()
-	bpy.ops.mcprep.reload_materials()
-	bpy.ops.mcprep.reload_models()
-	env.material_sync_cache = None
+    """Triggered if the scene-level resource pack path is updated."""
+    bpy.ops.mcprep.reload_items()
+    bpy.ops.mcprep.reload_materials()
+    bpy.ops.mcprep.reload_models()
+    env.material_sync_cache = None
 
-	# Forces particle plane emitter to now use the newly set resource pack
-	# the first time, but the value gets saved again after.
-	context.scene.mcprep_particle_plane_file = ''
+    # Forces particle plane emitter to now use the newly set resource pack
+    # the first time, but the value gets saved again after.
+    context.scene.mcprep_particle_plane_file = ""
 
 
 def get_mc_canonical_name(name):
-	"""Convert a material name to standard MC name.
+    """Convert a material name to standard MC name.
 
-	Returns:
-		canonical name, or fallback to generalized name (never returns None)
-		form (mc, jmc, or mineways)
-	"""
-	general_name = util.nameGeneralize(name)
-	if not env.json_data:
-		res = util.load_mcprep_json()
-		if not res:
-			return general_name, None
+    Returns:
+            canonical name, or fallback to generalized name (never returns None)
+            form (mc, jmc, or mineways)
+    """
+    general_name = util.nameGeneralize(name)
+    if not env.json_data:
+        res = util.load_mcprep_json()
+        if not res:
+            return general_name, None
 
-	# Special case to allow material names, e.g. in meshswap, to end in .emit
-	# while still mapping to canonical names, to pick up features like animated
-	# textures. Cross check that name isn't exactly .emit to avoid None return.
-	if ".emit" in general_name and general_name != ".emit":
-		general_name = general_name.replace(".emit", "")
+    # Special case to allow material names, e.g. in meshswap, to end in .emit
+    # while still mapping to canonical names, to pick up features like animated
+    # textures. Cross check that name isn't exactly .emit to avoid None return.
+    if ".emit" in general_name and general_name != ".emit":
+        general_name = general_name.replace(".emit", "")
 
-	no_missing = "blocks" in env.json_data
-	no_missing &= "block_mapping_mc" in env.json_data["blocks"]
-	no_missing &= "block_mapping_jmc" in env.json_data["blocks"]
-	no_missing &= "block_mapping_mineways" in env.json_data["blocks"]
+    no_missing = "blocks" in env.json_data
+    no_missing &= "block_mapping_mc" in env.json_data["blocks"]
+    no_missing &= "block_mapping_jmc" in env.json_data["blocks"]
+    no_missing &= "block_mapping_mineways" in env.json_data["blocks"]
 
-	if no_missing is False:
-		env.log("Missing key values in json")
-		return general_name, None
+    if no_missing is False:
+        env.log("Missing key values in json")
+        return general_name, None
 
-	# The below workaround is to account for the jmc2obj v113+ which changes
-	# how mappings and assignments work.
-	if general_name.startswith("minecraft_block-"):
-		# minecraft_block-name maps to textures/block/name.png,
-		# other options over block are: entity, models, etc.
-		jmc_prefix = True
-		general_name = name[len("minecraft_block-"):]
-	else:
-		jmc_prefix = False
+    # The below workaround is to account for the jmc2obj v113+ which changes
+    # how mappings and assignments work.
+    if general_name.startswith("minecraft_block-"):
+        # minecraft_block-name maps to textures/block/name.png,
+        # other options over block are: entity, models, etc.
+        jmc_prefix = True
+        general_name = name[len("minecraft_block-") :]
+    else:
+        jmc_prefix = False
 
-	# Patch naming to avoid issues.
-	if general_name == "water":
-		# Improves connection with older exports, without getting
-		# mixed up with the new "water": "painting/water" texture.
-		general_name = "water_still"
+    # Patch naming to avoid issues.
+    if general_name == "water":
+        # Improves connection with older exports, without getting
+        # mixed up with the new "water": "painting/water" texture.
+        general_name = "water_still"
 
-	if general_name in env.json_data["blocks"]["block_mapping_mc"]:
-		canon = env.json_data["blocks"]["block_mapping_mc"][general_name]
-		form = "mc" if not jmc_prefix else "jmc2obj"
-	elif general_name in env.json_data["blocks"]["block_mapping_jmc"]:
-		canon = env.json_data["blocks"]["block_mapping_jmc"][general_name]
-		form = "jmc2obj"
-	elif general_name in env.json_data["blocks"]["block_mapping_mineways"]:
-		canon = env.json_data["blocks"]["block_mapping_mineways"][general_name]
-		form = "mineways"
-	elif general_name.lower() in env.json_data["blocks"]["block_mapping_jmc"]:
-		canon = env.json_data["blocks"]["block_mapping_jmc"][
-			general_name.lower()]
-		form = "jmc2obj"
-	elif general_name.lower() in env.json_data["blocks"]["block_mapping_mineways"]:
-		canon = env.json_data["blocks"]["block_mapping_mineways"][
-			general_name.lower()]
-		form = "mineways"
-	else:
-		env.log("Canonical name not matched: " + general_name, vv_only=True)
-		canon = general_name
-		form = None
+    if general_name in env.json_data["blocks"]["block_mapping_mc"]:
+        canon = env.json_data["blocks"]["block_mapping_mc"][general_name]
+        form = "mc" if not jmc_prefix else "jmc2obj"
+    elif general_name in env.json_data["blocks"]["block_mapping_jmc"]:
+        canon = env.json_data["blocks"]["block_mapping_jmc"][general_name]
+        form = "jmc2obj"
+    elif general_name in env.json_data["blocks"]["block_mapping_mineways"]:
+        canon = env.json_data["blocks"]["block_mapping_mineways"][general_name]
+        form = "mineways"
+    elif general_name.lower() in env.json_data["blocks"]["block_mapping_jmc"]:
+        canon = env.json_data["blocks"]["block_mapping_jmc"][general_name.lower()]
+        form = "jmc2obj"
+    elif general_name.lower() in env.json_data["blocks"]["block_mapping_mineways"]:
+        canon = env.json_data["blocks"]["block_mapping_mineways"][general_name.lower()]
+        form = "mineways"
+    else:
+        env.log("Canonical name not matched: " + general_name, vv_only=True)
+        canon = general_name
+        form = None
 
-	if canon is None or canon == '':
-		env.log("Error: Encountered None canon value with " + str(general_name))
-		canon = general_name
+    if canon is None or canon == "":
+        env.log("Error: Encountered None canon value with " + str(general_name))
+        canon = general_name
 
-	return canon, form
+    return canon, form
 
 
 def find_from_texturepack(blockname, resource_folder=None):
-	"""Given a blockname (and resource folder), find image filepath.
+    """Given a blockname (and resource folder), find image filepath.
 
-	Finds textures following any pack which should have this structure, and
-	the input folder or default resource folder could target at any of the
-	following sublevels above the <subfolder> level.
-	//pack_name/assets/minecraft/textures/<subfolder>/<blockname.png>
-	"""
-	if not resource_folder:
-		# default to internal pack
-		resource_folder = bpy.path.abspath(bpy.context.scene.mcprep_texturepack_path)
+    Finds textures following any pack which should have this structure, and
+    the input folder or default resource folder could target at any of the
+    following sublevels above the <subfolder> level.
+    //pack_name/assets/minecraft/textures/<subfolder>/<blockname.png>
+    """
+    if not resource_folder:
+        # default to internal pack
+        resource_folder = bpy.path.abspath(bpy.context.scene.mcprep_texturepack_path)
 
-	if not os.path.isdir(resource_folder):
-		env.log("Error, resource folder does not exist")
-		return
+    if not os.path.isdir(resource_folder):
+        env.log("Error, resource folder does not exist")
+        return
 
-	# Check multiple paths, picking the first match (order is important),
-	# goal of picking out the /textures folder.
-	check_dirs = [
-		os.path.join(resource_folder, "textures"),
-		os.path.join(resource_folder, "minecraft", "textures"),
-		os.path.join(resource_folder, "assets", "minecraft", "textures")]
-	for path in check_dirs:
-		if os.path.isdir(path):
-			resource_folder = path
-			break
+    # Check multiple paths, picking the first match (order is important),
+    # goal of picking out the /textures folder.
+    check_dirs = [
+        os.path.join(resource_folder, "textures"),
+        os.path.join(resource_folder, "minecraft", "textures"),
+        os.path.join(resource_folder, "assets", "minecraft", "textures"),
+    ]
+    for path in check_dirs:
+        if os.path.isdir(path):
+            resource_folder = path
+            break
 
-	search_paths = [
-		resource_folder,
-		# Both singular and plural shown below as it has varied historically.
-		os.path.join(resource_folder, "blocks"),
-		os.path.join(resource_folder, "block"),
-		os.path.join(resource_folder, "items"),
-		os.path.join(resource_folder, "item"),
-		os.path.join(resource_folder, "entity"),
-		os.path.join(resource_folder, "models"),
-		os.path.join(resource_folder, "model"),
-	]
-	res = None
+    search_paths = [
+        resource_folder,
+        # Both singular and plural shown below as it has varied historically.
+        os.path.join(resource_folder, "blocks"),
+        os.path.join(resource_folder, "block"),
+        os.path.join(resource_folder, "items"),
+        os.path.join(resource_folder, "item"),
+        os.path.join(resource_folder, "entity"),
+        os.path.join(resource_folder, "models"),
+        os.path.join(resource_folder, "model"),
+    ]
+    res = None
 
-	# first see if subpath included is found, prioritize use of that
-	extensions = [".png", ".jpg", ".jpeg"]
-	if "/" in blockname:
-		newpath = blockname.replace("/", os.path.sep)
-		for ext in extensions:
-			if os.path.isfile(os.path.join(resource_folder, newpath + ext)):
-				res = os.path.join(resource_folder, newpath + ext)
-				return res
-		newpath = os.path.basename(blockname)  # case where goes into other subpaths
-		for ext in extensions:
-			if os.path.isfile(os.path.join(resource_folder, newpath + ext)):
-				res = os.path.join(resource_folder, newpath + ext)
-				return res
+    # first see if subpath included is found, prioritize use of that
+    extensions = [".png", ".jpg", ".jpeg"]
+    if "/" in blockname:
+        newpath = blockname.replace("/", os.path.sep)
+        for ext in extensions:
+            if os.path.isfile(os.path.join(resource_folder, newpath + ext)):
+                res = os.path.join(resource_folder, newpath + ext)
+                return res
+        newpath = os.path.basename(blockname)  # case where goes into other subpaths
+        for ext in extensions:
+            if os.path.isfile(os.path.join(resource_folder, newpath + ext)):
+                res = os.path.join(resource_folder, newpath + ext)
+                return res
 
-	# fallback (more common case), wide-search for
-	for path in search_paths:
-		if not os.path.isdir(path):
-			continue
-		for ext in extensions:
-			check_path = os.path.join(path, blockname + ext)
-			if os.path.isfile(check_path):
-				res = os.path.join(path, blockname + ext)
-				return res
-	# Mineways fallback
-	for suffix in ["-Alpha", "-RGB", "-RGBA"]:
-		if blockname.endswith(suffix):
-			res = os.path.join(
-				resource_folder, "mineways_assets", "mineways" + suffix + ".png")
-			if os.path.isfile(res):
-				return res
+    # fallback (more common case), wide-search for
+    for path in search_paths:
+        if not os.path.isdir(path):
+            continue
+        for ext in extensions:
+            check_path = os.path.join(path, blockname + ext)
+            if os.path.isfile(check_path):
+                res = os.path.join(path, blockname + ext)
+                return res
+    # Mineways fallback
+    for suffix in ["-Alpha", "-RGB", "-RGBA"]:
+        if blockname.endswith(suffix):
+            res = os.path.join(
+                resource_folder, "mineways_assets", "mineways" + suffix + ".png"
+            )
+            if os.path.isfile(res):
+                return res
 
-	return res
+    return res
 
 
 def detect_form(materials):
-	"""Function which, given the input materials, guesses the exporter form.
+    """Function which, given the input materials, guesses the exporter form.
 
-	Useful for pre-determining elibibility of a function and also for tracking
-	reporting to give sense of how common which exporter is used.
-	"""
-	jmc2obj = 0
-	mc = 0
-	mineways = 0
-	for mat in materials:
-		if not mat:
-			continue
-		name = util.nameGeneralize(mat.name)
-		_, form = get_mc_canonical_name(name)
-		if form == "jmc2obj":
-			jmc2obj += 1
-		elif form == "mineways":
-			mineways += 1
-		else:
-			mc += 1
+    Useful for pre-determining elibibility of a function and also for tracking
+    reporting to give sense of how common which exporter is used.
+    """
+    jmc2obj = 0
+    mc = 0
+    mineways = 0
+    for mat in materials:
+        if not mat:
+            continue
+        name = util.nameGeneralize(mat.name)
+        _, form = get_mc_canonical_name(name)
+        if form == "jmc2obj":
+            jmc2obj += 1
+        elif form == "mineways":
+            mineways += 1
+        else:
+            mc += 1
 
-	# more logic, e.g. count
-	if mineways == 0 and jmc2obj == 0:
-		res = None  # unknown
-	elif mineways > 0 and jmc2obj == 0:
-		res = "mineways"
-	elif jmc2obj > 0 and mineways == 0:
-		res = "jmc2obj"
-	elif jmc2obj < mineways:
-		res = "mineways"
-	elif jmc2obj > mineways:
-		res = "jmc2obj"
-	else:
-		res = None  # unknown
+    # more logic, e.g. count
+    if mineways == 0 and jmc2obj == 0:
+        res = None  # unknown
+    elif mineways > 0 and jmc2obj == 0:
+        res = "mineways"
+    elif jmc2obj > 0 and mineways == 0:
+        res = "jmc2obj"
+    elif jmc2obj < mineways:
+        res = "mineways"
+    elif jmc2obj > mineways:
+        res = "jmc2obj"
+    else:
+        res = None  # unknown
 
-	return res  # one of jmc2obj, mineways, or None
+    return res  # one of jmc2obj, mineways, or None
 
 
 def checklist(matName, listName):
-	"""Helper to expand single wildcard within generalized material names"""
-	if not env.json_data:
-		env.log("No json_data for checklist to call from!")
-	if "blocks" not in env.json_data or listName not in env.json_data["blocks"]:
-		env.log(
-			"env.json_data is missing blocks or listName " + str(listName))
-		return False
-	if matName in env.json_data["blocks"][listName]:
-		return True
-	for name in env.json_data["blocks"][listName]:
-		if '*' not in name:
-			continue
-		x = name.split('*')
-		if x[0] != '' and x[0] in matName:
-			return True
-		elif x[1] != '' and x[1] in matName:
-			return True
-	return False
+    """Helper to expand single wildcard within generalized material names"""
+    if not env.json_data:
+        env.log("No json_data for checklist to call from!")
+    if "blocks" not in env.json_data or listName not in env.json_data["blocks"]:
+        env.log("env.json_data is missing blocks or listName " + str(listName))
+        return False
+    if matName in env.json_data["blocks"][listName]:
+        return True
+    for name in env.json_data["blocks"][listName]:
+        if "*" not in name:
+            continue
+        x = name.split("*")
+        if x[0] != "" and x[0] in matName:
+            return True
+        elif x[1] != "" and x[1] in matName:
+            return True
+    return False
+
 
 @dataclass
 class PrepOptions:
-	passes: dict[str]
-	use_reflections: bool
-	use_principled: bool
-	only_solid: bool
-	pack_format: str
-	use_emission_nodes: bool
-	use_emission: bool
+    passes: dict[str]
+    use_reflections: bool
+    use_principled: bool
+    only_solid: bool
+    pack_format: str
+    use_emission_nodes: bool
+    use_emission: bool
+
 
 def matprep_cycles(mat, options: PrepOptions):
-	"""Determine how to prep or generate the cycles materials.
+    """Determine how to prep or generate the cycles materials.
 
-	Args:
-		mat: the existing material
-		passes: dictionary struc of all found pass names
-		use_reflections: whether to turn reflections on
-		use_principled: if available and cycles, use principled node
-		saturate: if a desaturated texture (by canonical resource), add color
-		pack_format: which format of PBR, string ("Simple", Specular", "SEUS")
+    Args:
+            mat: the existing material
+            passes: dictionary struc of all found pass names
+            use_reflections: whether to turn reflections on
+            use_principled: if available and cycles, use principled node
+            saturate: if a desaturated texture (by canonical resource), add color
+            pack_format: which format of PBR, string ("Simple", Specular", "SEUS")
 
-	Returns:
-		int: 0 only if successful, otherwise None or other
-	"""
-	if util.bv28():
-		# ensure nodes are enabled esp. after importing from BI scenes
-		mat.use_nodes = True
+    Returns:
+            int: 0 only if successful, otherwise None or other
+    """
+    if util.bv28():
+        # ensure nodes are enabled esp. after importing from BI scenes
+        mat.use_nodes = True
 
-	matGen = util.nameGeneralize(mat.name)
-	canon, _ = get_mc_canonical_name(matGen)
-	options.use_emission = checklist(canon, "emit") or "emit" in mat.name.lower()
+    matGen = util.nameGeneralize(mat.name)
+    canon, _ = get_mc_canonical_name(matGen)
+    options.use_emission = checklist(canon, "emit") or "emit" in mat.name.lower()
 
-	# TODO: Update different options for water before enabling this
-	# if use_reflections and checklist(canon, "water"):
-	#	res = matgen_special_water(mat, passes)
-	# if use_reflections and checklist(canon, "glass"):
-	#	res = matgen_special_glass(mat, passes)
-	if options.pack_format == "simple" and util.bv28():
-		res = matgen_cycles_simple(mat, options)
-	elif options.use_principled and hasattr(bpy.types, 'ShaderNodeBsdfPrincipled'):
-		res = matgen_cycles_principled(mat, options) 	
-	else:
-		res = matgen_cycles_original(mat, options) 
-	return res
+    # TODO: Update different options for water before enabling this
+    # if use_reflections and checklist(canon, "water"):
+    # 	res = matgen_special_water(mat, passes)
+    # if use_reflections and checklist(canon, "glass"):
+    # 	res = matgen_special_glass(mat, passes)
+    if options.pack_format == "simple" and util.bv28():
+        res = matgen_cycles_simple(mat, options)
+    elif options.use_principled and hasattr(bpy.types, "ShaderNodeBsdfPrincipled"):
+        res = matgen_cycles_principled(mat, options)
+    else:
+        res = matgen_cycles_original(mat, options)
+    return res
 
 
 def set_texture_pack(material, folder, use_extra_passes):
-	"""Replace existing material's image with texture pack's.
+    """Replace existing material's image with texture pack's.
 
-	Run through and check for each if counterpart material exists, then
-	run the swap (and auto load e.g. normals and specs if avail.)
-	"""
-	mc_name, _ = get_mc_canonical_name(material.name)
-	image = find_from_texturepack(mc_name, folder)
-	if image is None:
-		return 0
+    Run through and check for each if counterpart material exists, then
+    run the swap (and auto load e.g. normals and specs if avail.)
+    """
+    mc_name, _ = get_mc_canonical_name(material.name)
+    image = find_from_texturepack(mc_name, folder)
+    if image is None:
+        return 0
 
-	image_data = util.loadTexture(image)
-	_ = set_cycles_texture(image_data, material, True)
-	return 1
+    image_data = util.loadTexture(image)
+    _ = set_cycles_texture(image_data, material, True)
+    return 1
 
 
 def assert_textures_on_materials(image, materials):
-	"""Called for any texture changing, e.g. skin, input a list of material and
-	an already loaded image datablock."""
-	# TODO: Add option to search for or ignore/remove extra maps (normal, etc)
-	count = 0
-	for mat in materials:
-		status = set_cycles_texture(image, mat)
-		if status:
-			count += 1
-	return count
+    """Called for any texture changing, e.g. skin, input a list of material and
+    an already loaded image datablock."""
+    # TODO: Add option to search for or ignore/remove extra maps (normal, etc)
+    count = 0
+    for mat in materials:
+        status = set_cycles_texture(image, mat)
+        if status:
+            count += 1
+    return count
 
 
 def set_cycles_texture(image, material, extra_passes=False):
-	"""
-	Used by skin swap and assiging missing textures or tex swapping.
-	Args:
-		image: already loaded image datablock
-		material: existing material datablock
-		extra_passes: whether to include or hard exclude non diffuse passes
-	"""
-	env.log("Setting cycles texture for img: {} mat: {}".format(
-		image.name, material.name))
-	if material.node_tree is None:
-		return False
-	# check if there is more data to see pass types
-	img_sets = {}
-	if extra_passes:
-		img_sets = find_additional_passes(image.filepath)
-	changed = False
+    """
+    Used by skin swap and assiging missing textures or tex swapping.
+    Args:
+            image: already loaded image datablock
+            material: existing material datablock
+            extra_passes: whether to include or hard exclude non diffuse passes
+    """
+    env.log(
+        "Setting cycles texture for img: {} mat: {}".format(image.name, material.name)
+    )
+    if material.node_tree is None:
+        return False
+    # check if there is more data to see pass types
+    img_sets = {}
+    if extra_passes:
+        img_sets = find_additional_passes(image.filepath)
+    changed = False
 
-	is_grayscale = False
+    is_grayscale = False
 
-	canon, _ = get_mc_canonical_name(util.nameGeneralize(material.name))
-	if checklist(canon, "desaturated"):
-		is_grayscale = is_image_grayscale(image)
+    canon, _ = get_mc_canonical_name(util.nameGeneralize(material.name))
+    if checklist(canon, "desaturated"):
+        is_grayscale = is_image_grayscale(image)
 
-	for node in material.node_tree.nodes:
-		if node.type == "MIX_RGB" and "SATURATE" in node:
-			node.mute = not is_grayscale
-			node.hide = not is_grayscale
-			env.log(" mix_rgb to saturate texture")
+    for node in material.node_tree.nodes:
+        if node.type == "MIX_RGB" and "SATURATE" in node:
+            node.mute = not is_grayscale
+            node.hide = not is_grayscale
+            env.log(" mix_rgb to saturate texture")
 
-		# if node.type != "TEX_IMAGE": continue
+        # if node.type != "TEX_IMAGE": continue
 
-		# check to see nodes and their respective pre-named field,
-		# saved as an attribute on the node
-		if "MCPREP_diffuse" in node:
-			node.image = image
-			node.mute = False
-			node.hide = False
-		elif "MCPREP_normal" in node and node.type == 'TEX_IMAGE':
-			if "normal" in img_sets:
-				new_img = util.loadTexture(img_sets["normal"])
-				node.image = new_img
-				util.apply_colorspace(node, 'Non-Color')
-				node.mute = False
-				node.hide = False
-			else:
-				node.mute = True
-				node.hide = True
+        # check to see nodes and their respective pre-named field,
+        # saved as an attribute on the node
+        if "MCPREP_diffuse" in node:
+            node.image = image
+            node.mute = False
+            node.hide = False
+        elif "MCPREP_normal" in node and node.type == "TEX_IMAGE":
+            if "normal" in img_sets:
+                new_img = util.loadTexture(img_sets["normal"])
+                node.image = new_img
+                util.apply_colorspace(node, "Non-Color")
+                node.mute = False
+                node.hide = False
+            else:
+                node.mute = True
+                node.hide = True
 
-				# remove the link between normal map and principled shader
-				# normal_map = node.outputs[0].links[0].to_node
-				# principled = ...
+                # remove the link between normal map and principled shader
+                # normal_map = node.outputs[0].links[0].to_node
+                # principled = ...
 
-		elif "MCPREP_specular" in node and node.type == 'TEX_IMAGE':
-			if "specular" in img_sets:
-				new_img = util.loadTexture(img_sets["specular"])
-				node.image = new_img
-				node.mute = False
-				node.hide = False
-				util.apply_colorspace(node, 'Non-Color')
-			else:
-				node.mute = True
-				node.hide = True
+        elif "MCPREP_specular" in node and node.type == "TEX_IMAGE":
+            if "specular" in img_sets:
+                new_img = util.loadTexture(img_sets["specular"])
+                node.image = new_img
+                node.mute = False
+                node.hide = False
+                util.apply_colorspace(node, "Non-Color")
+            else:
+                node.mute = True
+                node.hide = True
 
-		elif node.type == "TEX_IMAGE":
-			# assume all unlabeled texture nodes should be the diffuse pass
-			node["MCPREP_diffuse"] = True  # annotate node for future reference
-			node.image = image
-			node.mute = False
-			node.hide = False
-		else:
-			continue
+        elif node.type == "TEX_IMAGE":
+            # assume all unlabeled texture nodes should be the diffuse pass
+            node["MCPREP_diffuse"] = True  # annotate node for future reference
+            node.image = image
+            node.mute = False
+            node.hide = False
+        else:
+            continue
 
-		changed = True
+        changed = True
 
-	return changed
+    return changed
+
 
 def get_node_for_pass(material, pass_name):
-	"""Assumes cycles material, returns texture node for given pass in mat."""
-	if pass_name not in ["diffuse", "specular", "normal", "displace"]:
-		return None
-	if not material.node_tree:
-		return None
-	return_node = None
-	for node in material.node_tree.nodes:
-		if node.type != "TEX_IMAGE":
-			continue
-		elif "MCPREP_diffuse" in node and pass_name == "diffuse":
-			return_node = node
-		elif "MCPREP_normal" in node and pass_name == "normal":
-			return_node = node
-		elif "MCPREP_specular" in node and pass_name == "specular":
-			return_node = node
-		elif "MCPREP_displace" in node and pass_name == "displace":
-			return_node = node
-		else:
-			if not return_node:
-				return_node = node
-	return return_node
+    """Assumes cycles material, returns texture node for given pass in mat."""
+    if pass_name not in ["diffuse", "specular", "normal", "displace"]:
+        return None
+    if not material.node_tree:
+        return None
+    return_node = None
+    for node in material.node_tree.nodes:
+        if node.type != "TEX_IMAGE":
+            continue
+        elif "MCPREP_diffuse" in node and pass_name == "diffuse":
+            return_node = node
+        elif "MCPREP_normal" in node and pass_name == "normal":
+            return_node = node
+        elif "MCPREP_specular" in node and pass_name == "specular":
+            return_node = node
+        elif "MCPREP_displace" in node and pass_name == "displace":
+            return_node = node
+        else:
+            if not return_node:
+                return_node = node
+    return return_node
 
 
 def get_texlayer_for_pass(material, pass_name):
-	"""Assumes BI material, returns texture layer for given pass in mat."""
-	if pass_name not in ["diffuse", "specular", "normal", "displace"]:
-		return None
+    """Assumes BI material, returns texture layer for given pass in mat."""
+    if pass_name not in ["diffuse", "specular", "normal", "displace"]:
+        return None
 
-	if not hasattr(material, "texture_slots"):
-		return None
+    if not hasattr(material, "texture_slots"):
+        return None
 
-	for sl in material.texture_slots:
-		if not (sl and sl.use and sl.texture is not None
-				and hasattr(sl.texture, "image")
-				and sl.texture.image is not None):
-			continue
-		if sl.use_map_color_diffuse and pass_name == "diffuse":
-			return sl.texture
-		elif sl.use_map_normal and pass_name == "normal":
-			return sl.texture
-		elif sl.use_map_specular and pass_name == "specular":
-			return sl.texture
-		elif sl.use_map_displacement and pass_name == "displace":
-			return sl.texture
+    for sl in material.texture_slots:
+        if not (
+            sl
+            and sl.use
+            and sl.texture is not None
+            and hasattr(sl.texture, "image")
+            and sl.texture.image is not None
+        ):
+            continue
+        if sl.use_map_color_diffuse and pass_name == "diffuse":
+            return sl.texture
+        elif sl.use_map_normal and pass_name == "normal":
+            return sl.texture
+        elif sl.use_map_specular and pass_name == "specular":
+            return sl.texture
+        elif sl.use_map_displacement and pass_name == "displace":
+            return sl.texture
 
 
 def get_textures(material):
-	"""Extract the image datablocks for a given material (prefer cycles).
+    """Extract the image datablocks for a given material (prefer cycles).
 
-	Returns {"diffuse":texture.image, "normal":node.image "spec":None, ...}
-	"""
-	passes = {
-		"diffuse": None, "specular": None, "normal": None, "displace": None}
+    Returns {"diffuse":texture.image, "normal":node.image "spec":None, ...}
+    """
+    passes = {"diffuse": None, "specular": None, "normal": None, "displace": None}
 
-	if not material:
-		return passes
+    if not material:
+        return passes
 
-	# first try cycles materials, fall back to internal if not present
-	if material.use_nodes is True:
-		for node in material.node_tree.nodes:
-			if node.type != "TEX_IMAGE":
-				continue
-			elif "MCPREP_diffuse" in node:
-				passes["diffuse"] = node.image
-			elif "MCPREP_normal" in node:
-				passes["normal"] = node.image
-			elif "MCPREP_specular" in node:
-				passes["specular"] = node.image
-			else:
-				if not passes["diffuse"]:
-					passes["diffuse"] = node.image
+    # first try cycles materials, fall back to internal if not present
+    if material.use_nodes is True:
+        for node in material.node_tree.nodes:
+            if node.type != "TEX_IMAGE":
+                continue
+            elif "MCPREP_diffuse" in node:
+                passes["diffuse"] = node.image
+            elif "MCPREP_normal" in node:
+                passes["normal"] = node.image
+            elif "MCPREP_specular" in node:
+                passes["specular"] = node.image
+            else:
+                if not passes["diffuse"]:
+                    passes["diffuse"] = node.image
 
-	# look through internal, unless already found main diffuse pass
-	# TODO: Consider checking more explicitly checking based on selected engine
-	if hasattr(material, "texture_slots") and not passes["diffuse"]:
-		for sl in material.texture_slots:
-			if not (sl and sl.use and sl.texture is not None
-					and hasattr(sl.texture, "image")
-					and sl.texture.image is not None):
-				continue
-			if sl.use_map_color_diffuse and passes["diffuse"] is None:
-				passes["diffuse"] = sl.texture.image
-			elif sl.use_map_normal and passes["normal"] is None:
-				passes["normal"] = sl.texture.image
-			elif sl.use_map_specular and passes["specular"] is None:
-				passes["specular"] = sl.texture.image
-			elif sl.use_map_displacement and passes["displace"] is None:
-				passes["displace"] = sl.texture.image
+    # look through internal, unless already found main diffuse pass
+    # TODO: Consider checking more explicitly checking based on selected engine
+    if hasattr(material, "texture_slots") and not passes["diffuse"]:
+        for sl in material.texture_slots:
+            if not (
+                sl
+                and sl.use
+                and sl.texture is not None
+                and hasattr(sl.texture, "image")
+                and sl.texture.image is not None
+            ):
+                continue
+            if sl.use_map_color_diffuse and passes["diffuse"] is None:
+                passes["diffuse"] = sl.texture.image
+            elif sl.use_map_normal and passes["normal"] is None:
+                passes["normal"] = sl.texture.image
+            elif sl.use_map_specular and passes["specular"] is None:
+                passes["specular"] = sl.texture.image
+            elif sl.use_map_displacement and passes["displace"] is None:
+                passes["displace"] = sl.texture.image
 
-	return passes
+    return passes
 
 
 def find_additional_passes(image_file):
-	"""Find relevant passes like normal and spec in same folder as image."""
-	abs_img_file = bpy.path.abspath(image_file)
-	env.log("\tFind additional passes for: " + image_file, vv_only=True)
-	if not os.path.isfile(abs_img_file):
-		return {}
+    """Find relevant passes like normal and spec in same folder as image."""
+    abs_img_file = bpy.path.abspath(image_file)
+    env.log("\tFind additional passes for: " + image_file, vv_only=True)
+    if not os.path.isfile(abs_img_file):
+        return {}
 
-	img_dir = os.path.dirname(abs_img_file)
-	img_base = os.path.basename(abs_img_file)
-	base_name = os.path.splitext(img_base)[0]  # remove extension
+    img_dir = os.path.dirname(abs_img_file)
+    img_base = os.path.basename(abs_img_file)
+    base_name = os.path.splitext(img_base)[0]  # remove extension
 
-	# valid extentsions and ending names for pass types
-	exts = [".png", ".jpg", ".jpeg", ".tiff"]
-	normal = [" n", "_n", "-n", " normal", "_norm", "_nrm", " normals"]
-	spec = [" s", "_s", "-s", " specular", "_spec"]
-	disp = [" d", "_d", "-d", " displace", "_disp", " bump", " b", "_b", "-b"]
-	res = {"diffuse": image_file}
+    # valid extentsions and ending names for pass types
+    exts = [".png", ".jpg", ".jpeg", ".tiff"]
+    normal = [" n", "_n", "-n", " normal", "_norm", "_nrm", " normals"]
+    spec = [" s", "_s", "-s", " specular", "_spec"]
+    disp = [" d", "_d", "-d", " displace", "_disp", " bump", " b", "_b", "-b"]
+    res = {"diffuse": image_file}
 
-	# find lowercase base name matching with valid extentions
-	filtered_files = []
-	for f in os.listdir(img_dir):
-		if not f.lower().startswith(base_name.lower()):
-			continue
-		if not os.path.isfile(os.path.join(img_dir, f)):
-			continue
-		if os.path.splitext(f)[-1].lower() not in exts:
-			continue
-		filtered_files.append(f)
+    # find lowercase base name matching with valid extentions
+    filtered_files = []
+    for f in os.listdir(img_dir):
+        if not f.lower().startswith(base_name.lower()):
+            continue
+        if not os.path.isfile(os.path.join(img_dir, f)):
+            continue
+        if os.path.splitext(f)[-1].lower() not in exts:
+            continue
+        filtered_files.append(f)
 
-	# now do narrow matching based on each extention name type
-	for filtered in filtered_files:
-		this_base = os.path.splitext(filtered)[0]
-		for npass in normal:
-			if this_base.lower() == (base_name + npass).lower():
-				res["normal"] = os.path.join(img_dir, filtered)
-		for spass in spec:
-			if this_base.lower() == (base_name + spass).lower():
-				res["specular"] = os.path.join(img_dir, filtered)
-		for dpass in disp:
-			if this_base.lower() == (base_name + dpass).lower():
-				res["displace"] = os.path.join(img_dir, filtered)
+    # now do narrow matching based on each extention name type
+    for filtered in filtered_files:
+        this_base = os.path.splitext(filtered)[0]
+        for npass in normal:
+            if this_base.lower() == (base_name + npass).lower():
+                res["normal"] = os.path.join(img_dir, filtered)
+        for spass in spec:
+            if this_base.lower() == (base_name + spass).lower():
+                res["specular"] = os.path.join(img_dir, filtered)
+        for dpass in disp:
+            if this_base.lower() == (base_name + dpass).lower():
+                res["displace"] = os.path.join(img_dir, filtered)
 
-	return res
+    return res
 
 
 def replace_missing_texture(image):
-	"""If image missing from image datablock, replace from texture pack.
+    """If image missing from image datablock, replace from texture pack.
 
-	Image block name could be the diffuse or any other pass of material, and
-	should handle accordingly
-	"""
+    Image block name could be the diffuse or any other pass of material, and
+    should handle accordingly
+    """
 
-	if image is None:
-		return False
-	if image.source == 'SEQUENCE' and os.path.isfile(bpy.path.abspath(image.filepath)):
-		# technically the next statement should prevail, but this filecheck
-		# addresses animated textures who show up without any size/pixel data
-		# just after a reload (even though functional)
-		return False
-	if image.size[0] != 0 and image.size[1] != 0:
-		# Non zero means currently loaded, but could be lost on reload
-		if image.packed_file:
-			# only assume safe if packed...
-			return False
-		elif os.path.isfile(bpy.path.abspath(image.filepath)):
-			# ... or the filepath is present.
-			return False
-	env.log("Missing datablock detected: " + image.name)
+    if image is None:
+        return False
+    if image.source == "SEQUENCE" and os.path.isfile(bpy.path.abspath(image.filepath)):
+        # technically the next statement should prevail, but this filecheck
+        # addresses animated textures who show up without any size/pixel data
+        # just after a reload (even though functional)
+        return False
+    if image.size[0] != 0 and image.size[1] != 0:
+        # Non zero means currently loaded, but could be lost on reload
+        if image.packed_file:
+            # only assume safe if packed...
+            return False
+        elif os.path.isfile(bpy.path.abspath(image.filepath)):
+            # ... or the filepath is present.
+            return False
+    env.log("Missing datablock detected: " + image.name)
 
-	name = image.name
-	if len(name) > 4 and name[-4] == ".":
-		name = name[:-4]  # cuts off e.g. .png
-	elif len(name) > 5 and name[-5] == ".":
-		name = name[:-5]  # cuts off e.g. .jpeg
-	canon, _ = get_mc_canonical_name(name)
-	# TODO: detect for pass structure like normal and still look for right pass
-	image_path = find_from_texturepack(canon)
-	if not image_path:
-		return False
-	image.filepath = image_path
-	# image.reload() # not needed?
-	# pack?
+    name = image.name
+    if len(name) > 4 and name[-4] == ".":
+        name = name[:-4]  # cuts off e.g. .png
+    elif len(name) > 5 and name[-5] == ".":
+        name = name[:-5]  # cuts off e.g. .jpeg
+    canon, _ = get_mc_canonical_name(name)
+    # TODO: detect for pass structure like normal and still look for right pass
+    image_path = find_from_texturepack(canon)
+    if not image_path:
+        return False
+    image.filepath = image_path
+    # image.reload() # not needed?
+    # pack?
 
-	return True  # updated image block
+    return True  # updated image block
 
 
 def is_image_grayscale(image):
-	"""Returns true if image data is all grayscale, false otherwise"""
+    """Returns true if image data is all grayscale, false otherwise"""
 
-	def rgb_to_saturation(r, g, b):
-		"""Converter 0-1 rgb values back to 0-1 saturation value"""
-		mx = max(r, g, b)
-		if mx == 0:
-			return 0
-		mn = min(r, g, b)
-		df = mx - mn
-		return (df / mx)
+    def rgb_to_saturation(r, g, b):
+        """Converter 0-1 rgb values back to 0-1 saturation value"""
+        mx = max(r, g, b)
+        if mx == 0:
+            return 0
+        mn = min(r, g, b)
+        df = mx - mn
+        return df / mx
 
-	if not image:
-		return None
-	env.log("Checking image for grayscale " + image.name, vv_only=True)
-	if 'grayscale' in image:  # cache
-		return image['grayscale']
-	if not image.pixels:
-		env.log("Not an image / no pixels", vv_only=True)
-		return None
+    if not image:
+        return None
+    env.log("Checking image for grayscale " + image.name, vv_only=True)
+    if "grayscale" in image:  # cache
+        return image["grayscale"]
+    if not image.pixels:
+        env.log("Not an image / no pixels", vv_only=True)
+        return None
 
-	# setup sampling to limit number of processed pixels
-	max_samples = 1024  # A 32 by 32 image. May be higher with rounding.
-	pxl_count = len(image.pixels) / image.channels
-	aspect = image.size[0] / image.size[1]
-	datablock_copied = False
+    # setup sampling to limit number of processed pixels
+    max_samples = 1024  # A 32 by 32 image. May be higher with rounding.
+    pxl_count = len(image.pixels) / image.channels
+    aspect = image.size[0] / image.size[1]
+    datablock_copied = False
 
-	if pxl_count > max_samples:
-		imgcp = image.copy()  # Duplicate the datablock
+    if pxl_count > max_samples:
+        imgcp = image.copy()  # Duplicate the datablock
 
-		# Find new pixel sizes keeping aspect ratio, equation of:
-		# 1024 = nwith * nheight
-		# 1024 = (nheight * aspect) * nheight
-		# nheight = sqrtoot(1024 / aspect)
-		nheight = (1024 / aspect)**0.5
-		imgcp.scale(int(nheight * aspect), int(nheight))
-		pxl_count = imgcp.size[0] * imgcp.size[1]
-		datablock_copied = True
-	else:
-		imgcp = image
+        # Find new pixel sizes keeping aspect ratio, equation of:
+        # 1024 = nwith * nheight
+        # 1024 = (nheight * aspect) * nheight
+        # nheight = sqrtoot(1024 / aspect)
+        nheight = (1024 / aspect) ** 0.5
+        imgcp.scale(int(nheight * aspect), int(nheight))
+        pxl_count = imgcp.size[0] * imgcp.size[1]
+        datablock_copied = True
+    else:
+        imgcp = image
 
-	# Pixel by pixel saturation checks, with some wiggle room thresholds
-	thresh = 0.1  # treat saturated if any more than 10%
+    # Pixel by pixel saturation checks, with some wiggle room thresholds
+    thresh = 0.1  # treat saturated if any more than 10%
 
-	# max pixels above thresh to return as saturated,
-	# 15% is chosen as ~double the % of "yellow" pixels in vanilla jungle leaves
-	max_thresh = 0.15 * pxl_count
+    # max pixels above thresh to return as saturated,
+    # 15% is chosen as ~double the % of "yellow" pixels in vanilla jungle leaves
+    max_thresh = 0.15 * pxl_count
 
-	# running count to check against
-	pixels_saturated = 0
+    # running count to check against
+    pixels_saturated = 0
 
-	is_grayscale = True  # True until proven false.
+    is_grayscale = True  # True until proven false.
 
-	# check all pixels until exceeded threshold.
-	for ind in range(int(pxl_count))[::]:
-		ind = ind * imgcp.channels  # could be rgb or rgba
-		if imgcp.channels > 3 and imgcp.pixels[ind + 3] == 0:
-			continue  # skip alpha pixels during check
-		this_saturated = rgb_to_saturation(
-			imgcp.pixels[ind],
-			imgcp.pixels[ind + 1],
-			imgcp.pixels[ind + 2])
-		if this_saturated > thresh:
-			pixels_saturated += 1
-		if pixels_saturated >= max_thresh:
-			is_grayscale = False
-			env.log("Image not grayscale: " + image.name, vv_only=True)
-			break
+    # check all pixels until exceeded threshold.
+    for ind in range(int(pxl_count))[::]:
+        ind = ind * imgcp.channels  # could be rgb or rgba
+        if imgcp.channels > 3 and imgcp.pixels[ind + 3] == 0:
+            continue  # skip alpha pixels during check
+        this_saturated = rgb_to_saturation(
+            imgcp.pixels[ind], imgcp.pixels[ind + 1], imgcp.pixels[ind + 2]
+        )
+        if this_saturated > thresh:
+            pixels_saturated += 1
+        if pixels_saturated >= max_thresh:
+            is_grayscale = False
+            env.log("Image not grayscale: " + image.name, vv_only=True)
+            break
 
-	if datablock_copied:  # Cleanup if image was copied to scale down size.
-		bpy.data.images.remove(imgcp)
+    if datablock_copied:  # Cleanup if image was copied to scale down size.
+        bpy.data.images.remove(imgcp)
 
-	image['grayscale'] = is_grayscale  # set cache
-	env.log("Image is grayscale: " + image.name, vv_only=True)
-	return is_grayscale
+    image["grayscale"] = is_grayscale  # set cache
+    env.log("Image is grayscale: " + image.name, vv_only=True)
+    return is_grayscale
 
 
 def set_saturation_material(mat):
-	"""Update material to be saturated or not"""
-	if not mat:
-		return
+    """Update material to be saturated or not"""
+    if not mat:
+        return
 
-	canon, _ = get_mc_canonical_name(mat.name)
-	if not checklist(canon, "desaturated"):
-		env.log("debug: not eligible for saturation", vv_only=True)
-		return
+    canon, _ = get_mc_canonical_name(mat.name)
+    if not checklist(canon, "desaturated"):
+        env.log("debug: not eligible for saturation", vv_only=True)
+        return
 
-	env.log("Running set_saturation on " + mat.name, vv_only=True)
-	diff_pass = get_node_for_pass(mat, "diffuse")
-	if not diff_pass:
-		return
-	diff_img = diff_pass.image
+    env.log("Running set_saturation on " + mat.name, vv_only=True)
+    diff_pass = get_node_for_pass(mat, "diffuse")
+    if not diff_pass:
+        return
+    diff_img = diff_pass.image
 
-	if not diff_img:
-		env.log("debug: No diffuse", vv_only=True)
-		return
+    if not diff_img:
+        env.log("debug: No diffuse", vv_only=True)
+        return
 
-	saturate = is_image_grayscale(diff_img)
+    saturate = is_image_grayscale(diff_img)
 
-	desat_color = env.json_data['blocks']['desaturated'][canon]
-	sat_node = None
-	for node in mat.node_tree.nodes:
-		if "SATURATE" not in node:
-			continue
-		sat_node = node
-		break
+    desat_color = env.json_data["blocks"]["desaturated"][canon]
+    sat_node = None
+    for node in mat.node_tree.nodes:
+        if "SATURATE" not in node:
+            continue
+        sat_node = node
+        break
 
-	if not sat_node:
-		return  # requires regenerating material to add back
-	if len(desat_color) == 3:
-		desat_color += [1]  # add in alpha
+    if not sat_node:
+        return  # requires regenerating material to add back
+    if len(desat_color) == 3:
+        desat_color += [1]  # add in alpha
 
-	sat_node_in = get_node_socket(node, is_input=True) # Get the node sockets in a version agnostic way	
-	sat_node.inputs[sat_node_in[2]].default_value = desat_color
-	sat_node.mute = not bool(saturate)
-	sat_node.hide = not bool(saturate)
+    sat_node_in = get_node_socket(
+        node, is_input=True
+    )  # Get the node sockets in a version agnostic way
+    sat_node.inputs[sat_node_in[2]].default_value = desat_color
+    sat_node.mute = not bool(saturate)
+    sat_node.hide = not bool(saturate)
 
 
 def create_node(tree_nodes, node_type, **attrs):
-	"""Create node with default attributes
+    """Create node with default attributes
 
-	Args:
-		tree_nodes: the material node tree's nodes
-		node_type: the type of the node
-		**attrs: set attributes if that node type has
-			(eg: location, name, blend_type...)
-			"node_tree" can be referencing nodegroup or name of that nodegroup
-			"hide_sockets" to hide the sockets only display linked when need
-	"""
-	if node_type == 'ShaderNodeMixRGB':  # MixRGB in 3.4
-		if util.min_bv((3, 4, 0)):
-			node = tree_nodes.new('ShaderNodeMix')
-			node.data_type = 'RGBA'
-		else:
-			node = tree_nodes.new('ShaderNodeMixRGB')
-	else:
-		node = tree_nodes.new(node_type)
-	for attr, value in attrs.items():
-		if hasattr(node, attr) and attr != 'node_tree':
-			setattr(node, attr, value)
-		elif attr == 'node_tree':  # node group
-			assign = bpy.data.node_groups[value] if type(value) is str else value
-			setattr(node, attr, assign)
-		elif attr == 'hide_sockets':  # option to hide socket for big node
-			node.inputs.foreach_set('hide', [value] * len(node.inputs))
-			node.outputs.foreach_set('hide', [value] * len(node.outputs))
-	return node
+    Args:
+            tree_nodes: the material node tree's nodes
+            node_type: the type of the node
+            **attrs: set attributes if that node type has
+                    (eg: location, name, blend_type...)
+                    "node_tree" can be referencing nodegroup or name of that nodegroup
+                    "hide_sockets" to hide the sockets only display linked when need
+    """
+    if node_type == "ShaderNodeMixRGB":  # MixRGB in 3.4
+        if util.min_bv((3, 4, 0)):
+            node = tree_nodes.new("ShaderNodeMix")
+            node.data_type = "RGBA"
+        else:
+            node = tree_nodes.new("ShaderNodeMixRGB")
+    else:
+        node = tree_nodes.new(node_type)
+    for attr, value in attrs.items():
+        if hasattr(node, attr) and attr != "node_tree":
+            setattr(node, attr, value)
+        elif attr == "node_tree":  # node group
+            assign = bpy.data.node_groups[value] if type(value) is str else value
+            setattr(node, attr, assign)
+        elif attr == "hide_sockets":  # option to hide socket for big node
+            node.inputs.foreach_set("hide", [value] * len(node.inputs))
+            node.outputs.foreach_set("hide", [value] * len(node.outputs))
+    return node
 
 
 def get_node_socket(node, is_input=True):
-	"""Gets the input or output sockets indicies for node"""
-	n_type = node.bl_idname
-	if n_type == 'ShaderNodeMix' or n_type == 'ShaderNodeMixRGB':
-		# Mix Color in 3.4 use socket indicies 0, 6, 7 for Factor, Color inputs
-		# and output with 2.
-		# MixRGB uses 0, 1, 2 and 0
-		if util.min_bv((3, 4, 0)):
-			if node.data_type == 'RGBA':
-				inputs, outputs = [0, 6, 7], [2]
-		else:
-			inputs, outputs = [0, 1, 2], [0]
-	else:
-		inputs = [i for i in range(len(node.inputs))]
-		outputs = [i for i in range(len(node.outputs))]
-	return inputs if is_input else outputs
+    """Gets the input or output sockets indicies for node"""
+    n_type = node.bl_idname
+    if n_type == "ShaderNodeMix" or n_type == "ShaderNodeMixRGB":
+        # Mix Color in 3.4 use socket indicies 0, 6, 7 for Factor, Color inputs
+        # and output with 2.
+        # MixRGB uses 0, 1, 2 and 0
+        if util.min_bv((3, 4, 0)):
+            if node.data_type == "RGBA":
+                inputs, outputs = [0, 6, 7], [2]
+        else:
+            inputs, outputs = [0, 1, 2], [0]
+    else:
+        inputs = [i for i in range(len(node.inputs))]
+        outputs = [i for i in range(len(node.outputs))]
+    return inputs if is_input else outputs
+
 
 # -----------------------------------------------------------------------------
 # Generating node groups
@@ -748,1109 +760,1141 @@ def get_node_socket(node, is_input=True):
 
 
 def copy_texture_animation_pass_settings(mat):
-	"""Get any animation settings for passes."""
-	# Pre-copy any animated node settings before clearing nodes
-	animated_data = {}
-	if not mat.use_nodes:
-		return {}
-	for node in mat.node_tree.nodes:
-		if node.type != "TEX_IMAGE":
-			continue
-		if not node.image:
-			continue
-		if not node.image.source == 'SEQUENCE':
-			continue
-		if "MCPREP_diffuse" in node:
-			passname = "diffuse"
-		elif "MCPREP_normal" in node:
-			passname = "normal"
-		elif "MCPREP_specular" in node:
-			passname = "specular"
-		elif "MCPREP_displace" in node:
-			passname = "displace"
-		else:
-			if not animated_data.get("diffuse"):
-				passname = "diffuse"
-		animated_data[passname] = {
-			"frame_duration": node.image_user.frame_duration,
-			"frame_start": node.image_user.frame_start,
-			"frame_offset": node.image_user.frame_offset
-		}
-	return animated_data
+    """Get any animation settings for passes."""
+    # Pre-copy any animated node settings before clearing nodes
+    animated_data = {}
+    if not mat.use_nodes:
+        return {}
+    for node in mat.node_tree.nodes:
+        if node.type != "TEX_IMAGE":
+            continue
+        if not node.image:
+            continue
+        if not node.image.source == "SEQUENCE":
+            continue
+        if "MCPREP_diffuse" in node:
+            passname = "diffuse"
+        elif "MCPREP_normal" in node:
+            passname = "normal"
+        elif "MCPREP_specular" in node:
+            passname = "specular"
+        elif "MCPREP_displace" in node:
+            passname = "displace"
+        else:
+            if not animated_data.get("diffuse"):
+                passname = "diffuse"
+        animated_data[passname] = {
+            "frame_duration": node.image_user.frame_duration,
+            "frame_start": node.image_user.frame_start,
+            "frame_offset": node.image_user.frame_offset,
+        }
+    return animated_data
 
 
 def apply_texture_animation_pass_settings(mat, animated_data):
-	"""Apply animated texture settings for all given passes of dict."""
+    """Apply animated texture settings for all given passes of dict."""
 
-	if not mat.use_nodes:
-		return {}
+    if not mat.use_nodes:
+        return {}
 
-	node_diff = get_node_for_pass(mat, "diffuse")
-	node_normal = get_node_for_pass(mat, "normal")
-	node_specular = get_node_for_pass(mat, "specular")
-	node_displace = get_node_for_pass(mat, "displace")
+    node_diff = get_node_for_pass(mat, "diffuse")
+    node_normal = get_node_for_pass(mat, "normal")
+    node_specular = get_node_for_pass(mat, "specular")
+    node_displace = get_node_for_pass(mat, "displace")
 
-	for itm in animated_data:
-		if itm == "diffuse" and node_diff:
-			anim_node = node_diff
-		elif itm == "normal" and node_normal:
-			anim_node = node_normal
-		elif itm == "specular" and node_specular:
-			anim_node = node_specular
-		elif itm == "displace" and node_displace:
-			anim_node = node_displace
-		else:
-			continue
+    for itm in animated_data:
+        if itm == "diffuse" and node_diff:
+            anim_node = node_diff
+        elif itm == "normal" and node_normal:
+            anim_node = node_normal
+        elif itm == "specular" and node_specular:
+            anim_node = node_specular
+        elif itm == "displace" and node_displace:
+            anim_node = node_displace
+        else:
+            continue
 
-		anim_node.image_user.frame_duration = animated_data[itm]["frame_duration"]
-		anim_node.image_user.frame_start = animated_data[itm]["frame_start"]
-		anim_node.image_user.frame_offset = animated_data[itm]["frame_offset"]
-		anim_node.image_user.use_auto_refresh = True
-		anim_node.image_user.use_cyclic = True
+        anim_node.image_user.frame_duration = animated_data[itm]["frame_duration"]
+        anim_node.image_user.frame_start = animated_data[itm]["frame_start"]
+        anim_node.image_user.frame_offset = animated_data[itm]["frame_offset"]
+        anim_node.image_user.use_auto_refresh = True
+        anim_node.image_user.use_cyclic = True
 
 
 def texgen_specular(mat, passes, nodeInputs, use_reflections):
-	matGen = util.nameGeneralize(mat.name)
-	canon, form = get_mc_canonical_name(matGen)
+    matGen = util.nameGeneralize(mat.name)
+    canon, form = get_mc_canonical_name(matGen)
 
-	# Define links and nodes
-	nodes = mat.node_tree.nodes
-	links = mat.node_tree.links
+    # Define links and nodes
+    nodes = mat.node_tree.nodes
+    links = mat.node_tree.links
 
-	# Define the diffuse, normal, and specular nodes
-	image_diff = passes["diffuse"]
-	image_norm = passes["normal"]
-	image_spec = passes["specular"]
+    # Define the diffuse, normal, and specular nodes
+    image_diff = passes["diffuse"]
+    image_norm = passes["normal"]
+    image_spec = passes["specular"]
 
-	# Creates the necessary nodes
-	nodeTexDiff = create_node(
-		nodes, "ShaderNodeTexImage",
-		name="Diffuse Texture",
-		label="Diffuse Texture",
-		location=(-380, 140),
-		interpolation='Closest')
-	nodeTexNorm = create_node(
-		nodes, "ShaderNodeTexImage",
-		name="Normal Texture",
-		label="Normal Texture",
-		location=(-680, -500))
-	nodeTexSpec = create_node(
-		nodes, "ShaderNodeTexImage",
-		name="Specular Texture",
-		label="Specular Texture",
-		location=(-380, -180),
-		interpolation='Closest')
-	nodeSaturateMix = create_node(
-		nodes, "ShaderNodeMixRGB",
-		name="Add Color",
-		label="Add Color",
-		location=(-80, 140),
-		blend_type='MULTIPLY',
-		mute=True,
-		hide=True)
+    # Creates the necessary nodes
+    nodeTexDiff = create_node(
+        nodes,
+        "ShaderNodeTexImage",
+        name="Diffuse Texture",
+        label="Diffuse Texture",
+        location=(-380, 140),
+        interpolation="Closest",
+    )
+    nodeTexNorm = create_node(
+        nodes,
+        "ShaderNodeTexImage",
+        name="Normal Texture",
+        label="Normal Texture",
+        location=(-680, -500),
+    )
+    nodeTexSpec = create_node(
+        nodes,
+        "ShaderNodeTexImage",
+        name="Specular Texture",
+        label="Specular Texture",
+        location=(-380, -180),
+        interpolation="Closest",
+    )
+    nodeSaturateMix = create_node(
+        nodes,
+        "ShaderNodeMixRGB",
+        name="Add Color",
+        label="Add Color",
+        location=(-80, 140),
+        blend_type="MULTIPLY",
+        mute=True,
+        hide=True,
+    )
 
-	nodeSpecInv = create_node(
-		nodes, "ShaderNodeInvert",
-		name="Specular Inverse",
-		label="Specular Inverse",
-		location=(-80, -280))
-	nodeNormalInv = create_node(
-		nodes, "ShaderNodeRGBCurve",
-		name="Normal Inverse",
-		label="Normal Inverse",
-		location=(-380, -500))
-	nodeNormal = create_node(
-		nodes, "ShaderNodeNormalMap",
-		location=(-80, -500))
+    nodeSpecInv = create_node(
+        nodes,
+        "ShaderNodeInvert",
+        name="Specular Inverse",
+        label="Specular Inverse",
+        location=(-80, -280),
+    )
+    nodeNormalInv = create_node(
+        nodes,
+        "ShaderNodeRGBCurve",
+        name="Normal Inverse",
+        label="Normal Inverse",
+        location=(-380, -500),
+    )
+    nodeNormal = create_node(nodes, "ShaderNodeNormalMap", location=(-80, -500))
 
-	# Sets values
-	nodeSaturateMix.inputs[0].default_value = 1.0  # Graystyle Blending
-	nodeNormalInv.mapping.curves[1].points[0].location = (0, 1)
-	nodeNormalInv.mapping.curves[1].points[1].location = (1, 0)
+    # Sets values
+    nodeSaturateMix.inputs[0].default_value = 1.0  # Graystyle Blending
+    nodeNormalInv.mapping.curves[1].points[0].location = (0, 1)
+    nodeNormalInv.mapping.curves[1].points[1].location = (1, 0)
 
-	# Get MixRGB sockets
-	saturateMixIn = get_node_socket(nodeSaturateMix)
-	saturateMixOut = get_node_socket(nodeSaturateMix, is_input=False)
+    # Get MixRGB sockets
+    saturateMixIn = get_node_socket(nodeSaturateMix)
+    saturateMixOut = get_node_socket(nodeSaturateMix, is_input=False)
 
-	# Links the nodes to the reroute nodes.
-	links.new(nodeTexDiff.outputs["Color"], nodeSaturateMix.inputs[saturateMixIn[1]])
-	links.new(nodeTexNorm.outputs["Color"], nodeNormalInv.inputs["Color"])
-	links.new(nodeNormalInv.outputs["Color"], nodeNormal.inputs["Color"])
-	links.new(nodeTexSpec.outputs["Color"], nodeSpecInv.inputs["Color"])
+    # Links the nodes to the reroute nodes.
+    links.new(nodeTexDiff.outputs["Color"], nodeSaturateMix.inputs[saturateMixIn[1]])
+    links.new(nodeTexNorm.outputs["Color"], nodeNormalInv.inputs["Color"])
+    links.new(nodeNormalInv.outputs["Color"], nodeNormal.inputs["Color"])
+    links.new(nodeTexSpec.outputs["Color"], nodeSpecInv.inputs["Color"])
 
-	for i in nodeInputs[0]:
-		links.new(nodeSaturateMix.outputs[saturateMixOut[0]], i)
-	for i in nodeInputs[1]:
-		links.new(nodeTexDiff.outputs["Alpha"], i)
-	if image_spec and use_reflections:
-		for i in nodeInputs[3]:
-			links.new(nodeSpecInv.outputs["Color"], i)
-		for i in nodeInputs[5]:
-			links.new(nodeTexSpec.outputs["Color"], i)
-	for i in nodeInputs[6]:
-		links.new(nodeNormal.outputs["Normal"], i)
+    for i in nodeInputs[0]:
+        links.new(nodeSaturateMix.outputs[saturateMixOut[0]], i)
+    for i in nodeInputs[1]:
+        links.new(nodeTexDiff.outputs["Alpha"], i)
+    if image_spec and use_reflections:
+        for i in nodeInputs[3]:
+            links.new(nodeSpecInv.outputs["Color"], i)
+        for i in nodeInputs[5]:
+            links.new(nodeTexSpec.outputs["Color"], i)
+    for i in nodeInputs[6]:
+        links.new(nodeNormal.outputs["Normal"], i)
 
-	# Mutes necessary nodes if no specular map
-	if image_spec:
-		nodeTexSpec.image = image_spec
-	else:
-		nodeTexSpec.mute = True
+    # Mutes necessary nodes if no specular map
+    if image_spec:
+        nodeTexSpec.image = image_spec
+    else:
+        nodeTexSpec.mute = True
 
-	# Mutes necessary nodes if no normal map
-	if image_norm:
-		nodeTexNorm.image = image_norm
-	else:
-		nodeTexNorm.mute = True
-		nodeNormalInv.mute = True
-		nodeNormal.mute = True
+    # Mutes necessary nodes if no normal map
+    if image_norm:
+        nodeTexNorm.image = image_norm
+    else:
+        nodeTexNorm.mute = True
+        nodeNormalInv.mute = True
+        nodeNormal.mute = True
 
-	# Update to use non-color data for spec and normal
-	util.apply_colorspace(nodeTexSpec, 'Non-Color')
-	util.apply_colorspace(nodeTexNorm, 'Non-Color')
+    # Update to use non-color data for spec and normal
+    util.apply_colorspace(nodeTexSpec, "Non-Color")
+    util.apply_colorspace(nodeTexNorm, "Non-Color")
 
-	# Graystyle Blending
-	if not checklist(canon, "desaturated"):
-		pass
-	elif not is_image_grayscale(image_diff):
-		pass
-	else:
-		env.log("Texture desaturated: " + canon, vv_only=True)
-		desat_color = env.json_data['blocks']['desaturated'][canon]
-		if len(desat_color) < len(nodeSaturateMix.inputs[saturateMixIn[2]].default_value):
-			desat_color.append(1.0)
-		nodeSaturateMix.inputs[saturateMixIn[2]].default_value = desat_color
-		nodeSaturateMix.mute = False
-		nodeSaturateMix.hide = False
+    # Graystyle Blending
+    if not checklist(canon, "desaturated"):
+        pass
+    elif not is_image_grayscale(image_diff):
+        pass
+    else:
+        env.log("Texture desaturated: " + canon, vv_only=True)
+        desat_color = env.json_data["blocks"]["desaturated"][canon]
+        if len(desat_color) < len(
+            nodeSaturateMix.inputs[saturateMixIn[2]].default_value
+        ):
+            desat_color.append(1.0)
+        nodeSaturateMix.inputs[saturateMixIn[2]].default_value = desat_color
+        nodeSaturateMix.mute = False
+        nodeSaturateMix.hide = False
 
-	# annotate special nodes for finding later, and load images if available
-	nodeTexDiff["MCPREP_diffuse"] = True
-	nodeTexSpec["MCPREP_specular"] = True
-	nodeTexNorm["MCPREP_normal"] = True
-	# to also be also muted if no normal tex
-	nodeNormal["MCPREP_normal"] = True
-	nodeSaturateMix["SATURATE"] = True
-	# nodeTexDisp["MCPREP_disp"] = True
-	nodeTexDiff.image = image_diff
+    # annotate special nodes for finding later, and load images if available
+    nodeTexDiff["MCPREP_diffuse"] = True
+    nodeTexSpec["MCPREP_specular"] = True
+    nodeTexNorm["MCPREP_normal"] = True
+    # to also be also muted if no normal tex
+    nodeNormal["MCPREP_normal"] = True
+    nodeSaturateMix["SATURATE"] = True
+    # nodeTexDisp["MCPREP_disp"] = True
+    nodeTexDiff.image = image_diff
 
 
 def texgen_seus(mat, passes, nodeInputs, use_reflections, use_emission):
+    matGen = util.nameGeneralize(mat.name)
+    canon, form = get_mc_canonical_name(matGen)
 
-	matGen = util.nameGeneralize(mat.name)
-	canon, form = get_mc_canonical_name(matGen)
+    # Define links and nodes
+    nodes = mat.node_tree.nodes
+    links = mat.node_tree.links
 
-	# Define links and nodes
-	nodes = mat.node_tree.nodes
-	links = mat.node_tree.links
+    # Define the diffuse, normal, and specular nodes
+    image_diff = passes["diffuse"]
+    image_norm = passes["normal"]
+    image_spec = passes["specular"]
 
-	# Define the diffuse, normal, and specular nodes
-	image_diff = passes["diffuse"]
-	image_norm = passes["normal"]
-	image_spec = passes["specular"]
+    # Creates the necessary nodes
+    nodeTexDiff = create_node(
+        nodes,
+        "ShaderNodeTexImage",
+        name="Diffuse Texture",
+        label="Diffuse Texture",
+        location=(-380, 140),
+        interpolation="Closest",
+    )
+    nodeTexNorm = create_node(
+        nodes,
+        "ShaderNodeTexImage",
+        name="Normal Texture",
+        label="Normal Texture",
+        location=(-680, -500),
+    )
+    nodeTexSpec = create_node(
+        nodes,
+        "ShaderNodeTexImage",
+        name="Specular Texture",
+        label="Specular Texture",
+        location=(-580, -180),
+        interpolation="Closest",
+    )
+    nodeSaturateMix = create_node(
+        nodes,
+        "ShaderNodeMixRGB",
+        name="Add Color",
+        label="Add Color",
+        location=(-80, 140),
+        blend_type="MULTIPLY",
+        mute=True,
+        hide=True,
+    )
 
-	# Creates the necessary nodes
-	nodeTexDiff = create_node(
-		nodes, "ShaderNodeTexImage",
-		name="Diffuse Texture",
-		label="Diffuse Texture",
-		location=(-380, 140),
-		interpolation='Closest')
-	nodeTexNorm = create_node(
-		nodes, "ShaderNodeTexImage",
-		name="Normal Texture",
-		label="Normal Texture",
-		location=(-680, -500))
-	nodeTexSpec = create_node(
-		nodes, "ShaderNodeTexImage",
-		name="Specular Texture",
-		label="Specular Texture",
-		location=(-580, -180),
-		interpolation='Closest')
-	nodeSaturateMix = create_node(
-		nodes, "ShaderNodeMixRGB",
-		name="Add Color",
-		label="Add Color",
-		location=(-80, 140),
-		blend_type='MULTIPLY',
-		mute=True,
-		hide=True)
+    nodeSpecInv = create_node(
+        nodes,
+        "ShaderNodeInvert",
+        name="Smooth Inverse",
+        label="Smooth Inverse",
+        location=(-80, -280),
+    )
+    nodeSeperate = create_node(
+        nodes,
+        "ShaderNodeSeparateRGB",
+        name="RGB Seperation",
+        label="RGB Seperation",
+        location=(-280, -280),
+    )
+    nodeNormal = create_node(nodes, "ShaderNodeNormalMap", location=(-80, -500))
+    nodeNormalInv = create_node(
+        nodes,
+        "ShaderNodeRGBCurve",
+        name="Normal Inverse",
+        label="Normal Inverse",
+        location=(-380, -500),
+    )
 
-	nodeSpecInv = create_node(
-		nodes, "ShaderNodeInvert",
-		name="Smooth Inverse",
-		label="Smooth Inverse",
-		location=(-80, -280))
-	nodeSeperate = create_node(
-		nodes, "ShaderNodeSeparateRGB",
-		name="RGB Seperation",
-		label="RGB Seperation",
-		location=(-280, -280))
-	nodeNormal = create_node(
-		nodes, "ShaderNodeNormalMap",
-		location=(-80, -500))
-	nodeNormalInv = create_node(
-		nodes, "ShaderNodeRGBCurve",
-		name="Normal Inverse",
-		label="Normal Inverse",
-		location=(-380, -500))
+    # Sets values
+    nodeSaturateMix.inputs[0].default_value = 1.0  # Graystyle Blending
+    nodeNormalInv.mapping.curves[1].points[0].location = (0, 1)
+    nodeNormalInv.mapping.curves[1].points[1].location = (1, 0)
 
-	# Sets values
-	nodeSaturateMix.inputs[0].default_value = 1.0  # Graystyle Blending
-	nodeNormalInv.mapping.curves[1].points[0].location = (0, 1)
-	nodeNormalInv.mapping.curves[1].points[1].location = (1, 0)
+    # Get MixRGB sockets
+    saturateMixIn = get_node_socket(nodeSaturateMix)
+    saturateMixOut = get_node_socket(nodeSaturateMix, is_input=False)
 
-	# Get MixRGB sockets
-	saturateMixIn = get_node_socket(nodeSaturateMix)
-	saturateMixOut = get_node_socket(nodeSaturateMix, is_input=False)
+    # Links the nodes to the reroute nodes.
+    links.new(nodeTexDiff.outputs["Color"], nodeSaturateMix.inputs[saturateMixIn[1]])
+    links.new(nodeTexNorm.outputs["Color"], nodeNormalInv.inputs["Color"])
+    links.new(nodeNormalInv.outputs["Color"], nodeNormal.inputs["Color"])
+    links.new(nodeTexSpec.outputs["Color"], nodeSeperate.inputs["Image"])
+    links.new(nodeSeperate.outputs["R"], nodeSpecInv.inputs["Color"])
 
-	# Links the nodes to the reroute nodes.
-	links.new(nodeTexDiff.outputs["Color"], nodeSaturateMix.inputs[saturateMixIn[1]])
-	links.new(nodeTexNorm.outputs["Color"], nodeNormalInv.inputs["Color"])
-	links.new(nodeNormalInv.outputs["Color"], nodeNormal.inputs["Color"])
-	links.new(nodeTexSpec.outputs["Color"], nodeSeperate.inputs["Image"])
-	links.new(nodeSeperate.outputs["R"], nodeSpecInv.inputs["Color"])
+    for i in nodeInputs[0]:
+        if i == nodeSaturateMix.outputs[saturateMixOut[0]]:
+            continue
+        links.new(nodeSaturateMix.outputs[saturateMixOut[0]], i)
+    for i in nodeInputs[1]:
+        links.new(nodeTexDiff.outputs["Alpha"], i)
+    if image_spec and use_reflections:
+        if use_emission:
+            for i in nodeInputs[2]:
+                links.new(nodeSeperate.outputs["B"], i)
+        for i in nodeInputs[4]:
+            links.new(nodeSeperate.outputs["G"], i)
+        for i in nodeInputs[3]:
+            links.new(nodeSpecInv.outputs["Color"], i)
+    for i in nodeInputs[6]:
+        links.new(nodeNormal.outputs["Normal"], i)
 
-	for i in nodeInputs[0]:
-		if i == nodeSaturateMix.outputs[saturateMixOut[0]]:
-			continue
-		links.new(nodeSaturateMix.outputs[saturateMixOut[0]], i)
-	for i in nodeInputs[1]:
-		links.new(nodeTexDiff.outputs["Alpha"], i)
-	if image_spec and use_reflections:
-		if use_emission:
-			for i in nodeInputs[2]:
-				links.new(nodeSeperate.outputs["B"], i)
-		for i in nodeInputs[4]:
-			links.new(nodeSeperate.outputs["G"], i)
-		for i in nodeInputs[3]:
-			links.new(nodeSpecInv.outputs["Color"], i)
-	for i in nodeInputs[6]:
-		links.new(nodeNormal.outputs["Normal"], i)
+    # Mutes necessary nodes if no specular map
+    if image_spec:
+        nodeTexSpec.image = image_spec
+        nodeTexSpec.mute = False
+        nodeSeperate.mute = False
+    else:
+        nodeTexSpec.mute = True
+        nodeSeperate.mute = True
 
-	# Mutes necessary nodes if no specular map
-	if image_spec:
-		nodeTexSpec.image = image_spec
-		nodeTexSpec.mute = False
-		nodeSeperate.mute = False
-	else:
-		nodeTexSpec.mute = True
-		nodeSeperate.mute = True
+    # Mutes necessary nodes if no normal map
+    if image_norm:
+        nodeTexNorm.image = image_norm
+        nodeTexNorm.mute = False
+        nodeNormalInv.mute = False
+        nodeNormal.mute = False
+    else:
+        nodeTexNorm.mute = True
+        nodeNormalInv.mute = True
+        nodeNormal.mute = True
 
-	# Mutes necessary nodes if no normal map
-	if image_norm:
-		nodeTexNorm.image = image_norm
-		nodeTexNorm.mute = False
-		nodeNormalInv.mute = False
-		nodeNormal.mute = False
-	else:
-		nodeTexNorm.mute = True
-		nodeNormalInv.mute = True
-		nodeNormal.mute = True
+    # Update to use non-color data for spec and normal
+    util.apply_colorspace(nodeTexSpec, "Non-Color")
+    util.apply_colorspace(nodeTexNorm, "Non-Color")
 
-	# Update to use non-color data for spec and normal
-	util.apply_colorspace(nodeTexSpec, 'Non-Color')
-	util.apply_colorspace(nodeTexNorm, 'Non-Color')
+    # Graystyle Blending
+    if not checklist(canon, "desaturated"):
+        pass
+    elif not is_image_grayscale(image_diff):
+        pass
+    else:
+        env.log("Texture desaturated: " + canon, vv_only=True)
+        desat_color = env.json_data["blocks"]["desaturated"][canon]
+        desat_cmpr = len(nodeSaturateMix.inputs[saturateMixIn[2]].default_value)
+        if len(desat_color) < desat_cmpr:
+            desat_color.append(1.0)
+        nodeSaturateMix.inputs[saturateMixIn[2]].default_value = desat_color
+        nodeSaturateMix.mute = False
+        nodeSaturateMix.hide = False
 
-	# Graystyle Blending
-	if not checklist(canon, "desaturated"):
-		pass
-	elif not is_image_grayscale(image_diff):
-		pass
-	else:
-		env.log("Texture desaturated: " + canon, vv_only=True)
-		desat_color = env.json_data['blocks']['desaturated'][canon]
-		desat_cmpr = len(nodeSaturateMix.inputs[saturateMixIn[2]].default_value)
-		if len(desat_color) < desat_cmpr:
-			desat_color.append(1.0)
-		nodeSaturateMix.inputs[saturateMixIn[2]].default_value = desat_color
-		nodeSaturateMix.mute = False
-		nodeSaturateMix.hide = False
-
-	# annotate special nodes for finding later, and load images if available
-	nodeTexDiff["MCPREP_diffuse"] = True
-	nodeTexSpec["MCPREP_specular"] = True
-	nodeTexNorm["MCPREP_normal"] = True
-	# to also be also muted if no normal tex
-	nodeNormal["MCPREP_normal"] = True
-	nodeSaturateMix["SATURATE"] = True
-	# nodeTexDisp["MCPREP_disp"] = True
-	nodeTexDiff.image = image_diff
+    # annotate special nodes for finding later, and load images if available
+    nodeTexDiff["MCPREP_diffuse"] = True
+    nodeTexSpec["MCPREP_specular"] = True
+    nodeTexNorm["MCPREP_normal"] = True
+    # to also be also muted if no normal tex
+    nodeNormal["MCPREP_normal"] = True
+    nodeSaturateMix["SATURATE"] = True
+    # nodeTexDisp["MCPREP_disp"] = True
+    nodeTexDiff.image = image_diff
 
 
 def matgen_cycles_simple(mat, options: PrepOptions):
-	"""Generate principled cycles material."""
+    """Generate principled cycles material."""
 
-	matGen = util.nameGeneralize(mat.name)
-	canon, form = get_mc_canonical_name(matGen)
+    matGen = util.nameGeneralize(mat.name)
+    canon, form = get_mc_canonical_name(matGen)
 
-	image_diff = options.passes["diffuse"]
+    image_diff = options.passes["diffuse"]
 
-	if not image_diff:
-		print("Could not find diffuse image, halting generation: " + mat.name)
-		return
-	elif image_diff.size[0] == 0 or image_diff.size[1] == 0:
-		if image_diff.source != 'SEQUENCE':
-			# Common non animated case; this means the image is missing and would
-			# have already checked for replacement textures by now, so skip.
-			return
-		if not os.path.isfile(bpy.path.abspath(image_diff.filepath)):
-			# can't check size or pixels as it often is not immediately avaialble
-			# so instead, check against firs frame of sequence to verify load
-			return
+    if not image_diff:
+        print("Could not find diffuse image, halting generation: " + mat.name)
+        return
+    elif image_diff.size[0] == 0 or image_diff.size[1] == 0:
+        if image_diff.source != "SEQUENCE":
+            # Common non animated case; this means the image is missing and would
+            # have already checked for replacement textures by now, so skip.
+            return
+        if not os.path.isfile(bpy.path.abspath(image_diff.filepath)):
+            # can't check size or pixels as it often is not immediately avaialble
+            # so instead, check against firs frame of sequence to verify load
+            return
 
-	mat.use_nodes = True
-	animated_data = copy_texture_animation_pass_settings(mat)
-	nodes = mat.node_tree.nodes
-	links = mat.node_tree.links
-	nodes.clear()
+    mat.use_nodes = True
+    animated_data = copy_texture_animation_pass_settings(mat)
+    nodes = mat.node_tree.nodes
+    links = mat.node_tree.links
+    nodes.clear()
 
-	nodeTexDiff = create_node(
-		nodes, "ShaderNodeTexImage",
-		name="Diffuse Texture",
-		label="Diffuse Texture",
-		location=(0, 0),
-		interpolation='Closest',
-		image=image_diff)
-	nodeSaturateMix = create_node(
-		nodes, "ShaderNodeMixRGB",
-		name="Add Color",
-		label="Add Color",
-		location=(300, 0),
-		blend_type='MULTIPLY',
-		mute=True,
-		hide=True)
+    nodeTexDiff = create_node(
+        nodes,
+        "ShaderNodeTexImage",
+        name="Diffuse Texture",
+        label="Diffuse Texture",
+        location=(0, 0),
+        interpolation="Closest",
+        image=image_diff,
+    )
+    nodeSaturateMix = create_node(
+        nodes,
+        "ShaderNodeMixRGB",
+        name="Add Color",
+        label="Add Color",
+        location=(300, 0),
+        blend_type="MULTIPLY",
+        mute=True,
+        hide=True,
+    )
 
-	principled = create_node(nodes, "ShaderNodeBsdfPrincipled", location=(600, 0))
-	node_out = create_node(nodes, "ShaderNodeOutputMaterial", location=(900, 0))
+    principled = create_node(nodes, "ShaderNodeBsdfPrincipled", location=(600, 0))
+    node_out = create_node(nodes, "ShaderNodeOutputMaterial", location=(900, 0))
 
-	# Sets default reflective values
-	if options.use_reflections and checklist(canon, "reflective"):
-		principled.inputs["Roughness"].default_value = 0
-	else:
-		principled.inputs["Roughness"].default_value = 0.7
+    # Sets default reflective values
+    if options.use_reflections and checklist(canon, "reflective"):
+        principled.inputs["Roughness"].default_value = 0
+    else:
+        principled.inputs["Roughness"].default_value = 0.7
 
-	# Sets default metallic values
-	if options.use_reflections and checklist(canon, "metallic"):
-		principled.inputs["Metallic"].default_value = 1
-		if principled.inputs["Roughness"].default_value < 0.2:
-			principled.inputs["Roughness"].default_value = 0.2
-	else:
-		principled.inputs["Metallic"].default_value = 0
+    # Sets default metallic values
+    if options.use_reflections and checklist(canon, "metallic"):
+        principled.inputs["Metallic"].default_value = 1
+        if principled.inputs["Roughness"].default_value < 0.2:
+            principled.inputs["Roughness"].default_value = 0.2
+    else:
+        principled.inputs["Metallic"].default_value = 0
 
-	# Get MixRGB sockets
-	saturateMixIn = get_node_socket(nodeSaturateMix)
-	saturateMixOut = get_node_socket(nodeSaturateMix, is_input=False)
+    # Get MixRGB sockets
+    saturateMixIn = get_node_socket(nodeSaturateMix)
+    saturateMixOut = get_node_socket(nodeSaturateMix, is_input=False)
 
-	# Set values.
-	# Specular causes issues with how blocks look, so let's disable it.
-	nodeSaturateMix.inputs[saturateMixIn[0]].default_value = 1.0
-	principled.inputs["Specular"].default_value = 0
+    # Set values.
+    # Specular causes issues with how blocks look, so let's disable it.
+    nodeSaturateMix.inputs[saturateMixIn[0]].default_value = 1.0
+    principled.inputs["Specular"].default_value = 0
 
-	# Connect nodes.
-	links.new(nodeTexDiff.outputs[0], nodeSaturateMix.inputs[saturateMixIn[1]])
-	links.new(nodeSaturateMix.outputs[saturateMixOut[0]], principled.inputs[0])
-	links.new(principled.outputs["BSDF"], node_out.inputs[0])
+    # Connect nodes.
+    links.new(nodeTexDiff.outputs[0], nodeSaturateMix.inputs[saturateMixIn[1]])
+    links.new(nodeSaturateMix.outputs[saturateMixOut[0]], principled.inputs[0])
+    links.new(principled.outputs["BSDF"], node_out.inputs[0])
 
-	if options.only_solid is True or checklist(canon, "solid"):
-		# faster, and appropriate for non-transparent (and refelctive?) materials
-		principled.distribution = 'GGX'
-		if hasattr(mat, "blend_method"):
-			mat.blend_method = 'OPAQUE'  # eevee setting
-	else:
-		# non-solid (potentially, not necessarily though)
-		links.new(nodeTexDiff.outputs[1], principled.inputs["Alpha"])
-		if hasattr(mat, "blend_method"):  # 2.8 eevee settings
-			if hasattr(mat, "blend_method"):
-				mat.blend_method = 'HASHED'
-			if hasattr(mat, "shadow_method"):
-				mat.shadow_method = 'HASHED'
-	
-	if options.use_emission_nodes and options.use_emission:
-		inputs = [inp.name for inp in principled.inputs]
-		if 'Emission Strength' in inputs:  # Later 2.9 versions only.
-			principled.inputs['Emission Strength'].default_value = 1
-		links.new(
-			nodeSaturateMix.outputs[saturateMixOut[0]],
-			principled.inputs["Emission"])
+    if options.only_solid is True or checklist(canon, "solid"):
+        # faster, and appropriate for non-transparent (and refelctive?) materials
+        principled.distribution = "GGX"
+        if hasattr(mat, "blend_method"):
+            mat.blend_method = "OPAQUE"  # eevee setting
+    else:
+        # non-solid (potentially, not necessarily though)
+        links.new(nodeTexDiff.outputs[1], principled.inputs["Alpha"])
+        if hasattr(mat, "blend_method"):  # 2.8 eevee settings
+            if hasattr(mat, "blend_method"):
+                mat.blend_method = "HASHED"
+            if hasattr(mat, "shadow_method"):
+                mat.shadow_method = "HASHED"
 
-	# reapply animation data if any to generated nodes
-	apply_texture_animation_pass_settings(mat, animated_data)
+    if options.use_emission_nodes and options.use_emission:
+        inputs = [inp.name for inp in principled.inputs]
+        if "Emission Strength" in inputs:  # Later 2.9 versions only.
+            principled.inputs["Emission Strength"].default_value = 1
+        links.new(
+            nodeSaturateMix.outputs[saturateMixOut[0]], principled.inputs["Emission"]
+        )
 
-	# Graystyle Blending
-	if not checklist(canon, "desaturated"):
-		pass
-	elif not is_image_grayscale(image_diff):
-		pass
-	else:
-		env.log("Texture desaturated: " + canon, vv_only=True)
-		desat_color = env.json_data['blocks']['desaturated'][canon]
-		if len(desat_color) < len(nodeSaturateMix.inputs[2].default_value):
-				desat_color.append(1.0)
-		nodeSaturateMix.inputs[saturateMixIn[2]].default_value = desat_color
-		nodeSaturateMix.mute = False
-		nodeSaturateMix.hide = False
+    # reapply animation data if any to generated nodes
+    apply_texture_animation_pass_settings(mat, animated_data)
 
-	# annotate special nodes for finding later, and load images if available
-	nodeTexDiff["MCPREP_diffuse"] = True
-	nodeSaturateMix["SATURATE"] = True
+    # Graystyle Blending
+    if not checklist(canon, "desaturated"):
+        pass
+    elif not is_image_grayscale(image_diff):
+        pass
+    else:
+        env.log("Texture desaturated: " + canon, vv_only=True)
+        desat_color = env.json_data["blocks"]["desaturated"][canon]
+        if len(desat_color) < len(nodeSaturateMix.inputs[2].default_value):
+            desat_color.append(1.0)
+        nodeSaturateMix.inputs[saturateMixIn[2]].default_value = desat_color
+        nodeSaturateMix.mute = False
+        nodeSaturateMix.hide = False
 
-	return 0
+    # annotate special nodes for finding later, and load images if available
+    nodeTexDiff["MCPREP_diffuse"] = True
+    nodeSaturateMix["SATURATE"] = True
+
+    return 0
 
 
 def matgen_cycles_principled(mat, options: PrepOptions):
-	"""Generate principled cycles material"""
+    """Generate principled cycles material"""
 
-	matGen = util.nameGeneralize(mat.name)
-	canon, form = get_mc_canonical_name(matGen)
+    matGen = util.nameGeneralize(mat.name)
+    canon, form = get_mc_canonical_name(matGen)
 
-	image_diff = options.passes["diffuse"]
+    image_diff = options.passes["diffuse"]
 
-	if not image_diff:
-		print("Could not find diffuse image, halting generation: " + mat.name)
-		return
-	elif image_diff.size[0] == 0 or image_diff.size[1] == 0:
-		if image_diff.source != 'SEQUENCE':
-			# Common non animated case; this means the image is missing and would
-			# have already checked for replacement textures by now, so skip
-			return
-		if not os.path.isfile(bpy.path.abspath(image_diff.filepath)):
-			# can't check size or pixels as it often is not immediately avaialble
-			# so instead, check against first frame of sequence to verify load
-			return
+    if not image_diff:
+        print("Could not find diffuse image, halting generation: " + mat.name)
+        return
+    elif image_diff.size[0] == 0 or image_diff.size[1] == 0:
+        if image_diff.source != "SEQUENCE":
+            # Common non animated case; this means the image is missing and would
+            # have already checked for replacement textures by now, so skip
+            return
+        if not os.path.isfile(bpy.path.abspath(image_diff.filepath)):
+            # can't check size or pixels as it often is not immediately avaialble
+            # so instead, check against first frame of sequence to verify load
+            return
 
-	mat.use_nodes = True
-	animated_data = copy_texture_animation_pass_settings(mat)
-	nodes = mat.node_tree.nodes
-	links = mat.node_tree.links
-	nodes.clear()
+    mat.use_nodes = True
+    animated_data = copy_texture_animation_pass_settings(mat)
+    nodes = mat.node_tree.nodes
+    links = mat.node_tree.links
+    nodes.clear()
 
-	principled = create_node(
-		nodes, "ShaderNodeBsdfPrincipled", location=(120, 0))
-	nodeTrans = create_node(
-		nodes, "ShaderNodeBsdfTransparent", location=(420, 140))
-	nodeMixTrans = create_node(
-		nodes, "ShaderNodeMixShader", location=(620, 0))
-	nodeOut = create_node(
-		nodes, "ShaderNodeOutputMaterial", location=(820, 0))
+    principled = create_node(nodes, "ShaderNodeBsdfPrincipled", location=(120, 0))
+    nodeTrans = create_node(nodes, "ShaderNodeBsdfTransparent", location=(420, 140))
+    nodeMixTrans = create_node(nodes, "ShaderNodeMixShader", location=(620, 0))
+    nodeOut = create_node(nodes, "ShaderNodeOutputMaterial", location=(820, 0))
 
-	# Sets default transparency value
-	nodeMixTrans.inputs[0].default_value = 1
-	
-	# Sets default reflective values
-	if options.use_reflections and checklist(canon, "reflective"):
-		principled.inputs["Roughness"].default_value = 0
-	else:
-		principled.inputs["Roughness"].default_value = 0.7
+    # Sets default transparency value
+    nodeMixTrans.inputs[0].default_value = 1
 
-	# Sets default metallic values
-	if options.use_reflections and checklist(canon, "metallic"):
-		principled.inputs["Metallic"].default_value = 1
-		if principled.inputs["Roughness"].default_value < 0.2:
-			principled.inputs["Roughness"].default_value = 0.2
-	else:
-		principled.inputs["Metallic"].default_value = 0
+    # Sets default reflective values
+    if options.use_reflections and checklist(canon, "reflective"):
+        principled.inputs["Roughness"].default_value = 0
+    else:
+        principled.inputs["Roughness"].default_value = 0.7
 
-	# Connect nodes
-	links.new(nodeTrans.outputs["BSDF"], nodeMixTrans.inputs[1])
-	links.new(nodeMixTrans.outputs["Shader"], nodeOut.inputs[0])
+    # Sets default metallic values
+    if options.use_reflections and checklist(canon, "metallic"):
+        principled.inputs["Metallic"].default_value = 1
+        if principled.inputs["Roughness"].default_value < 0.2:
+            principled.inputs["Roughness"].default_value = 0.2
+    else:
+        principled.inputs["Metallic"].default_value = 0
 
-	nodeEmit = create_node(
-			nodes, "ShaderNodeEmission", location=(120, 140))
-	nodeEmitCam = create_node(
-			nodes, "ShaderNodeEmission", location=(120, 260))
-	nodeMixEmit = create_node(
-			nodes, "ShaderNodeMixShader", location=(420, 0))
-	if options.use_emission_nodes:
-		# Create emission nodes
-		nodeMixCam = create_node(
-			nodes, "ShaderNodeMixShader", location=(320, 260))
-		nodeFalloff = create_node(
-			nodes, "ShaderNodeLightFalloff", location=(-80, 320))
-		nodeLightPath = create_node(
-			nodes, "ShaderNodeLightPath", location=(-320, 520))
-				
-		# Set values
-		nodeFalloff.inputs["Strength"].default_value = 32
-		nodeEmitCam.inputs["Strength"].default_value = 4
+    # Connect nodes
+    links.new(nodeTrans.outputs["BSDF"], nodeMixTrans.inputs[1])
+    links.new(nodeMixTrans.outputs["Shader"], nodeOut.inputs[0])
 
-		# Create the links
-		links.new(principled.outputs["BSDF"], nodeMixEmit.inputs[1])
-		links.new(nodeLightPath.outputs["Is Camera Ray"], nodeMixCam.inputs["Fac"])
-		links.new(nodeFalloff.outputs["Linear"], nodeEmit.inputs["Strength"])
-		links.new(nodeEmit.outputs["Emission"], nodeMixCam.inputs[1])
-		links.new(nodeEmitCam.outputs["Emission"], nodeMixCam.inputs[2])
-		links.new(nodeMixCam.outputs["Shader"], nodeMixEmit.inputs[2])
-		links.new(nodeMixEmit.outputs["Shader"], nodeMixTrans.inputs[2])
+    nodeEmit = create_node(nodes, "ShaderNodeEmission", location=(120, 140))
+    nodeEmitCam = create_node(nodes, "ShaderNodeEmission", location=(120, 260))
+    nodeMixEmit = create_node(nodes, "ShaderNodeMixShader", location=(420, 0))
+    if options.use_emission_nodes:
+        # Create emission nodes
+        nodeMixCam = create_node(nodes, "ShaderNodeMixShader", location=(320, 260))
+        nodeFalloff = create_node(nodes, "ShaderNodeLightFalloff", location=(-80, 320))
+        nodeLightPath = create_node(nodes, "ShaderNodeLightPath", location=(-320, 520))
 
-		if options.use_emission:
-			nodeMixEmit.inputs[0].default_value = 1
-		else:
-			nodeMixEmit.inputs[0].default_value = 0
-	else:
-		links.new(principled.outputs[0], nodeMixTrans.inputs[2])
+        # Set values
+        nodeFalloff.inputs["Strength"].default_value = 32
+        nodeEmitCam.inputs["Strength"].default_value = 4
 
+        # Create the links
+        links.new(principled.outputs["BSDF"], nodeMixEmit.inputs[1])
+        links.new(nodeLightPath.outputs["Is Camera Ray"], nodeMixCam.inputs["Fac"])
+        links.new(nodeFalloff.outputs["Linear"], nodeEmit.inputs["Strength"])
+        links.new(nodeEmit.outputs["Emission"], nodeMixCam.inputs[1])
+        links.new(nodeEmitCam.outputs["Emission"], nodeMixCam.inputs[2])
+        links.new(nodeMixCam.outputs["Shader"], nodeMixEmit.inputs[2])
+        links.new(nodeMixEmit.outputs["Shader"], nodeMixTrans.inputs[2])
 
-	nodeInputs = [
-		[
-			principled.inputs["Base Color"],
-			nodeEmit.inputs["Color"],
-			nodeEmitCam.inputs["Color"]],
-		[nodeMixTrans.inputs["Fac"]],
-		[nodeMixEmit.inputs[0]],
-		[principled.inputs["Roughness"]],
-		[principled.inputs["Metallic"]],
-		[principled.inputs["Specular"]],
-		[principled.inputs["Normal"]]]
-	
-	if not options.use_emission_nodes:
-		nodes.remove(nodeEmit)
-		nodes.remove(nodeEmitCam)
-		nodes.remove(nodeMixEmit)
-	# generate texture format and connect
-	if options.pack_format == "specular":
-		texgen_specular(mat, options.passes, nodeInputs, options.use_reflections)
-	elif options.pack_format == "seus":
-		texgen_seus(mat, options.passes, nodeInputs, options.use_reflections, options.use_emission_nodes)
+        if options.use_emission:
+            nodeMixEmit.inputs[0].default_value = 1
+        else:
+            nodeMixEmit.inputs[0].default_value = 0
+    else:
+        links.new(principled.outputs[0], nodeMixTrans.inputs[2])
 
-	if options.only_solid is True or checklist(canon, "solid"):
-		nodes.remove(nodeTrans)
-		nodes.remove(nodeMixTrans)
-		nodeOut.location = (620, 0)
+    nodeInputs = [
+        [
+            principled.inputs["Base Color"],
+            nodeEmit.inputs["Color"],
+            nodeEmitCam.inputs["Color"],
+        ],
+        [nodeMixTrans.inputs["Fac"]],
+        [nodeMixEmit.inputs[0]],
+        [principled.inputs["Roughness"]],
+        [principled.inputs["Metallic"]],
+        [principled.inputs["Specular"]],
+        [principled.inputs["Normal"]],
+    ]
 
-		if options.use_emission_nodes:
-			links.new(nodeMixEmit.outputs[0], nodeOut.inputs[0])
+    if not options.use_emission_nodes:
+        nodes.remove(nodeEmit)
+        nodes.remove(nodeEmitCam)
+        nodes.remove(nodeMixEmit)
+    # generate texture format and connect
+    if options.pack_format == "specular":
+        texgen_specular(mat, options.passes, nodeInputs, options.use_reflections)
+    elif options.pack_format == "seus":
+        texgen_seus(
+            mat,
+            options.passes,
+            nodeInputs,
+            options.use_reflections,
+            options.use_emission_nodes,
+        )
 
-		# faster, and appropriate for non-transparent (and refelctive?) materials
-		principled.distribution = 'GGX'
-		if hasattr(mat, "blend_method"):
-			mat.blend_method = 'OPAQUE'  # eevee setting
-	else:
-		# non-solid (potentially, not necessarily though)
-		if hasattr(mat, "blend_method"):  # 2.8 eevee settings
-			# TODO: Work on finding the optimal decision here
-			# clip could be better in cases of true/false transparency
-			# could do work to detect this from the image directly..
-			# though would be slower
+    if options.only_solid is True or checklist(canon, "solid"):
+        nodes.remove(nodeTrans)
+        nodes.remove(nodeMixTrans)
+        nodeOut.location = (620, 0)
 
-			# noisy, but workable for partial trans; bad for materials with
-			# no partial trans (makes view-through all somewhat noisy)
-			# Note: placed with hasattr to reduce bugs, seemingly only on old
-			# 2.80 build
-			if hasattr(mat, "blend_method"):
-				mat.blend_method = 'HASHED'
-			if hasattr(mat, "shadow_method"):
-				mat.shadow_method = 'HASHED'
+        if options.use_emission_nodes:
+            links.new(nodeMixEmit.outputs[0], nodeOut.inputs[0])
 
-			# best if there is no partial transparency
-			# material.blend_method = 'CLIP' for no partial transparency
-			# both work fine with depth of field.
+        # faster, and appropriate for non-transparent (and refelctive?) materials
+        principled.distribution = "GGX"
+        if hasattr(mat, "blend_method"):
+            mat.blend_method = "OPAQUE"  # eevee setting
+    else:
+        # non-solid (potentially, not necessarily though)
+        if hasattr(mat, "blend_method"):  # 2.8 eevee settings
+            # TODO: Work on finding the optimal decision here
+            # clip could be better in cases of true/false transparency
+            # could do work to detect this from the image directly..
+            # though would be slower
 
-			# but, BLEND does NOT work well with Depth of Field or layering
-	
-	# reapply animation data if any to generated nodes
-	apply_texture_animation_pass_settings(mat, animated_data)
+            # noisy, but workable for partial trans; bad for materials with
+            # no partial trans (makes view-through all somewhat noisy)
+            # Note: placed with hasattr to reduce bugs, seemingly only on old
+            # 2.80 build
+            if hasattr(mat, "blend_method"):
+                mat.blend_method = "HASHED"
+            if hasattr(mat, "shadow_method"):
+                mat.shadow_method = "HASHED"
 
-	return 0
+            # best if there is no partial transparency
+            # material.blend_method = 'CLIP' for no partial transparency
+            # both work fine with depth of field.
+
+            # but, BLEND does NOT work well with Depth of Field or layering
+
+    # reapply animation data if any to generated nodes
+    apply_texture_animation_pass_settings(mat, animated_data)
+
+    return 0
 
 
 def matgen_cycles_original(mat, options: PrepOptions):
-	"""Generate principled cycles material"""
+    """Generate principled cycles material"""
 
-	matGen = util.nameGeneralize(mat.name)
-	canon, form = get_mc_canonical_name(matGen)
+    matGen = util.nameGeneralize(mat.name)
+    canon, form = get_mc_canonical_name(matGen)
 
-	image_diff = options.passes["diffuse"]
+    image_diff = options.passes["diffuse"]
 
-	if not image_diff:
-		print("Could not find diffuse image, halting generation: " + mat.name)
-		return
-	elif image_diff.size[0] == 0 or image_diff.size[1] == 0:
-		if image_diff.source != 'SEQUENCE':
-			# Common non animated case; this means the image is missing and would
-			# have already checked for replacement textures by now, so skip
-			return
-		if not os.path.isfile(bpy.path.abspath(image_diff.filepath)):
-			# can't check size or pixels as it often is not immediately avaialble
-			# so instea, check against firs frame of sequence to verify load
-			return
+    if not image_diff:
+        print("Could not find diffuse image, halting generation: " + mat.name)
+        return
+    elif image_diff.size[0] == 0 or image_diff.size[1] == 0:
+        if image_diff.source != "SEQUENCE":
+            # Common non animated case; this means the image is missing and would
+            # have already checked for replacement textures by now, so skip
+            return
+        if not os.path.isfile(bpy.path.abspath(image_diff.filepath)):
+            # can't check size or pixels as it often is not immediately avaialble
+            # so instea, check against firs frame of sequence to verify load
+            return
 
-	mat.use_nodes = True
-	animated_data = copy_texture_animation_pass_settings(mat)
-	nodes = mat.node_tree.nodes
-	links = mat.node_tree.links
-	nodes.clear()
+    mat.use_nodes = True
+    animated_data = copy_texture_animation_pass_settings(mat)
+    nodes = mat.node_tree.nodes
+    links = mat.node_tree.links
+    nodes.clear()
 
-	# Shader
-	nodeDiff = create_node(nodes, "ShaderNodeBsdfDiffuse", location=(940, 200))
-	nodeGlossDiff = create_node(nodes, "ShaderNodeBsdfGlossy", location=(940, 60))
-	nodeGlossMetallic = create_node(
-		nodes, "ShaderNodeBsdfGlossy", location=(1140, -120))
-	nodeTrans = create_node(
-		nodes, "ShaderNodeBsdfTransparent", location=(1740, 120))
-	nodeEmit = create_node(nodes, "ShaderNodeEmission", location=(1340, 120))
-	nodeEmitCam = create_node(nodes, "ShaderNodeEmission", location=(1340, 240))
-	# Mix Shader
-	nodeMixDiff = create_node(nodes, "ShaderNodeMixShader", location=(1140, 40))
-	nodeMixMetallic = create_node(
-		nodes, "ShaderNodeMixShader", location=(1340, 0))
-	nodeMixTrans = create_node(nodes, "ShaderNodeMixShader", location=(1940, 0))
-	nodeMixEmit = create_node(nodes, "ShaderNodeMixShader", location=(1740, 0))
-	nodeMixCam = create_node(nodes, "ShaderNodeMixShader", location=(1540, 240))
-	# Mix
-	nodeMixRGBDiff = create_node(nodes, "ShaderNodeMixRGB", location=(560, 200))
-	nodeMixRGB = create_node(nodes, "ShaderNodeMixRGB", location=(180, 360))
-	nodeMixRGBMetallic = create_node(
-		nodes, "ShaderNodeMixRGB", location=(940, -120))
-	# Input
-	nodeFresnel = create_node(nodes, "ShaderNodeFresnel", location=(360, 160))
-	nodeFresnelMetallic = create_node(
-		nodes, "ShaderNodeFresnel", location=(740, -120))
-	nodeLightPath = create_node(
-		nodes, "ShaderNodeLightPath", location=(1340, 600))
-	nodeGeometry = create_node(nodes, "ShaderNodeNewGeometry", location=(0, 600))
-	# Math
-	nodeMathPower = create_node(
-		nodes, "ShaderNodeMath",
-		location=(0, 360),
-		operation="POWER")
-	nodeMathPowerDiff = create_node(
-		nodes, "ShaderNodeMath",
-		location=(360, 360),
-		operation="POWER")
-	nodeMathMultiplyDiff = create_node(
-		nodes, "ShaderNodeMath",
-		location=(740, 200),
-		operation="MULTIPLY")
-	nodeMathMetallic = create_node(
-		nodes, "ShaderNodeMath",
-		location=(740, -280),
-		operation="MULTIPLY")
-	# Etc
-	nodeBump = create_node(
-		nodes, "ShaderNodeBump", location=(-200, 600))
-	nodeFalloff = create_node(
-		nodes, "ShaderNodeLightFalloff", location=(1140, 240))
-	nodeOut = create_node(
-		nodes, "ShaderNodeOutputMaterial", location=(2140, 0))
+    # Shader
+    nodeDiff = create_node(nodes, "ShaderNodeBsdfDiffuse", location=(940, 200))
+    nodeGlossDiff = create_node(nodes, "ShaderNodeBsdfGlossy", location=(940, 60))
+    nodeGlossMetallic = create_node(
+        nodes, "ShaderNodeBsdfGlossy", location=(1140, -120)
+    )
+    nodeTrans = create_node(nodes, "ShaderNodeBsdfTransparent", location=(1740, 120))
+    nodeEmit = create_node(nodes, "ShaderNodeEmission", location=(1340, 120))
+    nodeEmitCam = create_node(nodes, "ShaderNodeEmission", location=(1340, 240))
+    # Mix Shader
+    nodeMixDiff = create_node(nodes, "ShaderNodeMixShader", location=(1140, 40))
+    nodeMixMetallic = create_node(nodes, "ShaderNodeMixShader", location=(1340, 0))
+    nodeMixTrans = create_node(nodes, "ShaderNodeMixShader", location=(1940, 0))
+    nodeMixEmit = create_node(nodes, "ShaderNodeMixShader", location=(1740, 0))
+    nodeMixCam = create_node(nodes, "ShaderNodeMixShader", location=(1540, 240))
+    # Mix
+    nodeMixRGBDiff = create_node(nodes, "ShaderNodeMixRGB", location=(560, 200))
+    nodeMixRGB = create_node(nodes, "ShaderNodeMixRGB", location=(180, 360))
+    nodeMixRGBMetallic = create_node(nodes, "ShaderNodeMixRGB", location=(940, -120))
+    # Input
+    nodeFresnel = create_node(nodes, "ShaderNodeFresnel", location=(360, 160))
+    nodeFresnelMetallic = create_node(nodes, "ShaderNodeFresnel", location=(740, -120))
+    nodeLightPath = create_node(nodes, "ShaderNodeLightPath", location=(1340, 600))
+    nodeGeometry = create_node(nodes, "ShaderNodeNewGeometry", location=(0, 600))
+    # Math
+    nodeMathPower = create_node(
+        nodes, "ShaderNodeMath", location=(0, 360), operation="POWER"
+    )
+    nodeMathPowerDiff = create_node(
+        nodes, "ShaderNodeMath", location=(360, 360), operation="POWER"
+    )
+    nodeMathMultiplyDiff = create_node(
+        nodes, "ShaderNodeMath", location=(740, 200), operation="MULTIPLY"
+    )
+    nodeMathMetallic = create_node(
+        nodes, "ShaderNodeMath", location=(740, -280), operation="MULTIPLY"
+    )
+    # Etc
+    nodeBump = create_node(nodes, "ShaderNodeBump", location=(-200, 600))
+    nodeFalloff = create_node(nodes, "ShaderNodeLightFalloff", location=(1140, 240))
+    nodeOut = create_node(nodes, "ShaderNodeOutputMaterial", location=(2140, 0))
 
-	# Get MixRGB sockets
-	mixDiffIn = get_node_socket(nodeMixRGBDiff)
-	mixIn = get_node_socket(nodeMixRGB)
-	mixMetallicIn = get_node_socket(nodeMixRGBMetallic)
-	mixOut = get_node_socket(nodeMixRGB, is_input=False)
-	mixDiffOut = get_node_socket(nodeMixRGBDiff, is_input=False)
-	mixMetallicOut = get_node_socket(nodeMixRGBMetallic, is_input=False)
+    # Get MixRGB sockets
+    mixDiffIn = get_node_socket(nodeMixRGBDiff)
+    mixIn = get_node_socket(nodeMixRGB)
+    mixMetallicIn = get_node_socket(nodeMixRGBMetallic)
+    mixOut = get_node_socket(nodeMixRGB, is_input=False)
+    mixDiffOut = get_node_socket(nodeMixRGBDiff, is_input=False)
+    mixMetallicOut = get_node_socket(nodeMixRGBMetallic, is_input=False)
 
-	# Sets default transparency value
-	nodeMixTrans.inputs["Fac"].default_value = 1
-	nodeMathMultiplyDiff.inputs[1].default_value = 0.1
-	nodeFalloff.inputs["Strength"].default_value = 32
-	nodeEmitCam.inputs["Strength"].default_value = 4
-	nodeMathPowerDiff.inputs[0].default_value = 0
-	nodeMathPowerDiff.inputs[1].default_value = 2
-	nodeMathPower.inputs[1].default_value = 2
-	nodeMathMetallic.inputs[1].default_value = 4
-	nodeMixRGBDiff.inputs[mixDiffIn[2]].default_value = [1, 1, 1, 1]
+    # Sets default transparency value
+    nodeMixTrans.inputs["Fac"].default_value = 1
+    nodeMathMultiplyDiff.inputs[1].default_value = 0.1
+    nodeFalloff.inputs["Strength"].default_value = 32
+    nodeEmitCam.inputs["Strength"].default_value = 4
+    nodeMathPowerDiff.inputs[0].default_value = 0
+    nodeMathPowerDiff.inputs[1].default_value = 2
+    nodeMathPower.inputs[1].default_value = 2
+    nodeMathMetallic.inputs[1].default_value = 4
+    nodeMixRGBDiff.inputs[mixDiffIn[2]].default_value = [1, 1, 1, 1]
 
-	# Sets default reflective values
-	if options.use_reflections and checklist(canon, "reflective"):
-		nodeGlossMetallic.inputs["Roughness"].default_value = 0
-		nodeMathPower.inputs[0].default_value = 0
-		nodeGlossDiff.inputs["Roughness"].default_value = 0
-	else:
-		nodeGlossMetallic.inputs["Roughness"].default_value = 0.7
-		nodeMathPower.inputs[0].default_value = 0.7
-		nodeGlossDiff.inputs["Roughness"].default_value = 0.7
+    # Sets default reflective values
+    if options.use_reflections and checklist(canon, "reflective"):
+        nodeGlossMetallic.inputs["Roughness"].default_value = 0
+        nodeMathPower.inputs[0].default_value = 0
+        nodeGlossDiff.inputs["Roughness"].default_value = 0
+    else:
+        nodeGlossMetallic.inputs["Roughness"].default_value = 0.7
+        nodeMathPower.inputs[0].default_value = 0.7
+        nodeGlossDiff.inputs["Roughness"].default_value = 0.7
 
-	# Sets default metallic values
-	if options.use_reflections and checklist(canon, "metallic"):
-		nodeMixMetallic.inputs["Fac"].default_value = 1
+    # Sets default metallic values
+    if options.use_reflections and checklist(canon, "metallic"):
+        nodeMixMetallic.inputs["Fac"].default_value = 1
 
-		if nodeGlossMetallic.inputs["Roughness"].default_value < 0.2:
-			nodeGlossMetallic.inputs["Roughness"].default_value = 0.2
-		if nodeMathPower.inputs[0].default_value < 0.2:
-			nodeMathPower.inputs[0].default_value = 0.2
-		if nodeGlossDiff.inputs["Roughness"].default_value < 0.2:
-			nodeGlossDiff.inputs["Roughness"].default_value = 0.2
+        if nodeGlossMetallic.inputs["Roughness"].default_value < 0.2:
+            nodeGlossMetallic.inputs["Roughness"].default_value = 0.2
+        if nodeMathPower.inputs[0].default_value < 0.2:
+            nodeMathPower.inputs[0].default_value = 0.2
+        if nodeGlossDiff.inputs["Roughness"].default_value < 0.2:
+            nodeGlossDiff.inputs["Roughness"].default_value = 0.2
 
-	else:
-		nodeMixMetallic.inputs["Fac"].default_value = 0
+    else:
+        nodeMixMetallic.inputs["Fac"].default_value = 0
 
-	# Connect nodes
-	links.new(nodeMixDiff.outputs["Shader"], nodeMixMetallic.inputs[1])
-	links.new(nodeMathPower.outputs[0], nodeMixRGB.inputs[mixIn[0]])
-	links.new(nodeMathPower.outputs[0], nodeDiff.inputs["Roughness"])
-	links.new(nodeMixRGB.outputs[mixOut[0]], nodeFresnel.inputs["Normal"])
-	links.new(nodeFresnel.outputs[0], nodeMixRGBDiff.inputs[mixDiffIn[0]])
-	links.new(nodeGeometry.outputs["Incoming"], nodeMixRGB.inputs[mixIn[2]])
-	links.new(nodeBump.outputs["Normal"], nodeMixRGB.inputs[mixIn[1]])
-	links.new(
-		nodeMathPowerDiff.outputs["Value"],
-		nodeMixRGBDiff.inputs[mixDiffIn[1]])
-	links.new(
-		nodeMixRGBDiff.outputs[mixDiffOut[0]],
-		nodeMathMultiplyDiff.inputs[0])
-	links.new(nodeMathMultiplyDiff.outputs["Value"], nodeMixDiff.inputs["Fac"])
-	links.new(nodeDiff.outputs["BSDF"], nodeMixDiff.inputs[1])
-	links.new(nodeGlossDiff.outputs["BSDF"], nodeMixDiff.inputs[2])
-	links.new(
-		nodeFresnelMetallic.outputs["Fac"],
-		nodeMixRGBMetallic.inputs[mixMetallicIn[0]])
-	links.new(
-		nodeMathMetallic.outputs["Value"],
-		nodeMixRGBMetallic.inputs[mixMetallicIn[2]])
-	links.new(
-		nodeMixRGBMetallic.outputs[mixMetallicOut[0]],
-		nodeGlossMetallic.inputs["Color"])
-	links.new(nodeGlossMetallic.outputs["BSDF"], nodeMixMetallic.inputs[2])
-	links.new(nodeMixMetallic.outputs["Shader"], nodeMixEmit.inputs[1])
-	links.new(nodeMixCam.outputs["Shader"], nodeMixEmit.inputs[2])
-	links.new(nodeTrans.outputs["BSDF"], nodeMixTrans.inputs[1])
-	links.new(nodeFalloff.outputs["Linear"], nodeEmit.inputs["Strength"])
-	links.new(nodeLightPath.outputs["Is Camera Ray"], nodeMixCam.inputs["Fac"])
-	links.new(nodeEmit.outputs["Emission"], nodeMixCam.inputs[1])
-	links.new(nodeEmitCam.outputs["Emission"], nodeMixCam.inputs[2])
-	links.new(nodeMixEmit.outputs["Shader"], nodeMixTrans.inputs[2])
-	links.new(nodeMixTrans.outputs["Shader"], nodeOut.inputs["Surface"])
+    # Connect nodes
+    links.new(nodeMixDiff.outputs["Shader"], nodeMixMetallic.inputs[1])
+    links.new(nodeMathPower.outputs[0], nodeMixRGB.inputs[mixIn[0]])
+    links.new(nodeMathPower.outputs[0], nodeDiff.inputs["Roughness"])
+    links.new(nodeMixRGB.outputs[mixOut[0]], nodeFresnel.inputs["Normal"])
+    links.new(nodeFresnel.outputs[0], nodeMixRGBDiff.inputs[mixDiffIn[0]])
+    links.new(nodeGeometry.outputs["Incoming"], nodeMixRGB.inputs[mixIn[2]])
+    links.new(nodeBump.outputs["Normal"], nodeMixRGB.inputs[mixIn[1]])
+    links.new(nodeMathPowerDiff.outputs["Value"], nodeMixRGBDiff.inputs[mixDiffIn[1]])
+    links.new(nodeMixRGBDiff.outputs[mixDiffOut[0]], nodeMathMultiplyDiff.inputs[0])
+    links.new(nodeMathMultiplyDiff.outputs["Value"], nodeMixDiff.inputs["Fac"])
+    links.new(nodeDiff.outputs["BSDF"], nodeMixDiff.inputs[1])
+    links.new(nodeGlossDiff.outputs["BSDF"], nodeMixDiff.inputs[2])
+    links.new(
+        nodeFresnelMetallic.outputs["Fac"], nodeMixRGBMetallic.inputs[mixMetallicIn[0]]
+    )
+    links.new(
+        nodeMathMetallic.outputs["Value"], nodeMixRGBMetallic.inputs[mixMetallicIn[2]]
+    )
+    links.new(
+        nodeMixRGBMetallic.outputs[mixMetallicOut[0]], nodeGlossMetallic.inputs["Color"]
+    )
+    links.new(nodeGlossMetallic.outputs["BSDF"], nodeMixMetallic.inputs[2])
+    links.new(nodeMixMetallic.outputs["Shader"], nodeMixEmit.inputs[1])
+    links.new(nodeMixCam.outputs["Shader"], nodeMixEmit.inputs[2])
+    links.new(nodeTrans.outputs["BSDF"], nodeMixTrans.inputs[1])
+    links.new(nodeFalloff.outputs["Linear"], nodeEmit.inputs["Strength"])
+    links.new(nodeLightPath.outputs["Is Camera Ray"], nodeMixCam.inputs["Fac"])
+    links.new(nodeEmit.outputs["Emission"], nodeMixCam.inputs[1])
+    links.new(nodeEmitCam.outputs["Emission"], nodeMixCam.inputs[2])
+    links.new(nodeMixEmit.outputs["Shader"], nodeMixTrans.inputs[2])
+    links.new(nodeMixTrans.outputs["Shader"], nodeOut.inputs["Surface"])
 
-	nodeInputs = [
-		[
-			nodeMixRGBMetallic.inputs[mixMetallicIn[1]],
-			nodeMathMetallic.inputs[0],
-			nodeDiff.inputs["Color"],
-			nodeEmit.inputs["Color"],
-			nodeEmitCam.inputs["Color"]],
-		[nodeMixTrans.inputs["Fac"]],
-		[nodeMixEmit.inputs[0]],
-		[
-			nodeGlossDiff.inputs["Roughness"],
-			nodeGlossMetallic.inputs["Roughness"],
-			nodeMathPower.inputs[0]],
-		[nodeMixMetallic.inputs["Fac"]],
-		[nodeMathPowerDiff.inputs[0]],
-		[
-			nodeDiff.inputs["Normal"],
-			nodeGlossMetallic.inputs["Normal"],
-			nodeFresnelMetallic.inputs["Normal"],
-			nodeGlossDiff.inputs["Normal"],
-			nodeBump.inputs["Normal"]]]
+    nodeInputs = [
+        [
+            nodeMixRGBMetallic.inputs[mixMetallicIn[1]],
+            nodeMathMetallic.inputs[0],
+            nodeDiff.inputs["Color"],
+            nodeEmit.inputs["Color"],
+            nodeEmitCam.inputs["Color"],
+        ],
+        [nodeMixTrans.inputs["Fac"]],
+        [nodeMixEmit.inputs[0]],
+        [
+            nodeGlossDiff.inputs["Roughness"],
+            nodeGlossMetallic.inputs["Roughness"],
+            nodeMathPower.inputs[0],
+        ],
+        [nodeMixMetallic.inputs["Fac"]],
+        [nodeMathPowerDiff.inputs[0]],
+        [
+            nodeDiff.inputs["Normal"],
+            nodeGlossMetallic.inputs["Normal"],
+            nodeFresnelMetallic.inputs["Normal"],
+            nodeGlossDiff.inputs["Normal"],
+            nodeBump.inputs["Normal"],
+        ],
+    ]
 
-	# generate texture format and connect
-	if options.pack_format == "specular":
-		texgen_specular(mat, options.passes, nodeInputs, options.use_reflections)
-	elif options.pack_format == "seus":
-		texgen_seus(mat, options.passes, nodeInputs, options.use_reflections, options.use_emission_nodes)
+    # generate texture format and connect
+    if options.pack_format == "specular":
+        texgen_specular(mat, options.passes, nodeInputs, options.use_reflections)
+    elif options.pack_format == "seus":
+        texgen_seus(
+            mat,
+            options.passes,
+            nodeInputs,
+            options.use_reflections,
+            options.use_emission_nodes,
+        )
 
-	if options.only_solid is True or checklist(canon, "solid"):
-		nodes.remove(nodeTrans)
-		nodes.remove(nodeMixTrans)
-		nodeOut.location = (1540, 0)
-		links.new(nodeMixEmit.outputs[0], nodeOut.inputs[0])
+    if options.only_solid is True or checklist(canon, "solid"):
+        nodes.remove(nodeTrans)
+        nodes.remove(nodeMixTrans)
+        nodeOut.location = (1540, 0)
+        links.new(nodeMixEmit.outputs[0], nodeOut.inputs[0])
 
-		if hasattr(mat, "blend_method"):
-			mat.blend_method = 'OPAQUE'  # eevee setting
-	else:
-		# non-solid (potentially, not necessarily though)
-		if hasattr(mat, "blend_method"):  # 2.8 eevee settings
-			# TODO: Work on finding the optimal decision here
-			# clip could be better in cases of true/false transparency
-			# could do work to detect this from the image directly..
-			# though would be slower
+        if hasattr(mat, "blend_method"):
+            mat.blend_method = "OPAQUE"  # eevee setting
+    else:
+        # non-solid (potentially, not necessarily though)
+        if hasattr(mat, "blend_method"):  # 2.8 eevee settings
+            # TODO: Work on finding the optimal decision here
+            # clip could be better in cases of true/false transparency
+            # could do work to detect this from the image directly..
+            # though would be slower
 
-			# noisy, but workable for partial trans; bad for materials with
-			# no partial trans (makes view-through all somewhat noisy)
-			# Note: placed with hasattr to reduce bugs, seemingly only on old
-			# 2.80 build
-			if hasattr(mat, "blend_method"):
-				mat.blend_method = 'HASHED'
-			if hasattr(mat, "shadow_method"):
-				mat.shadow_method = 'HASHED'
+            # noisy, but workable for partial trans; bad for materials with
+            # no partial trans (makes view-through all somewhat noisy)
+            # Note: placed with hasattr to reduce bugs, seemingly only on old
+            # 2.80 build
+            if hasattr(mat, "blend_method"):
+                mat.blend_method = "HASHED"
+            if hasattr(mat, "shadow_method"):
+                mat.shadow_method = "HASHED"
 
-			# best if there is no partial transparency
-			# material.blend_method = 'CLIP' for no partial transparency
-			# both work fine with depth of field.
+            # best if there is no partial transparency
+            # material.blend_method = 'CLIP' for no partial transparency
+            # both work fine with depth of field.
 
-			# but, BLEND does NOT work well with Depth of Field or layering
+            # but, BLEND does NOT work well with Depth of Field or layering
 
-	if options.use_emission:
-		nodeMixEmit.inputs[0].default_value = 1
-	else:
-		nodeMixEmit.inputs[0].default_value = 0
+    if options.use_emission:
+        nodeMixEmit.inputs[0].default_value = 1
+    else:
+        nodeMixEmit.inputs[0].default_value = 0
 
-	# reapply animation data if any to generated nodes
-	apply_texture_animation_pass_settings(mat, animated_data)
+    # reapply animation data if any to generated nodes
+    apply_texture_animation_pass_settings(mat, animated_data)
 
-	return 0
+    return 0
 
 
 def matgen_special_water(mat, passes):
-	"""Generate special water material"""
+    """Generate special water material"""
 
-	matGen = util.nameGeneralize(mat.name)
-	canon, form = get_mc_canonical_name(matGen)
+    matGen = util.nameGeneralize(mat.name)
+    canon, form = get_mc_canonical_name(matGen)
 
-	# get the texture, but will fail if NoneType
-	image_diff = passes["diffuse"]
-	image_norm = passes["normal"]
+    # get the texture, but will fail if NoneType
+    image_diff = passes["diffuse"]
+    image_norm = passes["normal"]
 
-	if not image_diff:
-		print("Could not find diffuse image, halting generation: " + mat.name)
-		return
-	elif image_diff.size[0] == 0 or image_diff.size[1] == 0:
-		if image_diff.source != 'SEQUENCE':
-			# Common non animated case; this means the image is missing and would
-			# have already checked for replacement textures by now, so skip
-			return
-		if not os.path.isfile(bpy.path.abspath(image_diff.filepath)):
-			# can't check size or pixels as it often is not immediately avaialble
-			# so instea, check against firs frame of sequence to verify load
-			return
+    if not image_diff:
+        print("Could not find diffuse image, halting generation: " + mat.name)
+        return
+    elif image_diff.size[0] == 0 or image_diff.size[1] == 0:
+        if image_diff.source != "SEQUENCE":
+            # Common non animated case; this means the image is missing and would
+            # have already checked for replacement textures by now, so skip
+            return
+        if not os.path.isfile(bpy.path.abspath(image_diff.filepath)):
+            # can't check size or pixels as it often is not immediately avaialble
+            # so instea, check against firs frame of sequence to verify load
+            return
 
-	mat.use_nodes = True
-	animated_data = copy_texture_animation_pass_settings(mat)
-	nodes = mat.node_tree.nodes
-	links = mat.node_tree.links
-	nodes.clear()
+    mat.use_nodes = True
+    animated_data = copy_texture_animation_pass_settings(mat)
+    nodes = mat.node_tree.nodes
+    links = mat.node_tree.links
+    nodes.clear()
 
-	nodeTexDiff = create_node(
-		nodes, 'ShaderNodeTexImage',
-		name="Diffuse Texure",
-		label="Diffuse Texure",
-		location=(-180, 140),
-		interpolation='Closest',
-		image=image_diff)
-	nodeTexNorm = create_node(
-		nodes, 'ShaderNodeTexImage',
-		name="Normal Texure",
-		label="Normal Texure",
-		location=(-290, -180),
-		interpolation='Closest')
-	nodeSaturateMix = create_node(
-		nodes, 'ShaderNodeMixRGB',
-		name="Add Color",
-		label="Add Color",
-		location=(320, 140),
-		blend_type='MULTIPLY',
-		mute=True,
-		hide=True)
-	nodeNormalInv = create_node(
-		nodes, 'ShaderNodeRGBCurve',
-		name="Normal Inverse",
-		label="Normal Inverse",
-		location=(10, -180))
-	nodeNormal = create_node(
-		nodes, 'ShaderNodeNormalMap', location=(310, -180))
-	nodeBrightContrast = create_node(
-		nodes, 'ShaderNodeBrightContrast', location=(120, 140))
+    nodeTexDiff = create_node(
+        nodes,
+        "ShaderNodeTexImage",
+        name="Diffuse Texure",
+        label="Diffuse Texure",
+        location=(-180, 140),
+        interpolation="Closest",
+        image=image_diff,
+    )
+    nodeTexNorm = create_node(
+        nodes,
+        "ShaderNodeTexImage",
+        name="Normal Texure",
+        label="Normal Texure",
+        location=(-290, -180),
+        interpolation="Closest",
+    )
+    nodeSaturateMix = create_node(
+        nodes,
+        "ShaderNodeMixRGB",
+        name="Add Color",
+        label="Add Color",
+        location=(320, 140),
+        blend_type="MULTIPLY",
+        mute=True,
+        hide=True,
+    )
+    nodeNormalInv = create_node(
+        nodes,
+        "ShaderNodeRGBCurve",
+        name="Normal Inverse",
+        label="Normal Inverse",
+        location=(10, -180),
+    )
+    nodeNormal = create_node(nodes, "ShaderNodeNormalMap", location=(310, -180))
+    nodeBrightContrast = create_node(
+        nodes, "ShaderNodeBrightContrast", location=(120, 140)
+    )
 
-	nodeGlass = create_node(
-		nodes, 'ShaderNodeBsdfGlass', location=(520, 140))
-	nodeTrans = create_node(
-		nodes, 'ShaderNodeBsdfTransparent', location=(520, 340))
-	nodeMixTrans = create_node(
-		nodes, 'ShaderNodeMixShader', location=(720, 140))
-	nodeOut = create_node(
-		nodes, 'ShaderNodeOutputMaterial', location=(920, 140))
+    nodeGlass = create_node(nodes, "ShaderNodeBsdfGlass", location=(520, 140))
+    nodeTrans = create_node(nodes, "ShaderNodeBsdfTransparent", location=(520, 340))
+    nodeMixTrans = create_node(nodes, "ShaderNodeMixShader", location=(720, 140))
+    nodeOut = create_node(nodes, "ShaderNodeOutputMaterial", location=(920, 140))
 
-	# Mix RGB sockets for 3.4
-	saturateMixIn = get_node_socket(nodeSaturateMix)
-	saturateMixOut = get_node_socket(nodeSaturateMix, is_input=False)
+    # Mix RGB sockets for 3.4
+    saturateMixIn = get_node_socket(nodeSaturateMix)
+    saturateMixOut = get_node_socket(nodeSaturateMix, is_input=False)
 
-	# Sets default values
-	nodeSaturateMix.inputs[0].default_value = 1.0	# Graystyle Blending
-	nodeNormalInv.mapping.curves[1].points[0].location = (0, 1)
-	nodeNormalInv.mapping.curves[1].points[1].location = (1, 0)
-	nodeMixTrans.inputs[0].default_value = 0.8
-	nodeBrightContrast.inputs[1].default_value = 12
-	nodeBrightContrast.inputs[2].default_value = 24
-	nodeGlass.inputs[1].default_value = 0.1
-	nodeGlass.inputs[2].default_value = 1.333
+    # Sets default values
+    nodeSaturateMix.inputs[0].default_value = 1.0  # Graystyle Blending
+    nodeNormalInv.mapping.curves[1].points[0].location = (0, 1)
+    nodeNormalInv.mapping.curves[1].points[1].location = (1, 0)
+    nodeMixTrans.inputs[0].default_value = 0.8
+    nodeBrightContrast.inputs[1].default_value = 12
+    nodeBrightContrast.inputs[2].default_value = 24
+    nodeGlass.inputs[1].default_value = 0.1
+    nodeGlass.inputs[2].default_value = 1.333
 
-	# Connect nodes
-	links.new(nodeTexDiff.outputs[0], nodeBrightContrast.inputs[0])
-	links.new(nodeBrightContrast.outputs[0], nodeSaturateMix.inputs[1])
-	links.new(nodeSaturateMix.outputs[saturateMixOut[0]], nodeGlass.inputs[0])
-	links.new(nodeGlass.outputs[0], nodeMixTrans.inputs[2])
-	links.new(nodeTrans.outputs[0], nodeMixTrans.inputs[1])
-	links.new(nodeMixTrans.outputs[0], nodeOut.inputs[0])
-	links.new(nodeTexNorm.outputs[0], nodeNormalInv.inputs[0])
-	links.new(nodeNormalInv.outputs[0], nodeNormal.inputs[0])
-	links.new(nodeNormal.outputs[0], nodeGlass.inputs[3])
+    # Connect nodes
+    links.new(nodeTexDiff.outputs[0], nodeBrightContrast.inputs[0])
+    links.new(nodeBrightContrast.outputs[0], nodeSaturateMix.inputs[1])
+    links.new(nodeSaturateMix.outputs[saturateMixOut[0]], nodeGlass.inputs[0])
+    links.new(nodeGlass.outputs[0], nodeMixTrans.inputs[2])
+    links.new(nodeTrans.outputs[0], nodeMixTrans.inputs[1])
+    links.new(nodeMixTrans.outputs[0], nodeOut.inputs[0])
+    links.new(nodeTexNorm.outputs[0], nodeNormalInv.inputs[0])
+    links.new(nodeNormalInv.outputs[0], nodeNormal.inputs[0])
+    links.new(nodeNormal.outputs[0], nodeGlass.inputs[3])
 
-	# Normal update
-	util.apply_colorspace(nodeTexNorm, 'Non-Color')
-	if image_norm:
-		nodeTexNorm.image = image_norm
-		nodeTexNorm.mute = False
-		nodeNormalInv.mute = False
-		nodeNormal.mute = False
-	else:
-		nodeTexNorm.mute = True
-		nodeNormalInv.mute = True
-		nodeNormal.mute = True
+    # Normal update
+    util.apply_colorspace(nodeTexNorm, "Non-Color")
+    if image_norm:
+        nodeTexNorm.image = image_norm
+        nodeTexNorm.mute = False
+        nodeNormalInv.mute = False
+        nodeNormal.mute = False
+    else:
+        nodeTexNorm.mute = True
+        nodeNormalInv.mute = True
+        nodeNormal.mute = True
 
-	# non-solid (potentially, not necessarily though)
-	if hasattr(mat, "blend_method"):  # 2.8 eevee settings
-		# TODO: Work on finding the optimal decision here
-		# clip could be better in cases of true/false transparency
-		# could do work to detect this from the image directly..
-		# though would be slower
+    # non-solid (potentially, not necessarily though)
+    if hasattr(mat, "blend_method"):  # 2.8 eevee settings
+        # TODO: Work on finding the optimal decision here
+        # clip could be better in cases of true/false transparency
+        # could do work to detect this from the image directly..
+        # though would be slower
 
-		# noisy, but workable for partial trans; bad for materials with
-		# no partial trans (makes view-through all somewhat noisy)
-		# Note: placed with hasattr to reduce bugs, seemingly only on old
-		# 2.80 build
-		if hasattr(mat, "blend_method"):
-			mat.blend_method = 'HASHED'
-		if hasattr(mat, "shadow_method"):
-			mat.shadow_method = 'HASHED'
+        # noisy, but workable for partial trans; bad for materials with
+        # no partial trans (makes view-through all somewhat noisy)
+        # Note: placed with hasattr to reduce bugs, seemingly only on old
+        # 2.80 build
+        if hasattr(mat, "blend_method"):
+            mat.blend_method = "HASHED"
+        if hasattr(mat, "shadow_method"):
+            mat.shadow_method = "HASHED"
 
-		# best if there is no partial transparency
-		# material.blend_method = 'CLIP' for no partial transparency
-		# both work fine with depth of field.
+        # best if there is no partial transparency
+        # material.blend_method = 'CLIP' for no partial transparency
+        # both work fine with depth of field.
 
-		# but, BLEND does NOT work well with Depth of Field or layering
+        # but, BLEND does NOT work well with Depth of Field or layering
 
-	# reapply animation data if any to generated nodes
-	apply_texture_animation_pass_settings(mat, animated_data)
+    # reapply animation data if any to generated nodes
+    apply_texture_animation_pass_settings(mat, animated_data)
 
-	# Graystyle Blending
-	if not checklist(canon, "desaturated"):
-		pass
-	elif not is_image_grayscale(image_diff):
-		pass
-	else:
-		env.log("Texture desaturated: " + canon, vv_only=True)
-		desat_color = env.json_data['blocks']['desaturated'][canon]
-		if len(desat_color) < len(nodeSaturateMix.inputs[saturateMixIn[2]].default_value):
-			desat_color.append(1.0)
-		nodeSaturateMix.inputs[saturateMixIn[2]].default_value = desat_color
-		nodeSaturateMix.mute = False
-		nodeSaturateMix.hide = False
+    # Graystyle Blending
+    if not checklist(canon, "desaturated"):
+        pass
+    elif not is_image_grayscale(image_diff):
+        pass
+    else:
+        env.log("Texture desaturated: " + canon, vv_only=True)
+        desat_color = env.json_data["blocks"]["desaturated"][canon]
+        if len(desat_color) < len(
+            nodeSaturateMix.inputs[saturateMixIn[2]].default_value
+        ):
+            desat_color.append(1.0)
+        nodeSaturateMix.inputs[saturateMixIn[2]].default_value = desat_color
+        nodeSaturateMix.mute = False
+        nodeSaturateMix.hide = False
 
-	# annotate special nodes for finding later, and load images if available
-	nodeTexDiff["MCPREP_diffuse"] = True
-	nodeTexNorm["MCPREP_normal"] = True
-	nodeNormal["MCPREP_normal"] = True  # to also be also muted if no normal tex
-	# nodeTexDisp["MCPREP_disp"] = True
+    # annotate special nodes for finding later, and load images if available
+    nodeTexDiff["MCPREP_diffuse"] = True
+    nodeTexNorm["MCPREP_normal"] = True
+    nodeNormal["MCPREP_normal"] = True  # to also be also muted if no normal tex
+    # nodeTexDisp["MCPREP_disp"] = True
 
-	return 0
+    return 0
 
 
 def matgen_special_glass(mat, passes):
-	"""Generate special glass material"""
+    """Generate special glass material"""
 
-	matGen = util.nameGeneralize(mat.name)
-	canon, form = get_mc_canonical_name(matGen)
+    matGen = util.nameGeneralize(mat.name)
+    canon, form = get_mc_canonical_name(matGen)
 
-	# get the texture, but will fail if NoneType
-	image_diff = passes["diffuse"]
-	image_norm = passes["normal"]
+    # get the texture, but will fail if NoneType
+    image_diff = passes["diffuse"]
+    image_norm = passes["normal"]
 
-	if not image_diff:
-		print("Could not find diffuse image, halting generation: " + mat.name)
-		return
-	elif image_diff.size[0] == 0 or image_diff.size[1] == 0:
-		if image_diff.source != 'SEQUENCE':
-			# Common non animated case; this means the image is missing and would
-			# have already checked for replacement textures by now, so skip
-			return
-		if not os.path.isfile(bpy.path.abspath(image_diff.filepath)):
-			# can't check size or pixels as it often is not immediately avaialble
-			# so instea, check against firs frame of sequence to verify load
-			return
+    if not image_diff:
+        print("Could not find diffuse image, halting generation: " + mat.name)
+        return
+    elif image_diff.size[0] == 0 or image_diff.size[1] == 0:
+        if image_diff.source != "SEQUENCE":
+            # Common non animated case; this means the image is missing and would
+            # have already checked for replacement textures by now, so skip
+            return
+        if not os.path.isfile(bpy.path.abspath(image_diff.filepath)):
+            # can't check size or pixels as it often is not immediately avaialble
+            # so instea, check against firs frame of sequence to verify load
+            return
 
-	mat.use_nodes = True
-	animated_data = copy_texture_animation_pass_settings(mat)
-	nodes = mat.node_tree.nodes
-	links = mat.node_tree.links
-	nodes.clear()
+    mat.use_nodes = True
+    animated_data = copy_texture_animation_pass_settings(mat)
+    nodes = mat.node_tree.nodes
+    links = mat.node_tree.links
+    nodes.clear()
 
-	nodeTexDiff = create_node(
-		nodes, 'ShaderNodeTexImage',
-		name="Diffuse Texture",
-		label="Diffuse Texture", 
-		location=(-380, 140),
-		interpolation='Closest',
-		image=image_diff)
-	nodeTexNorm = create_node(
-		nodes, 'ShaderNodeTexImage',
-		name="Normal Texture",
-		label="Normal Texture",
-		location=(-680, -180))
-	nodeNormalInv = create_node(
-		nodes, 'ShaderNodeRGBCurve',
-		name="Normal Inverse",
-		label="Normal Inverse",
-		location=(-380, -180))
-	nodeNormal = create_node(nodes, 'ShaderNodeNormalMap', location=(-80, -180))
-	nodeDiff = create_node(nodes, 'ShaderNodeBsdfDiffuse', location=(120, 0))
-	nodeMixTrans = create_node(nodes, 'ShaderNodeMixShader', location=(620, 0))
-	nodeGlass = create_node(nodes, 'ShaderNodeBsdfGlass', location=(120, 240))
-	nodeBrightContrast = create_node(
-		nodes, 'ShaderNodeBrightContrast', location=(420, 0))
-	nodeOut = create_node(nodes, 'ShaderNodeOutputMaterial', location=(820, 0))
+    nodeTexDiff = create_node(
+        nodes,
+        "ShaderNodeTexImage",
+        name="Diffuse Texture",
+        label="Diffuse Texture",
+        location=(-380, 140),
+        interpolation="Closest",
+        image=image_diff,
+    )
+    nodeTexNorm = create_node(
+        nodes,
+        "ShaderNodeTexImage",
+        name="Normal Texture",
+        label="Normal Texture",
+        location=(-680, -180),
+    )
+    nodeNormalInv = create_node(
+        nodes,
+        "ShaderNodeRGBCurve",
+        name="Normal Inverse",
+        label="Normal Inverse",
+        location=(-380, -180),
+    )
+    nodeNormal = create_node(nodes, "ShaderNodeNormalMap", location=(-80, -180))
+    nodeDiff = create_node(nodes, "ShaderNodeBsdfDiffuse", location=(120, 0))
+    nodeMixTrans = create_node(nodes, "ShaderNodeMixShader", location=(620, 0))
+    nodeGlass = create_node(nodes, "ShaderNodeBsdfGlass", location=(120, 240))
+    nodeBrightContrast = create_node(
+        nodes, "ShaderNodeBrightContrast", location=(420, 0)
+    )
+    nodeOut = create_node(nodes, "ShaderNodeOutputMaterial", location=(820, 0))
 
-	# Sets default transparency value
-	nodeMixTrans.inputs[0].default_value = 1
-	nodeGlass.inputs[1].default_value = 0
-	nodeGlass.inputs[2].default_value = 1.5
-	nodeBrightContrast.inputs[1].default_value = 0
-	nodeBrightContrast.inputs[2].default_value = 1
+    # Sets default transparency value
+    nodeMixTrans.inputs[0].default_value = 1
+    nodeGlass.inputs[1].default_value = 0
+    nodeGlass.inputs[2].default_value = 1.5
+    nodeBrightContrast.inputs[1].default_value = 0
+    nodeBrightContrast.inputs[2].default_value = 1
 
-	# Connect nodes
-	links.new(nodeGlass.outputs["BSDF"], nodeMixTrans.inputs[1])
-	links.new(nodeDiff.outputs["BSDF"], nodeMixTrans.inputs[2])
-	links.new(nodeTexDiff.outputs["Alpha"], nodeBrightContrast.inputs["Color"])
-	links.new(nodeBrightContrast.outputs[0], nodeMixTrans.inputs[0])
+    # Connect nodes
+    links.new(nodeGlass.outputs["BSDF"], nodeMixTrans.inputs[1])
+    links.new(nodeDiff.outputs["BSDF"], nodeMixTrans.inputs[2])
+    links.new(nodeTexDiff.outputs["Alpha"], nodeBrightContrast.inputs["Color"])
+    links.new(nodeBrightContrast.outputs[0], nodeMixTrans.inputs[0])
 
-	links.new(nodeDiff.outputs[0], nodeMixTrans.inputs[2])
-	links.new(nodeMixTrans.outputs[0], nodeOut.inputs[0])
-	links.new(nodeTexDiff.outputs["Color"], nodeDiff.inputs[0])
-	links.new(nodeTexNorm.outputs["Color"], nodeNormalInv.inputs["Color"])
-	links.new(nodeNormalInv.outputs["Color"], nodeNormal.inputs["Color"])
-	links.new(nodeNormal.outputs[0], nodeDiff.inputs[2])
+    links.new(nodeDiff.outputs[0], nodeMixTrans.inputs[2])
+    links.new(nodeMixTrans.outputs[0], nodeOut.inputs[0])
+    links.new(nodeTexDiff.outputs["Color"], nodeDiff.inputs[0])
+    links.new(nodeTexNorm.outputs["Color"], nodeNormalInv.inputs["Color"])
+    links.new(nodeNormalInv.outputs["Color"], nodeNormal.inputs["Color"])
+    links.new(nodeNormal.outputs[0], nodeDiff.inputs[2])
 
-	# Normal update
-	util.apply_colorspace(nodeTexNorm, 'Non-Color')
-	if image_norm:
-		nodeTexNorm.image = image_norm
-		nodeTexNorm.mute = False
-		nodeNormalInv.mute = False
-		nodeNormal.mute = False
-	else:
-		nodeTexNorm.mute = True
-		nodeNormalInv.mute = True
-		nodeNormal.mute = True
+    # Normal update
+    util.apply_colorspace(nodeTexNorm, "Non-Color")
+    if image_norm:
+        nodeTexNorm.image = image_norm
+        nodeTexNorm.mute = False
+        nodeNormalInv.mute = False
+        nodeNormal.mute = False
+    else:
+        nodeTexNorm.mute = True
+        nodeNormalInv.mute = True
+        nodeNormal.mute = True
 
-	# non-solid (potentially, not necessarily though)
-	if hasattr(mat, "blend_method"):  # 2.8 eevee settings
-		# TODO: Work on finding the optimal decision here
-		# clip could be better in cases of true/false transparency
-		# could do work to detect this from the image directly..
-		# though would be slower
+    # non-solid (potentially, not necessarily though)
+    if hasattr(mat, "blend_method"):  # 2.8 eevee settings
+        # TODO: Work on finding the optimal decision here
+        # clip could be better in cases of true/false transparency
+        # could do work to detect this from the image directly..
+        # though would be slower
 
-		# noisy, but workable for partial trans; bad for materials with
-		# no partial trans (makes view-through all somewhat noisy)
-		# Note: placed with hasattr to reduce bugs, seemingly only on old
-		# 2.80 build
-		if hasattr(mat, "blend_method"):
-			mat.blend_method = 'HASHED'
-		if hasattr(mat, "shadow_method"):
-			mat.shadow_method = 'HASHED'
+        # noisy, but workable for partial trans; bad for materials with
+        # no partial trans (makes view-through all somewhat noisy)
+        # Note: placed with hasattr to reduce bugs, seemingly only on old
+        # 2.80 build
+        if hasattr(mat, "blend_method"):
+            mat.blend_method = "HASHED"
+        if hasattr(mat, "shadow_method"):
+            mat.shadow_method = "HASHED"
 
-		# best if there is no partial transparency
-		# material.blend_method = 'CLIP' for no partial transparency
-		# both work fine with depth of field.
+        # best if there is no partial transparency
+        # material.blend_method = 'CLIP' for no partial transparency
+        # both work fine with depth of field.
 
-		# but, BLEND does NOT work well with Depth of Field or layering
+        # but, BLEND does NOT work well with Depth of Field or layering
 
-	# reapply animation data if any to generated nodes
-	apply_texture_animation_pass_settings(mat, animated_data)
+    # reapply animation data if any to generated nodes
+    apply_texture_animation_pass_settings(mat, animated_data)
 
-	# annotate special nodes for finding later, and load images if available
-	nodeTexDiff["MCPREP_diffuse"] = True
-	nodeTexNorm["MCPREP_normal"] = True
-	nodeNormal["MCPREP_normal"] = True  # to also be also muted if no normal tex
-	# nodeTexDisp["MCPREP_disp"] = True
+    # annotate special nodes for finding later, and load images if available
+    nodeTexDiff["MCPREP_diffuse"] = True
+    nodeTexNorm["MCPREP_normal"] = True
+    nodeNormal["MCPREP_normal"] = True  # to also be also muted if no normal tex
+    # nodeTexDisp["MCPREP_disp"] = True
 
-	return 0  # return 0 once implemented
+    return 0  # return 0 once implemented

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -35,75 +35,80 @@ from ..conf import env
 
 
 def reload_materials(context):
-	"""Reload the material UI list"""
-	mcprep_props = context.scene.mcprep_props
-	resource_folder = bpy.path.abspath(context.scene.mcprep_texturepack_path)
-	extensions = [".png", ".jpg", ".jpeg"]
+    """Reload the material UI list"""
+    mcprep_props = context.scene.mcprep_props
+    resource_folder = bpy.path.abspath(context.scene.mcprep_texturepack_path)
+    extensions = [".png", ".jpg", ".jpeg"]
 
-	mcprep_props.material_list.clear()
-	if env.use_icons and env.preview_collections["materials"]:
-		try:
-			bpy.utils.previews.remove(env.preview_collections["materials"])
-		except:
-			env.log("Failed to remove icon set, materials")
+    mcprep_props.material_list.clear()
+    if env.use_icons and env.preview_collections["materials"]:
+        try:
+            bpy.utils.previews.remove(env.preview_collections["materials"])
+        except:
+            env.log("Failed to remove icon set, materials")
 
-	if not os.path.isdir(resource_folder):
-		env.log("Error, resource folder does not exist")
-		return
+    if not os.path.isdir(resource_folder):
+        env.log("Error, resource folder does not exist")
+        return
 
-	# Check multiple paths, picking the first match (order is important),
-	# goal of picking out the /textures folder.
-	check_dirs = [
-		os.path.join(resource_folder, "textures"),
-		os.path.join(resource_folder, "minecraft", "textures"),
-		os.path.join(resource_folder, "assets", "minecraft", "textures")]
-	for path in check_dirs:
-		if os.path.isdir(path):
-			resource_folder = path
-			break
+    # Check multiple paths, picking the first match (order is important),
+    # goal of picking out the /textures folder.
+    check_dirs = [
+        os.path.join(resource_folder, "textures"),
+        os.path.join(resource_folder, "minecraft", "textures"),
+        os.path.join(resource_folder, "assets", "minecraft", "textures"),
+    ]
+    for path in check_dirs:
+        if os.path.isdir(path):
+            resource_folder = path
+            break
 
-	search_paths = [
-		resource_folder,
-		os.path.join(resource_folder, "blocks"),
-		os.path.join(resource_folder, "block")]
-	files = []
+    search_paths = [
+        resource_folder,
+        os.path.join(resource_folder, "blocks"),
+        os.path.join(resource_folder, "block"),
+    ]
+    files = []
 
-	for path in search_paths:
-		if not os.path.isdir(path):
-			continue
-		files += [
-			os.path.join(path, image_file)
-			for image_file in os.listdir(path)
-			if os.path.isfile(os.path.join(path, image_file))
-			and os.path.splitext(image_file.lower())[-1] in extensions]
-	for i, image_file in enumerate(sorted(files)):
-		basename = os.path.splitext(os.path.basename(image_file))[0]
-		if basename.endswith("_s") or basename.endswith("_n"):
-			continue  # ignore the pbr passes
+    for path in search_paths:
+        if not os.path.isdir(path):
+            continue
+        files += [
+            os.path.join(path, image_file)
+            for image_file in os.listdir(path)
+            if os.path.isfile(os.path.join(path, image_file))
+            and os.path.splitext(image_file.lower())[-1] in extensions
+        ]
+    for i, image_file in enumerate(sorted(files)):
+        basename = os.path.splitext(os.path.basename(image_file))[0]
+        if basename.endswith("_s") or basename.endswith("_n"):
+            continue  # ignore the pbr passes
 
-		canon, _ = generate.get_mc_canonical_name(basename)
-		asset = mcprep_props.material_list.add()
-		asset.name = canon
-		asset.description = "Generate {} ({})".format(canon, basename)
-		asset.path = image_file
-		asset.index = i
+        canon, _ = generate.get_mc_canonical_name(basename)
+        asset = mcprep_props.material_list.add()
+        asset.name = canon
+        asset.description = "Generate {} ({})".format(canon, basename)
+        asset.path = image_file
+        asset.index = i
 
-		# if available, load the custom icon too
-		if not env.use_icons or env.preview_collections["materials"] == "":
-			continue
-		env.preview_collections["materials"].load(
-			"material-{}".format(i), image_file, 'IMAGE')
+        # if available, load the custom icon too
+        if not env.use_icons or env.preview_collections["materials"] == "":
+            continue
+        env.preview_collections["materials"].load(
+            "material-{}".format(i), image_file, "IMAGE"
+        )
 
-	if mcprep_props.material_list_index >= len(mcprep_props.material_list):
-		mcprep_props.material_list_index = len(mcprep_props.material_list) - 1
+    if mcprep_props.material_list_index >= len(mcprep_props.material_list):
+        mcprep_props.material_list_index = len(mcprep_props.material_list) - 1
 
 
 class ListMaterials(bpy.types.PropertyGroup):
-	"""For UI drawing of item assets and holding data"""
-	# inherited: name
-	description: bpy.props.StringProperty()
-	path: bpy.props.StringProperty(subtype='FILE_PATH')
-	index: bpy.props.IntProperty(min=0, default=0)  # for icon drawing
+    """For UI drawing of item assets and holding data"""
+
+    # inherited: name
+    description: bpy.props.StringProperty()
+    path: bpy.props.StringProperty(subtype="FILE_PATH")
+    index: bpy.props.IntProperty(min=0, default=0)  # for icon drawing
 
 
 # -----------------------------------------------------------------------------
@@ -112,359 +117,376 @@ class ListMaterials(bpy.types.PropertyGroup):
 
 
 class MCPREP_OT_reset_texturepack_path(bpy.types.Operator):
-	bl_idname = "mcprep.reset_texture_path"
-	bl_label = "Reset texture pack path"
-	bl_description = (
-		"Resets the texture pack folder to the MCprep default saved in preferences")
-	bl_options = {'REGISTER', 'UNDO'}
+    bl_idname = "mcprep.reset_texture_path"
+    bl_label = "Reset texture pack path"
+    bl_description = (
+        "Resets the texture pack folder to the MCprep default saved in preferences"
+    )
+    bl_options = {"REGISTER", "UNDO"}
 
-	@tracking.report_error
-	def execute(self, context):
-		addon_prefs = util.get_user_preferences(context)
-		context.scene.mcprep_texturepack_path = addon_prefs.custom_texturepack_path
-		return {'FINISHED'}
+    @tracking.report_error
+    def execute(self, context):
+        addon_prefs = util.get_user_preferences(context)
+        context.scene.mcprep_texturepack_path = addon_prefs.custom_texturepack_path
+        return {"FINISHED"}
 
 
 class MCPREP_OT_reload_materials(bpy.types.Operator):
-	bl_idname = "mcprep.reload_materials"
-	bl_label = "Reload materials"
-	bl_description = "Reload the material library"
+    bl_idname = "mcprep.reload_materials"
+    bl_label = "Reload materials"
+    bl_description = "Reload the material library"
 
-	@tracking.report_error
-	def execute(self, context):
-		reload_materials(context)
-		return {'FINISHED'}
+    @tracking.report_error
+    def execute(self, context):
+        reload_materials(context)
+        return {"FINISHED"}
 
 
 class MCPREP_OT_combine_materials(bpy.types.Operator):
-	bl_idname = "mcprep.combine_materials"
-	bl_label = "Combine materials"
-	bl_description = (
-		"Consolidate the same materials together e.g. mat.001 and mat.002")
-	bl_options = {'REGISTER', 'UNDO'}
+    bl_idname = "mcprep.combine_materials"
+    bl_label = "Combine materials"
+    bl_description = "Consolidate the same materials together e.g. mat.001 and mat.002"
+    bl_options = {"REGISTER", "UNDO"}
 
-	# arg to auto-force remove old? versus just keep as 0-users
-	selection_only: bpy.props.BoolProperty(
-		name="Selection only",
-		description="Build materials to consoldiate based on selected objects only",
-		default=True)
-	skipUsage: bpy.props.BoolProperty(default=False, options={'HIDDEN'})
+    # arg to auto-force remove old? versus just keep as 0-users
+    selection_only: bpy.props.BoolProperty(
+        name="Selection only",
+        description="Build materials to consoldiate based on selected objects only",
+        default=True,
+    )
+    skipUsage: bpy.props.BoolProperty(default=False, options={"HIDDEN"})
 
-	track_function = "combine_materials"
-	@tracking.report_error
-	def execute(self, context):
-		removeold = True
+    track_function = "combine_materials"
 
-		if self.selection_only is True and len(context.selected_objects) == 0:
-			self.report(
-				{'ERROR'},
-				"Either turn selection only off or select objects with materials")
-			return {'CANCELLED'}
+    @tracking.report_error
+    def execute(self, context):
+        removeold = True
 
-		# 2-level structure to hold base name and all
-		# materials blocks with the same base
-		name_cat = {}
+        if self.selection_only is True and len(context.selected_objects) == 0:
+            self.report(
+                {"ERROR"},
+                "Either turn selection only off or select objects with materials",
+            )
+            return {"CANCELLED"}
 
-		def getMaterials(self, context):
-			if self.selection_only is False:
-				return bpy.data.materials
-			else:
-				mats = []
-				for ob in bpy.data.objects:
-					for sl in ob.material_slots:
-						if sl is None or sl.material is None:
-							continue
-						if sl.material in mats:
-							continue
-						mats.append(sl.material)
-				return mats
+        # 2-level structure to hold base name and all
+        # materials blocks with the same base
+        name_cat = {}
 
-		data = getMaterials(self, context)
-		precount = len(["x" for x in data if x.users > 0])
+        def getMaterials(self, context):
+            if self.selection_only is False:
+                return bpy.data.materials
+            else:
+                mats = []
+                for ob in bpy.data.objects:
+                    for sl in ob.material_slots:
+                        if sl is None or sl.material is None:
+                            continue
+                        if sl.material in mats:
+                            continue
+                        mats.append(sl.material)
+                return mats
 
-		if not data:
-			if self.selection_only:
-				self.report({"ERROR"}, "No materials found on selected objects")
-			else:
-				self.report({"ERROR"}, "No materials in open file")
-			return {'CANCELLED'}
+        data = getMaterials(self, context)
+        precount = len(["x" for x in data if x.users > 0])
 
-		# get and categorize all materials names
-		for mat in data:
-			base = util.nameGeneralize(mat.name)
-			if base not in name_cat:
-				name_cat[base] = [mat.name]
-			elif mat.name not in name_cat[base]:
-				name_cat[base].append(mat.name)
-			else:
-				env.log("Skipping, already added material", True)
+        if not data:
+            if self.selection_only:
+                self.report({"ERROR"}, "No materials found on selected objects")
+            else:
+                self.report({"ERROR"}, "No materials in open file")
+            return {"CANCELLED"}
 
-		# Pre 2.78 solution, deep loop.
-		if bpy.app.version < (2, 78):
-			for ob in bpy.data.objects:
-				for sl in ob.material_slots:
-					if sl is None or sl.material is None:
-						continue
-					if sl.material not in data:
-						continue  # Selection only.
-					name_ref = name_cat[util.nameGeneralize(sl.material.name)][0]
-					sl.material = bpy.data.materials[name_ref]
-			# doesn't remove old textures, but gets it to zero users
+        # get and categorize all materials names
+        for mat in data:
+            base = util.nameGeneralize(mat.name)
+            if base not in name_cat:
+                name_cat[base] = [mat.name]
+            elif mat.name not in name_cat[base]:
+                name_cat[base].append(mat.name)
+            else:
+                env.log("Skipping, already added material", True)
 
-			postcount = len([True for x in bpy.data.materials if x.users > 0])
-			self.report(
-				{"INFO"},
-				"Consolidated {x} materials, down to {y} overall".format(
-					x=precount - postcount,
-					y=postcount))
-			return {'FINISHED'}
+        # Pre 2.78 solution, deep loop.
+        if bpy.app.version < (2, 78):
+            for ob in bpy.data.objects:
+                for sl in ob.material_slots:
+                    if sl is None or sl.material is None:
+                        continue
+                    if sl.material not in data:
+                        continue  # Selection only.
+                    name_ref = name_cat[util.nameGeneralize(sl.material.name)][0]
+                    sl.material = bpy.data.materials[name_ref]
+            # doesn't remove old textures, but gets it to zero users
 
-		# perform the consolidation with one basename set at a time
-		for base in name_cat:  # The keys of the dictionary.
-			if len(base) < 2:
-				continue
+            postcount = len([True for x in bpy.data.materials if x.users > 0])
+            self.report(
+                {"INFO"},
+                "Consolidated {x} materials, down to {y} overall".format(
+                    x=precount - postcount, y=postcount
+                ),
+            )
+            return {"FINISHED"}
 
-			name_cat[base].sort()  # in-place sorting
-			baseMat = bpy.data.materials[name_cat[base][0]]
+        # perform the consolidation with one basename set at a time
+        for base in name_cat:  # The keys of the dictionary.
+            if len(base) < 2:
+                continue
 
-			env.log([name_cat[base], " ## ", baseMat], vv_only=True)
+            name_cat[base].sort()  # in-place sorting
+            baseMat = bpy.data.materials[name_cat[base][0]]
 
-			for matname in name_cat[base][1:]:
-				# skip if fake user set
-				if bpy.data.materials[matname].use_fake_user is True:
-					continue
-				# otherwise, remap
-				res = util.remap_users(bpy.data.materials[matname], baseMat)
-				if res != 0:
-					self.report({'ERROR'}, str(res))
-					return {'CANCELLED'}
-				old = bpy.data.materials[matname]
-				env.log("removing old? " + matname, vv_only=True)
-				if removeold is True and old.users == 0:
-					env.log("removing old:" + matname, vv_only=True)
-					try:
-						data.remove(old)
-					except ReferenceError as err:
-						print('Error trying to remove material ' + matname)
-						print(str(err))
-					except ValueError as err:
-						print('Error trying to remove material ' + matname)
-						print(str(err))
+            env.log([name_cat[base], " ## ", baseMat], vv_only=True)
 
-			# Final step.. rename to not have .001 if it does,
-			# unless the target base-named material still exists and has users.
-			gen_base = util.nameGeneralize(baseMat.name)
-			gen_material = bpy.data.materials.get(gen_base)
-			if baseMat.name != gen_base:
-				if gen_material and gen_material.users != 0:
-					pass
-				else:
-					baseMat.name = gen_base
-			else:
-				baseMat.name = gen_base
-			env.log(["Final: ", baseMat], vv_only=True)
+            for matname in name_cat[base][1:]:
+                # skip if fake user set
+                if bpy.data.materials[matname].use_fake_user is True:
+                    continue
+                # otherwise, remap
+                res = util.remap_users(bpy.data.materials[matname], baseMat)
+                if res != 0:
+                    self.report({"ERROR"}, str(res))
+                    return {"CANCELLED"}
+                old = bpy.data.materials[matname]
+                env.log("removing old? " + matname, vv_only=True)
+                if removeold is True and old.users == 0:
+                    env.log("removing old:" + matname, vv_only=True)
+                    try:
+                        data.remove(old)
+                    except ReferenceError as err:
+                        print("Error trying to remove material " + matname)
+                        print(str(err))
+                    except ValueError as err:
+                        print("Error trying to remove material " + matname)
+                        print(str(err))
 
-		postcount = len(["x" for x in getMaterials(self, context) if x.users > 0])
-		self.report({"INFO"}, "Consolidated {x} materials down to {y}".format(
-			x=precount,
-			y=postcount))
+            # Final step.. rename to not have .001 if it does,
+            # unless the target base-named material still exists and has users.
+            gen_base = util.nameGeneralize(baseMat.name)
+            gen_material = bpy.data.materials.get(gen_base)
+            if baseMat.name != gen_base:
+                if gen_material and gen_material.users != 0:
+                    pass
+                else:
+                    baseMat.name = gen_base
+            else:
+                baseMat.name = gen_base
+            env.log(["Final: ", baseMat], vv_only=True)
 
-		return {'FINISHED'}
+        postcount = len(["x" for x in getMaterials(self, context) if x.users > 0])
+        self.report(
+            {"INFO"},
+            "Consolidated {x} materials down to {y}".format(x=precount, y=postcount),
+        )
+
+        return {"FINISHED"}
 
 
 class MCPREP_OT_combine_images(bpy.types.Operator):
-	bl_idname = "mcprep.combine_images"
-	bl_label = "Combine images"
-	bl_description = "Consolidate the same images together e.g. img.001 and img.002"
+    bl_idname = "mcprep.combine_images"
+    bl_label = "Combine images"
+    bl_description = "Consolidate the same images together e.g. img.001 and img.002"
 
-	# arg to auto-force remove old? versus just keep as 0-users
-	selection_only: bpy.props.BoolProperty(
-		name="Selection only",
-		description=(
-			"Build images to consoldiate based on selected objects' materials only"),
-		default=False)
-	skipUsage: bpy.props.BoolProperty(
-		default=False,
-		options={'HIDDEN'})
+    # arg to auto-force remove old? versus just keep as 0-users
+    selection_only: bpy.props.BoolProperty(
+        name="Selection only",
+        description=(
+            "Build images to consoldiate based on selected objects' materials only"
+        ),
+        default=False,
+    )
+    skipUsage: bpy.props.BoolProperty(default=False, options={"HIDDEN"})
 
-	track_function = "combine_images"
-	@tracking.report_error
-	def execute(self, context):
-		removeold = True
+    track_function = "combine_images"
 
-		if self.selection_only is True and len(context.selected_objects) == 0:
-			self.report(
-				{'ERROR'},
-				"Either turn selection only off or select objects with materials/images")
-			return {'CANCELLED'}
+    @tracking.report_error
+    def execute(self, context):
+        removeold = True
 
-		# 2-level structure to hold base name and all
-		# images blocks with the same base
-		if bpy.app.version < (2, 78):
-			self.report(
-				{'ERROR'}, "Must use blender 2.78 or higher to use this operator")
-			return {'CANCELLED'}
+        if self.selection_only is True and len(context.selected_objects) == 0:
+            self.report(
+                {"ERROR"},
+                "Either turn selection only off or select objects with materials/images",
+            )
+            return {"CANCELLED"}
 
-		if self.selection_only is True:
-			self.report({'ERROR'}, (
-				"Combine images does not yet work for selection only, retry "
-				"with option disabled"))
-			return {'CANCELLED'}
+        # 2-level structure to hold base name and all
+        # images blocks with the same base
+        if bpy.app.version < (2, 78):
+            self.report(
+                {"ERROR"}, "Must use blender 2.78 or higher to use this operator"
+            )
+            return {"CANCELLED"}
 
-		name_cat = {}
-		data = bpy.data.images
+        if self.selection_only is True:
+            self.report(
+                {"ERROR"},
+                (
+                    "Combine images does not yet work for selection only, retry "
+                    "with option disabled"
+                ),
+            )
+            return {"CANCELLED"}
 
-		precount = len(data)
+        name_cat = {}
+        data = bpy.data.images
 
-		# get and categorize all image names
-		for im in bpy.data.images:
-			base = util.nameGeneralize(im.name)
-			if base not in name_cat:
-				name_cat[base] = [im.name]
-			elif im.name not in name_cat[base]:
-				name_cat[base].append(im.name)
-			else:
-				env.log("Skipping, already added image", vv_only=True)
+        precount = len(data)
 
-		# pre 2.78 solution, deep loop
-		if bpy.app.version < (2, 78):
-			for ob in bpy.data.objects:
-				for sl in ob.material_slots:
-					if sl is None or sl.material is None or sl.material not in data:
-						continue  # selection only
-					sl.material = data[name_cat[util.nameGeneralize(sl.material.name)][0]]
-			# doesn't remove old textures, but gets it to zero users
+        # get and categorize all image names
+        for im in bpy.data.images:
+            base = util.nameGeneralize(im.name)
+            if base not in name_cat:
+                name_cat[base] = [im.name]
+            elif im.name not in name_cat[base]:
+                name_cat[base].append(im.name)
+            else:
+                env.log("Skipping, already added image", vv_only=True)
 
-			postcount = len(["x" for x in bpy.data.materials if x.users > 0])
-			self.report(
-				{"INFO"},
-				"Consolidated {x} materials, down to {y} overall".format(
-					x=precount - postcount, y=postcount))
-			return {'FINISHED'}
+        # pre 2.78 solution, deep loop
+        if bpy.app.version < (2, 78):
+            for ob in bpy.data.objects:
+                for sl in ob.material_slots:
+                    if sl is None or sl.material is None or sl.material not in data:
+                        continue  # selection only
+                    sl.material = data[
+                        name_cat[util.nameGeneralize(sl.material.name)][0]
+                    ]
+            # doesn't remove old textures, but gets it to zero users
 
-		# perform the consolidation with one basename set at a time
-		for base in name_cat:
-			if len(base) < 2:
-				continue
-			name_cat[base].sort()  # in-place sorting
-			baseImg = bpy.data.images[name_cat[base][0]]
+            postcount = len(["x" for x in bpy.data.materials if x.users > 0])
+            self.report(
+                {"INFO"},
+                "Consolidated {x} materials, down to {y} overall".format(
+                    x=precount - postcount, y=postcount
+                ),
+            )
+            return {"FINISHED"}
 
-			for imgname in name_cat[base][1:]:
-				# skip if fake user set
-				if bpy.data.images[imgname].use_fake_user is True:
-					continue
-				# otherwise, remap
-				util.remap_users(data[imgname], baseImg)
-				old = bpy.data.images[imgname]
-				if removeold is True and old.users == 0:
-					bpy.data.images.remove(bpy.data.images[imgname])
+        # perform the consolidation with one basename set at a time
+        for base in name_cat:
+            if len(base) < 2:
+                continue
+            name_cat[base].sort()  # in-place sorting
+            baseImg = bpy.data.images[name_cat[base][0]]
 
-			# Final step.. rename to not have .001 if it does
-			if baseImg.name != util.nameGeneralize(baseImg.name):
-				gen = util.nameGeneralize(baseImg.name)
-				in_data = gen in data
-				has_users = in_data and bpy.data.images[gen].users != 0
-				if has_users:
-					pass
-				else:
-					baseImg.name = util.nameGeneralize(baseImg.name)
-			else:
-				baseImg.name = util.nameGeneralize(baseImg.name)
+            for imgname in name_cat[base][1:]:
+                # skip if fake user set
+                if bpy.data.images[imgname].use_fake_user is True:
+                    continue
+                # otherwise, remap
+                util.remap_users(data[imgname], baseImg)
+                old = bpy.data.images[imgname]
+                if removeold is True and old.users == 0:
+                    bpy.data.images.remove(bpy.data.images[imgname])
 
-		postcount = len(["x" for x in bpy.data.images if x.users > 0])
-		self.report(
-			{"INFO"}, "Consolidated {x} images down to {y}".format(
-				x=precount,
-				y=postcount))
+            # Final step.. rename to not have .001 if it does
+            if baseImg.name != util.nameGeneralize(baseImg.name):
+                gen = util.nameGeneralize(baseImg.name)
+                in_data = gen in data
+                has_users = in_data and bpy.data.images[gen].users != 0
+                if has_users:
+                    pass
+                else:
+                    baseImg.name = util.nameGeneralize(baseImg.name)
+            else:
+                baseImg.name = util.nameGeneralize(baseImg.name)
 
-		return {'FINISHED'}
+        postcount = len(["x" for x in bpy.data.images if x.users > 0])
+        self.report(
+            {"INFO"},
+            "Consolidated {x} images down to {y}".format(x=precount, y=postcount),
+        )
+
+        return {"FINISHED"}
 
 
 class MCPREP_OT_replace_missing_textures(bpy.types.Operator):
-	"""Replace missing textures with matching images in the active texture pack"""
-	bl_idname = "mcprep.replace_missing_textures"
-	bl_label = "Find missing textures"
-	bl_options = {'REGISTER', 'UNDO'}
+    """Replace missing textures with matching images in the active texture pack"""
 
-	# deleteAlpha = False
-	animateTextures: bpy.props.BoolProperty(
-		name="Animate textures (may be slow first time)",
-		description="Convert tiled images into image sequence for material.",
-		default=True)
-	skipUsage: bpy.props.BoolProperty(
-		default=False,
-		options={'HIDDEN'})
+    bl_idname = "mcprep.replace_missing_textures"
+    bl_label = "Find missing textures"
+    bl_options = {"REGISTER", "UNDO"}
 
-	track_function = "replace_missing"
-	track_param = None
-	track_exporter = None
-	@tracking.report_error
-	def execute(self, context):
+    # deleteAlpha = False
+    animateTextures: bpy.props.BoolProperty(
+        name="Animate textures (may be slow first time)",
+        description="Convert tiled images into image sequence for material.",
+        default=True,
+    )
+    skipUsage: bpy.props.BoolProperty(default=False, options={"HIDDEN"})
 
-		# get list of selected objects
-		obj_list = context.selected_objects
-		if len(obj_list) == 0:
-			self.report({'ERROR'}, "No objects selected")
-			return {'CANCELLED'}
+    track_function = "replace_missing"
+    track_param = None
+    track_exporter = None
 
-		# gets the list of materials (without repetition) from selected
-		mat_list = util.materialsFromObj(obj_list)
-		if len(obj_list) == 0:
-			self.report({'ERROR'}, "No materials found on selected objects")
-			return {'CANCELLED'}
+    @tracking.report_error
+    def execute(self, context):
+        # get list of selected objects
+        obj_list = context.selected_objects
+        if len(obj_list) == 0:
+            self.report({"ERROR"}, "No objects selected")
+            return {"CANCELLED"}
 
-		count = 0
-		for mat in mat_list:
-			updated = False
-			passes = generate.get_textures(mat)
-			if not passes:
-				env.log("No images found within material")
-			for pass_name in passes:
-				if pass_name == 'diffuse' and passes[pass_name] is None:
-					res = self.load_from_texturepack(mat)
-				else:
-					res = generate.replace_missing_texture(passes[pass_name])
-				if res == 1:
-					updated = True
-			if updated:
-				count += 1
-				env.log("Updated " + mat.name)
-				if self.animateTextures:
-					sequences.animate_single_material(
-						mat, context.scene.render.engine)
-		if count == 0:
-			self.report(
-				{'INFO'},
-				"No missing image blocks detected in {} materials".format(
-					len(mat_list)))
+        # gets the list of materials (without repetition) from selected
+        mat_list = util.materialsFromObj(obj_list)
+        if len(obj_list) == 0:
+            self.report({"ERROR"}, "No materials found on selected objects")
+            return {"CANCELLED"}
 
-		self.report({'INFO'}, "Updated {} materials".format(count))
-		self.track_param = context.scene.render.engine
-		addon_prefs = util.get_user_preferences(context)
-		self.track_exporter = addon_prefs.MCprep_exporter_type
-		return {'FINISHED'}
+        count = 0
+        for mat in mat_list:
+            updated = False
+            passes = generate.get_textures(mat)
+            if not passes:
+                env.log("No images found within material")
+            for pass_name in passes:
+                if pass_name == "diffuse" and passes[pass_name] is None:
+                    res = self.load_from_texturepack(mat)
+                else:
+                    res = generate.replace_missing_texture(passes[pass_name])
+                if res == 1:
+                    updated = True
+            if updated:
+                count += 1
+                env.log("Updated " + mat.name)
+                if self.animateTextures:
+                    sequences.animate_single_material(mat, context.scene.render.engine)
+        if count == 0:
+            self.report(
+                {"INFO"},
+                "No missing image blocks detected in {} materials".format(
+                    len(mat_list)
+                ),
+            )
 
-	def load_from_texturepack(self, mat):
-		"""If image datablock not found in passes, try to directly load and assign"""
-		env.log("Loading from texpack for " + mat.name, vv_only=True)
-		canon, _ = generate.get_mc_canonical_name(mat.name)
-		image_path = generate.find_from_texturepack(canon)
-		if not image_path or not os.path.isfile(image_path):
-			env.log("Find missing images: No source file found for " + mat.name)
-			return False
+        self.report({"INFO"}, "Updated {} materials".format(count))
+        self.track_param = context.scene.render.engine
+        addon_prefs = util.get_user_preferences(context)
+        self.track_exporter = addon_prefs.MCprep_exporter_type
+        return {"FINISHED"}
 
-		# even if images of same name already exist, load new block
-		env.log("Find missing images: Creating new image datablock for " + mat.name)
-		# do not use 'check_existing=False' to keep compatibility pre 2.79
-		image = bpy.data.images.load(image_path, check_existing=True)
+    def load_from_texturepack(self, mat):
+        """If image datablock not found in passes, try to directly load and assign"""
+        env.log("Loading from texpack for " + mat.name, vv_only=True)
+        canon, _ = generate.get_mc_canonical_name(mat.name)
+        image_path = generate.find_from_texturepack(canon)
+        if not image_path or not os.path.isfile(image_path):
+            env.log("Find missing images: No source file found for " + mat.name)
+            return False
 
-		engine = bpy.context.scene.render.engine
-		if engine == 'CYCLES' or engine == 'BLENDER_EEVEE':
-			status = generate.set_cycles_texture(image, mat)
-		elif engine == 'BLENDER_RENDER' or engine == 'BLENDER_GAME':
-			status = generate.set_cycles_texture(image, mat)
+        # even if images of same name already exist, load new block
+        env.log("Find missing images: Creating new image datablock for " + mat.name)
+        # do not use 'check_existing=False' to keep compatibility pre 2.79
+        image = bpy.data.images.load(image_path, check_existing=True)
 
-		return status  # True or False
+        engine = bpy.context.scene.render.engine
+        if engine == "CYCLES" or engine == "BLENDER_EEVEE":
+            status = generate.set_cycles_texture(image, mat)
+        elif engine == "BLENDER_RENDER" or engine == "BLENDER_GAME":
+            status = generate.set_cycles_texture(image, mat)
+
+        return status  # True or False
 
 
 # -----------------------------------------------------------------------------
@@ -473,20 +495,20 @@ class MCPREP_OT_replace_missing_textures(bpy.types.Operator):
 
 
 classes = (
-	ListMaterials,
-	MCPREP_OT_reset_texturepack_path,
-	MCPREP_OT_reload_materials,
-	MCPREP_OT_combine_materials,
-	MCPREP_OT_combine_images,
-	MCPREP_OT_replace_missing_textures
+    ListMaterials,
+    MCPREP_OT_reset_texturepack_path,
+    MCPREP_OT_reload_materials,
+    MCPREP_OT_combine_materials,
+    MCPREP_OT_combine_images,
+    MCPREP_OT_replace_missing_textures,
 )
 
 
 def register():
-	for cls in classes:
-		bpy.utils.register_class(cls)
+    for cls in classes:
+        bpy.utils.register_class(cls)
 
 
 def unregister():
-	for cls in reversed(classes):
-		bpy.utils.unregister_class(cls)
+    for cls in reversed(classes):
+        bpy.utils.unregister_class(cls)

--- a/MCprep_addon/materials/prep.py
+++ b/MCprep_addon/materials/prep.py
@@ -691,18 +691,18 @@ class MCPREP_OT_load_material(bpy.types.Operator, McprepMaterialProps):
 
 
 classes = (
-	MCPREP_OT_prep_materials,
-	MCPREP_OT_materials_help,
-	MCPREP_OT_swap_texture_pack,
-	MCPREP_OT_load_material,
+    MCPREP_OT_prep_materials,
+    MCPREP_OT_materials_help,
+    MCPREP_OT_swap_texture_pack,
+    MCPREP_OT_load_material,
 )
 
 
 def register():
-	for cls in classes:
-		bpy.utils.register_class(cls)
+    for cls in classes:
+        bpy.utils.register_class(cls)
 
 
 def unregister():
-	for cls in reversed(classes):
-		bpy.utils.unregister_class(cls)
+    for cls in reversed(classes):
+        bpy.utils.unregister_class(cls)

--- a/MCprep_addon/materials/sequences.py
+++ b/MCprep_addon/materials/sequences.py
@@ -36,364 +36,373 @@ from ..conf import env
 # -----------------------------------------------------------------------------
 
 
-def animate_single_material(
-	mat, engine, export_location='original', clear_cache=False):
-	"""Animates texture for single material, including all passes.
+def animate_single_material(mat, engine, export_location="original", clear_cache=False):
+    """Animates texture for single material, including all passes.
 
-	Args:
-		mat: the existing material
-		engine: target render engine
-		export_location: enum of {original, texturepack, local}
-		clear_cache: whether to pre-remove existing sequence if existing
-	Returns:
-		Bool (if canonically affectable),
-		Bool (if actually updated or not),
-		Str (error text if any handled, e.g. OS permission error)
-	"""
-	mat_gen = util.nameGeneralize(mat.name)
-	canon, form = generate.get_mc_canonical_name(mat_gen)
-	affectable = False
+    Args:
+            mat: the existing material
+            engine: target render engine
+            export_location: enum of {original, texturepack, local}
+            clear_cache: whether to pre-remove existing sequence if existing
+    Returns:
+            Bool (if canonically affectable),
+            Bool (if actually updated or not),
+            Str (error text if any handled, e.g. OS permission error)
+    """
+    mat_gen = util.nameGeneralize(mat.name)
+    canon, form = generate.get_mc_canonical_name(mat_gen)
+    affectable = False
 
-	# get the primary loaded diffuse of the material
-	diffuse_block = generate.get_textures(mat)["diffuse"]
-	currently_tiled = is_image_tiled(diffuse_block)
-	if not currently_tiled and not affectable:
-		affectable = True  # retroactively assign to true, as tiled image found
+    # get the primary loaded diffuse of the material
+    diffuse_block = generate.get_textures(mat)["diffuse"]
+    currently_tiled = is_image_tiled(diffuse_block)
+    if not currently_tiled and not affectable:
+        affectable = True  # retroactively assign to true, as tiled image found
 
-	# get the base image from the texturepack (cycles/BI general)
-	image_path_canon = generate.find_from_texturepack(canon)
-	if not image_path_canon:
-		env.log("Canon path not found for {}:{}, form {}, path: {}".format(
-			mat_gen, canon, form, image_path_canon), vv_only=True)
-		return affectable, False, None
+    # get the base image from the texturepack (cycles/BI general)
+    image_path_canon = generate.find_from_texturepack(canon)
+    if not image_path_canon:
+        env.log(
+            "Canon path not found for {}:{}, form {}, path: {}".format(
+                mat_gen, canon, form, image_path_canon
+            ),
+            vv_only=True,
+        )
+        return affectable, False, None
 
-	if not os.path.isfile(image_path_canon + ".mcmeta"):
-		env.log(".mcmeta not found for " + mat_gen, vv_only=True)
-		affectable = False
-		return affectable, False, None
-	affectable = True
-	mcmeta = {}
-	with open(image_path_canon + ".mcmeta", "r") as mcf:
-		try:
-			mcmeta = json.load(mcf)
-		except json.JSONDecodeError:
-			print("Failed to parse the mcmeta data")
-	env.log("MCmeta for {}: {}".format(diffuse_block, mcmeta))
+    if not os.path.isfile(image_path_canon + ".mcmeta"):
+        env.log(".mcmeta not found for " + mat_gen, vv_only=True)
+        affectable = False
+        return affectable, False, None
+    affectable = True
+    mcmeta = {}
+    with open(image_path_canon + ".mcmeta", "r") as mcf:
+        try:
+            mcmeta = json.load(mcf)
+        except json.JSONDecodeError:
+            print("Failed to parse the mcmeta data")
+    env.log("MCmeta for {}: {}".format(diffuse_block, mcmeta))
 
-	# apply the sequence if any found, will be empty dict if not
-	if diffuse_block and hasattr(diffuse_block, "filepath"):
-		source_path = diffuse_block.filepath
-	else:
-		source_path = None
-	if not source_path:
-		source_path = image_path_canon
-		env.log("Fallback to using image canon path instead of source path")
-	tile_path_dict, err = generate_material_sequence(
-		source_path, image_path_canon, form, export_location, clear_cache)
-	if err:
-		env.log("Error occured during sequence generation:")
-		env.log(err)
-		return affectable, False, err
-	if tile_path_dict == {}:
-		return affectable, False, None
+    # apply the sequence if any found, will be empty dict if not
+    if diffuse_block and hasattr(diffuse_block, "filepath"):
+        source_path = diffuse_block.filepath
+    else:
+        source_path = None
+    if not source_path:
+        source_path = image_path_canon
+        env.log("Fallback to using image canon path instead of source path")
+    tile_path_dict, err = generate_material_sequence(
+        source_path, image_path_canon, form, export_location, clear_cache
+    )
+    if err:
+        env.log("Error occured during sequence generation:")
+        env.log(err)
+        return affectable, False, err
+    if tile_path_dict == {}:
+        return affectable, False, None
 
-	affected_materials = 0
-	for pass_name in tile_path_dict:
-		if not tile_path_dict[pass_name]:  # ie ''
-			env.log("Skipping passname: " + pass_name)
-			continue
-		if engine == 'CYCLES' or engine == 'BLENDER_EEVEE':
-			node = generate.get_node_for_pass(mat, pass_name)
-			if not node:
-				continue
-			set_sequence_to_texnode(node, tile_path_dict[pass_name])
-			affected_materials += 1
+    affected_materials = 0
+    for pass_name in tile_path_dict:
+        if not tile_path_dict[pass_name]:  # ie ''
+            env.log("Skipping passname: " + pass_name)
+            continue
+        if engine == "CYCLES" or engine == "BLENDER_EEVEE":
+            node = generate.get_node_for_pass(mat, pass_name)
+            if not node:
+                continue
+            set_sequence_to_texnode(node, tile_path_dict[pass_name])
+            affected_materials += 1
 
-			# since image sequences make it tricky to read pixel data (shows empty)
-			# assign cache based on the undersatnding if known desaturated or not
-			node.image['grayscale'] = generate.checklist(canon, "desaturated")
-		elif engine == 'BLENDER_RENDER' or engine == 'BLENDER_GAME':
-			texture = generate.get_texlayer_for_pass(mat, pass_name)
-			if not texture:
-				continue
-			set_sequence_to_texnode(texture, tile_path_dict[pass_name])
-			affected_materials += 1
+            # since image sequences make it tricky to read pixel data (shows empty)
+            # assign cache based on the undersatnding if known desaturated or not
+            node.image["grayscale"] = generate.checklist(canon, "desaturated")
+        elif engine == "BLENDER_RENDER" or engine == "BLENDER_GAME":
+            texture = generate.get_texlayer_for_pass(mat, pass_name)
+            if not texture:
+                continue
+            set_sequence_to_texnode(texture, tile_path_dict[pass_name])
+            affected_materials += 1
 
-	generate.set_saturation_material(mat)
-	return affectable, affected_materials > 0, None
+    generate.set_saturation_material(mat)
+    return affectable, affected_materials > 0, None
 
 
 def is_image_tiled(image_block):
-	"""Checks whether an image block tiled."""
-	if not image_block or image_block.size[0] == 0:
-		return False
-	tiles = image_block.size[1] / image_block.size[0]
-	if int(tiles) != tiles or not tiles > 1:
-		return False
-	else:
-		return True
+    """Checks whether an image block tiled."""
+    if not image_block or image_block.size[0] == 0:
+        return False
+    tiles = image_block.size[1] / image_block.size[0]
+    if int(tiles) != tiles or not tiles > 1:
+        return False
+    else:
+        return True
 
 
 def generate_material_sequence(
-	source_path, image_path, form, export_location, clear_cache):
-	"""Performs frame by frame export of sequences to location based on input.
+    source_path, image_path, form, export_location, clear_cache
+):
+    """Performs frame by frame export of sequences to location based on input.
 
-	Returns Dictionary of the image paths to the first tile of each
-	material pass type detected (e.g. diffuse, specular, normal)
+    Returns Dictionary of the image paths to the first tile of each
+    material pass type detected (e.g. diffuse, specular, normal)
 
-	Args:
-		source_path: Source of the previous image's folder (diffuse image)
-		image_path: The path of the tiled image from a resource pack
-		form: jmc2obj, mineways, or none
-		export_location: enum of type of location output
-		clear_cache: whether to delete and re-export frames, even if existing found
-	Returns:
-		tile_path_dict: list of filepaths
-		err: Error if any handled
-	"""
+    Args:
+            source_path: Source of the previous image's folder (diffuse image)
+            image_path: The path of the tiled image from a resource pack
+            form: jmc2obj, mineways, or none
+            export_location: enum of type of location output
+            clear_cache: whether to delete and re-export frames, even if existing found
+    Returns:
+            tile_path_dict: list of filepaths
+            err: Error if any handled
+    """
 
-	# get the currently assigned image passes (normal, spec. etc)
-	image_dict = {}
+    # get the currently assigned image passes (normal, spec. etc)
+    image_dict = {}
 
-	# gets available passes from current texturepack for given name
-	img_pass_dict = generate.find_additional_passes(image_path)
+    # gets available passes from current texturepack for given name
+    img_pass_dict = generate.find_additional_passes(image_path)
 
-	seq_path_base = None  # defaults to folder in resource pack
-	if export_location == "local":
-		if not bpy.data.filepath:
-			raise Exception("Must save file before using local option save location")
-		temp_abs = bpy.path.abspath(bpy.data.filepath)
-		seq_path_base = os.path.join(os.path.dirname(temp_abs), "Textures")
-	elif export_location == "original":
-		# export frames next to current files
-		# use regex to see if source path already is an animated subfolder,
-		# preventing a recursive subfolder regeneration of tiles
-		seq_path_base = os.path.dirname(bpy.path.abspath(source_path))
-		root = os.path.basename(seq_path_base)
+    seq_path_base = None  # defaults to folder in resource pack
+    if export_location == "local":
+        if not bpy.data.filepath:
+            raise Exception("Must save file before using local option save location")
+        temp_abs = bpy.path.abspath(bpy.data.filepath)
+        seq_path_base = os.path.join(os.path.dirname(temp_abs), "Textures")
+    elif export_location == "original":
+        # export frames next to current files
+        # use regex to see if source path already is an animated subfolder,
+        # preventing a recursive subfolder regeneration of tiles
+        seq_path_base = os.path.dirname(bpy.path.abspath(source_path))
+        root = os.path.basename(seq_path_base)
 
-		# match string-ending pattern: .../lava_flow/lava_flow_0001.png
-		resc = re.escape(root)  # Safely escape any meta character names
-		exp = r"(?i)"+resc+r"[\/\\]{1}"+resc+r"[_][0-9]{1,5}[.](png|jpg|jpeg)$"
-		if re.search(exp, source_path):
-			# now it will point to originating subfolder and check caching there
-			seq_path_base = os.path.dirname(seq_path_base)
+        # match string-ending pattern: .../lava_flow/lava_flow_0001.png
+        resc = re.escape(root)  # Safely escape any meta character names
+        exp = r"(?i)" + resc + r"[\/\\]{1}" + resc + r"[_][0-9]{1,5}[.](png|jpg|jpeg)$"
+        if re.search(exp, source_path):
+            # now it will point to originating subfolder and check caching there
+            seq_path_base = os.path.dirname(seq_path_base)
 
-		if not os.path.isdir(seq_path_base):
-			# issue with the current output folder not already existing
-			seq_path_base = None
+        if not os.path.isdir(seq_path_base):
+            # issue with the current output folder not already existing
+            seq_path_base = None
 
-	elif export_location == "texturepack":
-		# export to save frames in currently selected texturepack (could be addon)
-		seq_path_base = os.path.dirname(bpy.path.abspath(image_path))
+    elif export_location == "texturepack":
+        # export to save frames in currently selected texturepack (could be addon)
+        seq_path_base = os.path.dirname(bpy.path.abspath(image_path))
 
-	if env.very_verbose:
-		env.log("Pre-sequence details")
-		env.log(image_path)
-		env.log(image_dict)
-		env.log(img_pass_dict)
-		env.log(seq_path_base)
-		env.log("---")
+    if env.very_verbose:
+        env.log("Pre-sequence details")
+        env.log(image_path)
+        env.log(image_dict)
+        env.log(img_pass_dict)
+        env.log(seq_path_base)
+        env.log("---")
 
-	if form == "jmc2obj":
-		env.log("DEBUG - jmc2obj aniamted texture detected")
-	elif form == "mineways":
-		env.log("DEBUG - mineways aniamted texture detected")
-	else:
-		env.log("DEBUG - other form of animated texture detected")
+    if form == "jmc2obj":
+        env.log("DEBUG - jmc2obj aniamted texture detected")
+    elif form == "mineways":
+        env.log("DEBUG - mineways aniamted texture detected")
+    else:
+        env.log("DEBUG - other form of animated texture detected")
 
-	perm_denied = (
-		"Permission denied, could not make folder - "
-		"try running blender as admin")
+    perm_denied = (
+        "Permission denied, could not make folder - " "try running blender as admin"
+    )
 
-	for img_pass in img_pass_dict:
-		passfile = img_pass_dict[img_pass]
-		env.log("Running on file:")
-		env.log(bpy.path.abspath(passfile))
+    for img_pass in img_pass_dict:
+        passfile = img_pass_dict[img_pass]
+        env.log("Running on file:")
+        env.log(bpy.path.abspath(passfile))
 
-		# Create the sequence subdir (without race condition)
-		pass_name = os.path.splitext(os.path.basename(passfile))[0]
-		if not seq_path_base:
-			seq_path = os.path.join(os.path.dirname(passfile), pass_name)
-		else:
-			seq_path = os.path.join(seq_path_base, pass_name)
-		env.log("Using sequence directory: " + seq_path)
+        # Create the sequence subdir (without race condition)
+        pass_name = os.path.splitext(os.path.basename(passfile))[0]
+        if not seq_path_base:
+            seq_path = os.path.join(os.path.dirname(passfile), pass_name)
+        else:
+            seq_path = os.path.join(seq_path_base, pass_name)
+        env.log("Using sequence directory: " + seq_path)
 
-		try:  # check parent folder exists/create if needed
-			os.mkdir(os.path.dirname(seq_path))
-		except OSError as exc:
-			print(exc)
-			if exc.errno == errno.EACCES:
-				return {}, perm_denied
-			elif exc.errno != errno.EEXIST:  # ok if error is that it exists
-				raise Exception("Failed to make director, missing path: " + seq_path)
-		try:  # check folder exists/create if needed
-			os.mkdir(seq_path)
-		except OSError as exc:
-			if exc.errno == errno.EACCES:
-				return {}, perm_denied
-			elif exc.errno != errno.EEXIST:  # ok if error is that it exists
-				raise Exception("Path does not exist: " + seq_path)
+        try:  # check parent folder exists/create if needed
+            os.mkdir(os.path.dirname(seq_path))
+        except OSError as exc:
+            print(exc)
+            if exc.errno == errno.EACCES:
+                return {}, perm_denied
+            elif exc.errno != errno.EEXIST:  # ok if error is that it exists
+                raise Exception("Failed to make director, missing path: " + seq_path)
+        try:  # check folder exists/create if needed
+            os.mkdir(seq_path)
+        except OSError as exc:
+            if exc.errno == errno.EACCES:
+                return {}, perm_denied
+            elif exc.errno != errno.EEXIST:  # ok if error is that it exists
+                raise Exception("Path does not exist: " + seq_path)
 
-		# overwrite the files found if not cached
-		if not os.path.isdir(seq_path):
-			raise Exception("Path does not exist: " + seq_path)
-		cached = [
-			tile for tile in os.listdir(seq_path)
-			if os.path.isfile(os.path.join(seq_path, tile))
-			and tile.startswith(pass_name)]
-		if cached:
-			env.log("Cached detected")
+        # overwrite the files found if not cached
+        if not os.path.isdir(seq_path):
+            raise Exception("Path does not exist: " + seq_path)
+        cached = [
+            tile
+            for tile in os.listdir(seq_path)
+            if os.path.isfile(os.path.join(seq_path, tile))
+            and tile.startswith(pass_name)
+        ]
+        if cached:
+            env.log("Cached detected")
 
-		if clear_cache and cached:
-			for tile in cached:
-				try:
-					os.remove(os.path.join(seq_path, tile))
-				except OSError as exc:
-					if exc.errno == errno.EACCES:
-						return {}, perm_denied
-					else:
-						raise Exception(exc)
+        if clear_cache and cached:
+            for tile in cached:
+                try:
+                    os.remove(os.path.join(seq_path, tile))
+                except OSError as exc:
+                    if exc.errno == errno.EACCES:
+                        return {}, perm_denied
+                    else:
+                        raise Exception(exc)
 
-		# generate the sequences
-		params = []  # TODO: get from json file
-		if clear_cache or not cached:
-			first_tile = export_image_to_sequence(passfile, params, seq_path, form)
-		else:
-			first_tile = os.path.join(seq_path, sorted(cached)[0])
+        # generate the sequences
+        params = []  # TODO: get from json file
+        if clear_cache or not cached:
+            first_tile = export_image_to_sequence(passfile, params, seq_path, form)
+        else:
+            first_tile = os.path.join(seq_path, sorted(cached)[0])
 
-		# save first tile to dict
-		if first_tile:
-			image_dict[img_pass] = first_tile
-	return image_dict, None
+        # save first tile to dict
+        if first_tile:
+            image_dict[img_pass] = first_tile
+    return image_dict, None
 
 
 def export_image_to_sequence(image_path, params, output_folder=None, form=None):
-	"""Convert image tiles into image sequence files.
+    """Convert image tiles into image sequence files.
 
-	image_path: image filepath source
-	params: Settings from the json file or otherwise on *how* to animate it
-		e.g. ["linear", 2, false] = linear animation, 2 seconds long, and _?
-	form: jmc2obj, Mineways, or None (default)
-	Returns:
-		Full path of first image on success.
-	Does not auto load new images (or keep temporary ones created around)
-	"""
+    image_path: image filepath source
+    params: Settings from the json file or otherwise on *how* to animate it
+            e.g. ["linear", 2, false] = linear animation, 2 seconds long, and _?
+    form: jmc2obj, Mineways, or None (default)
+    Returns:
+            Full path of first image on success.
+    Does not auto load new images (or keep temporary ones created around)
+    """
 
-	# load in the image_path to a temporary datablock, check here if tiled
-	image = bpy.data.images.load(image_path)
-	tiles = image.size[1] / image.size[0]
-	if int(tiles) != tiles:
-		env.log("Not perfectly tiled image - " + image_path)
-		image.user_clear()
-		if image.users == 0:
-			bpy.data.images.remove(image)
-		else:
-			env.log("Couldn't remove image, shouldn't keep: " + image.name)
-		return None  # any non-titled materials will exit here
-	else:
-		tiles = int(tiles)
-	basename, ext = os.path.splitext(os.path.basename(image_path))
+    # load in the image_path to a temporary datablock, check here if tiled
+    image = bpy.data.images.load(image_path)
+    tiles = image.size[1] / image.size[0]
+    if int(tiles) != tiles:
+        env.log("Not perfectly tiled image - " + image_path)
+        image.user_clear()
+        if image.users == 0:
+            bpy.data.images.remove(image)
+        else:
+            env.log("Couldn't remove image, shouldn't keep: " + image.name)
+        return None  # any non-titled materials will exit here
+    else:
+        tiles = int(tiles)
+    basename, ext = os.path.splitext(os.path.basename(image_path))
 
-	# use the source image's filepath, or fallback to blend file's,
-	if not output_folder:
-		output_folder = os.path.dirname(image_path)
-	try:  # check parent folder exists/create if needed
-		os.mkdir(output_folder)
-	except OSError as exc:
-		if exc.errno != errno.EEXIST:
-			raise
+    # use the source image's filepath, or fallback to blend file's,
+    if not output_folder:
+        output_folder = os.path.dirname(image_path)
+    try:  # check parent folder exists/create if needed
+        os.mkdir(output_folder)
+    except OSError as exc:
+        if exc.errno != errno.EEXIST:
+            raise
 
-	# ind = self.get_sequence_int_index(first_img)
-	# base_name = first_img[:-ind]
-	# start_img = int(first_img[-ind:])
+    # ind = self.get_sequence_int_index(first_img)
+    # base_name = first_img[:-ind]
+    # start_img = int(first_img[-ind:])
 
-	pxlen = len(image.pixels)
-	first_img = None
-	for i in range(tiles):
-		env.log("Exporting sequence tile " + str(i))
-		tile_name = basename + "_" + str(i + 1).zfill(4)
-		out_path = os.path.join(output_folder, tile_name + ext)
-		if not first_img:
-			first_img = out_path
+    pxlen = len(image.pixels)
+    first_img = None
+    for i in range(tiles):
+        env.log("Exporting sequence tile " + str(i))
+        tile_name = basename + "_" + str(i + 1).zfill(4)
+        out_path = os.path.join(output_folder, tile_name + ext)
+        if not first_img:
+            first_img = out_path
 
-		revi = tiles - i - 1  # To reverse index, based on MC tile order.
+        revi = tiles - i - 1  # To reverse index, based on MC tile order.
 
-		# new image for copying pixels over to
-		if form != "minways":
-			img_tile = bpy.data.images.new(
-				basename + "-seq-temp",
-				image.size[0], image.size[0], alpha=(image.channels == 4))
-			img_tile.filepath = out_path
+        # new image for copying pixels over to
+        if form != "minways":
+            img_tile = bpy.data.images.new(
+                basename + "-seq-temp",
+                image.size[0],
+                image.size[0],
+                alpha=(image.channels == 4),
+            )
+            img_tile.filepath = out_path
 
-			if len(img_tile.pixels) * tiles != len(image.pixels):
-				raise Exception("Mis-match of tile size and source sequence")
-			start = int(pxlen / tiles * revi)
-			end = int(pxlen / tiles * (revi + 1))
-			img_tile.pixels = image.pixels[start:end]
+            if len(img_tile.pixels) * tiles != len(image.pixels):
+                raise Exception("Mis-match of tile size and source sequence")
+            start = int(pxlen / tiles * revi)
+            end = int(pxlen / tiles * (revi + 1))
+            img_tile.pixels = image.pixels[start:end]
 
-			# Could have OS issues here in form of RuntimeError.
-			img_tile.save()
+            # Could have OS issues here in form of RuntimeError.
+            img_tile.save()
 
-			# verify it now exists
-			if not os.path.isfile(out_path):
-				raise Exception("Did not successfully save tile frame from sequence")
-			img_tile.user_clear()
-			if img_tile.users == 0:
-				bpy.data.images.remove(img_tile)
-			else:
-				env.log("Couldn't remove tile, shouldn't keep: " + img_tile.name)
-		else:
-			img_tile = None
-			raise Exception("No Animate Textures Mineways support yet")
+            # verify it now exists
+            if not os.path.isfile(out_path):
+                raise Exception("Did not successfully save tile frame from sequence")
+            img_tile.user_clear()
+            if img_tile.users == 0:
+                bpy.data.images.remove(img_tile)
+            else:
+                env.log("Couldn't remove tile, shouldn't keep: " + img_tile.name)
+        else:
+            img_tile = None
+            raise Exception("No Animate Textures Mineways support yet")
 
-	env.log("Finished exporting frame sequence: " + basename)
-	image.user_clear()
-	if image.users == 0:
-		bpy.data.images.remove(image)
-	else:
-		env.log("Couldn't remove image block, shouldn't keep: " + image.name)
+    env.log("Finished exporting frame sequence: " + basename)
+    image.user_clear()
+    if image.users == 0:
+        bpy.data.images.remove(image)
+    else:
+        env.log("Couldn't remove image block, shouldn't keep: " + image.name)
 
-	return bpy.path.abspath(first_img)
+    return bpy.path.abspath(first_img)
 
 
 def get_sequence_int_index(base_name):
-	"""Return the index of the image name, number of digits at filename end."""
-	ind = 0
-	nums = '0123456789'
-	for i in range(len(base_name)):
-		if not base_name[-i - 1] in nums:
-			break
-		ind += 1
-	return ind
+    """Return the index of the image name, number of digits at filename end."""
+    ind = 0
+    nums = "0123456789"
+    for i in range(len(base_name)):
+        if not base_name[-i - 1] in nums:
+            break
+        ind += 1
+    return ind
 
 
 def set_sequence_to_texnode(node, image_path):
-	"""Take first image of sequence and apply full sequence to a node.
+    """Take first image of sequence and apply full sequence to a node.
 
-	Note: this also works as-is where "node" is actually a texture block
-	"""
-	env.log("Sequence exporting " + os.path.basename(image_path), vv_only=True)
-	image_path = bpy.path.abspath(image_path)
-	base_dir = os.path.dirname(image_path)
-	first_img = os.path.splitext(os.path.basename(image_path))[0]
-	env.log("IMAGE path to apply: {}, node/tex: {}".format(
-		image_path, node.name))
+    Note: this also works as-is where "node" is actually a texture block
+    """
+    env.log("Sequence exporting " + os.path.basename(image_path), vv_only=True)
+    image_path = bpy.path.abspath(image_path)
+    base_dir = os.path.dirname(image_path)
+    first_img = os.path.splitext(os.path.basename(image_path))[0]
+    env.log("IMAGE path to apply: {}, node/tex: {}".format(image_path, node.name))
 
-	ind = get_sequence_int_index(first_img)
-	base_name = first_img[:-ind]
-	start_img = int(first_img[-ind:])
-	img_sets = [f for f in os.listdir(base_dir) if f.startswith(base_name)]
-	img_count = len(img_sets)
+    ind = get_sequence_int_index(first_img)
+    base_name = first_img[:-ind]
+    start_img = int(first_img[-ind:])
+    img_sets = [f for f in os.listdir(base_dir) if f.startswith(base_name)]
+    img_count = len(img_sets)
 
-	image_data = bpy.data.images.load(image_path)
-	env.log("Loaded in " + str(image_data))
-	image_data.source = 'SEQUENCE'
-	node.image = image_data
-	node.image_user.frame_duration = img_count
-	node.image_user.frame_start = start_img
-	node.image_user.frame_offset = 0
-	node.image_user.use_cyclic = True
-	node.image_user.use_auto_refresh = True
+    image_data = bpy.data.images.load(image_path)
+    env.log("Loaded in " + str(image_data))
+    image_data.source = "SEQUENCE"
+    node.image = image_data
+    node.image_user.frame_duration = img_count
+    node.image_user.frame_start = start_img
+    node.image_user.frame_offset = 0
+    node.image_user.use_cyclic = True
+    node.image_user.use_auto_refresh = True
 
 
 # -----------------------------------------------------------------------------
@@ -402,123 +411,132 @@ def set_sequence_to_texnode(node, image_path):
 
 
 class MCPREP_OT_prep_animated_textures(bpy.types.Operator):
-	"""Replace static textures (where available) with animated sequence from the active texturepack"""
-	bl_idname = "mcprep.animate_textures"
-	bl_label = "Animate textures"
+    """Replace static textures (where available) with animated sequence from the active texturepack"""
 
-	clear_cache: bpy.props.BoolProperty(
-		default=False,
-		name="Clear cache of previous animated sequence exports",
-		description="Always regenerate tile files, even if tiles already exist"
-	)
-	export_location: bpy.props.EnumProperty(
-		name="Save location",
-		items=[
-			("original", "Next to current source image",
-				"Save animation tiles next to source image"),
-			("texturepack", "Inside MCprep texturepack",
-				"Save animation tiles to current MCprep texturepack"),
-			("local", "Next to this blend file",
-				"Save animation tiles next to current saved blend file")],
-		description="Set where to export (or duplicate to) tile sequence images."
-	)
-	skipUsage: bpy.props.BoolProperty(
-		default=False,
-		options={'HIDDEN'}
-	)
+    bl_idname = "mcprep.animate_textures"
+    bl_label = "Animate textures"
 
-	def invoke(self, context, event):
-		return context.window_manager.invoke_props_dialog(
-			self, width=400 * util.ui_scale())
+    clear_cache: bpy.props.BoolProperty(
+        default=False,
+        name="Clear cache of previous animated sequence exports",
+        description="Always regenerate tile files, even if tiles already exist",
+    )
+    export_location: bpy.props.EnumProperty(
+        name="Save location",
+        items=[
+            (
+                "original",
+                "Next to current source image",
+                "Save animation tiles next to source image",
+            ),
+            (
+                "texturepack",
+                "Inside MCprep texturepack",
+                "Save animation tiles to current MCprep texturepack",
+            ),
+            (
+                "local",
+                "Next to this blend file",
+                "Save animation tiles next to current saved blend file",
+            ),
+        ],
+        description="Set where to export (or duplicate to) tile sequence images.",
+    )
+    skipUsage: bpy.props.BoolProperty(default=False, options={"HIDDEN"})
 
-	def draw(self, context):
-		row = self.layout.row()
-		col = row.column()
-		subcol = col.column()
-		subcol.scale_y = 0.7
-		subcol.label(text="Converts still textures into animated ones")
-		subcol.label(text="using the active resource pack's maps,")
-		subcol.label(text="saves each animation tile to an image on disk.")
-		col.prop(self, "export_location")
-		col.prop(self, "clear_cache")
+    def invoke(self, context, event):
+        return context.window_manager.invoke_props_dialog(
+            self, width=400 * util.ui_scale()
+        )
 
-	# mid run utility variables
-	affectable_materials = 0
-	affected_materials = 0
-	break_err = None
+    def draw(self, context):
+        row = self.layout.row()
+        col = row.column()
+        subcol = col.column()
+        subcol.scale_y = 0.7
+        subcol.label(text="Converts still textures into animated ones")
+        subcol.label(text="using the active resource pack's maps,")
+        subcol.label(text="saves each animation tile to an image on disk.")
+        col.prop(self, "export_location")
+        col.prop(self, "clear_cache")
 
-	track_function = "animate_tex"
-	track_param = None
-	track_exporter = None
-	@tracking.report_error
-	def execute(self, context):
-		if not bpy.data.is_saved and self.export_location == "local":
-			self.report(
-				{'ERROR'}, "File must be saved first if saving sequence locally")
-			return {'CANCELLED'}
+    # mid run utility variables
+    affectable_materials = 0
+    affected_materials = 0
+    break_err = None
 
-		objs = context.selected_objects
-		if not len(objs):
-			self.report({'ERROR'}, "No objects selected")
-			return {'CANCELLED'}
+    track_function = "animate_tex"
+    track_param = None
+    track_exporter = None
 
-		mats = util.materialsFromObj(objs)
-		if not len(mats):
-			self.report({'ERROR'}, "No materials found on selected objects")
-			return {'CANCELLED'}
-		res = generate.detect_form(mats)
+    @tracking.report_error
+    def execute(self, context):
+        if not bpy.data.is_saved and self.export_location == "local":
+            self.report(
+                {"ERROR"}, "File must be saved first if saving sequence locally"
+            )
+            return {"CANCELLED"}
 
-		self.affectable_materials = 0
-		self.affected_materials = 0
-		self.break_err = None
-		for mat in mats:
-			self.process_single_material(context, mat)
-			if self.break_err:
-				break
+        objs = context.selected_objects
+        if not len(objs):
+            self.report({"ERROR"}, "No objects selected")
+            return {"CANCELLED"}
 
-		invalid_uv, affected_objs = uv_tools.detect_invalid_uvs_from_objs(objs)
+        mats = util.materialsFromObj(objs)
+        if not len(mats):
+            self.report({"ERROR"}, "No materials found on selected objects")
+            return {"CANCELLED"}
+        res = generate.detect_form(mats)
 
-		if self.break_err:
-			print(self.break_err)
-			self.report(
-				{"ERROR"},
-				"Halted: " + str(self.break_err))
-			return {'CANCELLED'}
-		elif self.affectable_materials == 0:
-			self.report(
-				{"ERROR"},
-				"No animate-able textures found on selected objects")
-			return {'CANCELLED'}
-		elif self.affected_materials == 0:
-			self.report(
-				{"ERROR"},
-				"Animated materials found, but none applied.")
-			return {'CANCELLED'}
-		elif invalid_uv:
-			self.report(
-				{'ERROR'},
-				("Detected scaled UV's (all in one texture), be sure to use "
-					"Mineway's 'Export Individual Textures To..' feature"))
-			env.log("Detected scaled UV's, incompatible with animate textures")
-			return {'FINISHED'}
-		else:
-			self.report({'INFO'}, "Modified {} material(s)".format(
-				self.affected_materials))
-			self.track_param = context.scene.render.engine
-			return {'FINISHED'}
+        self.affectable_materials = 0
+        self.affected_materials = 0
+        self.break_err = None
+        for mat in mats:
+            self.process_single_material(context, mat)
+            if self.break_err:
+                break
 
-	def process_single_material(self, context, mat):
-		"""Run animate textures for single material, and fix UVs and saturation"""
-		affectable, affected, err = animate_single_material(
-			mat, context.scene.render.engine,
-			self.export_location, self.clear_cache)
-		if err:
-			self.break_err = err
-			return
-		if affectable:
-			self.affectable_materials += 1
-		if affected:
-			self.affected_materials += 1
+        invalid_uv, affected_objs = uv_tools.detect_invalid_uvs_from_objs(objs)
+
+        if self.break_err:
+            print(self.break_err)
+            self.report({"ERROR"}, "Halted: " + str(self.break_err))
+            return {"CANCELLED"}
+        elif self.affectable_materials == 0:
+            self.report({"ERROR"}, "No animate-able textures found on selected objects")
+            return {"CANCELLED"}
+        elif self.affected_materials == 0:
+            self.report({"ERROR"}, "Animated materials found, but none applied.")
+            return {"CANCELLED"}
+        elif invalid_uv:
+            self.report(
+                {"ERROR"},
+                (
+                    "Detected scaled UV's (all in one texture), be sure to use "
+                    "Mineway's 'Export Individual Textures To..' feature"
+                ),
+            )
+            env.log("Detected scaled UV's, incompatible with animate textures")
+            return {"FINISHED"}
+        else:
+            self.report(
+                {"INFO"}, "Modified {} material(s)".format(self.affected_materials)
+            )
+            self.track_param = context.scene.render.engine
+            return {"FINISHED"}
+
+    def process_single_material(self, context, mat):
+        """Run animate textures for single material, and fix UVs and saturation"""
+        affectable, affected, err = animate_single_material(
+            mat, context.scene.render.engine, self.export_location, self.clear_cache
+        )
+        if err:
+            self.break_err = err
+            return
+        if affectable:
+            self.affectable_materials += 1
+        if affected:
+            self.affected_materials += 1
 
 
 # -----------------------------------------------------------------------------
@@ -526,16 +544,14 @@ class MCPREP_OT_prep_animated_textures(bpy.types.Operator):
 # -----------------------------------------------------------------------------
 
 
-classes = (
-	MCPREP_OT_prep_animated_textures,
-)
+classes = (MCPREP_OT_prep_animated_textures,)
 
 
 def register():
-	for cls in classes:
-		bpy.utils.register_class(cls)
+    for cls in classes:
+        bpy.utils.register_class(cls)
 
 
 def unregister():
-	for cls in reversed(classes):
-		bpy.utils.unregister_class(cls)
+    for cls in reversed(classes):
+        bpy.utils.unregister_class(cls)

--- a/MCprep_addon/materials/skin.py
+++ b/MCprep_addon/materials/skin.py
@@ -36,301 +36,301 @@ from ..conf import env
 
 
 def reloadSkinList(context):
-	"""Reload the skins in the directory for UI list"""
+    """Reload the skins in the directory for UI list"""
 
-	skinfolder = context.scene.mcprep_skin_path
-	skinfolder = bpy.path.abspath(skinfolder)
-	if os.path.isdir(skinfolder):
-		files = [
-			f for f in os.listdir(skinfolder)
-			if os.path.isfile(os.path.join(skinfolder, f))]
-	else:
-		files = []
+    skinfolder = context.scene.mcprep_skin_path
+    skinfolder = bpy.path.abspath(skinfolder)
+    if os.path.isdir(skinfolder):
+        files = [
+            f
+            for f in os.listdir(skinfolder)
+            if os.path.isfile(os.path.join(skinfolder, f))
+        ]
+    else:
+        files = []
 
-	skinlist = []
-	for path in files:
-		if path.split(".")[-1].lower() not in ["png", "jpg", "jpeg", "tiff"]:
-			continue
-		skinlist.append((path, "{x} skin".format(x=path)))
+    skinlist = []
+    for path in files:
+        if path.split(".")[-1].lower() not in ["png", "jpg", "jpeg", "tiff"]:
+            continue
+        skinlist.append((path, "{x} skin".format(x=path)))
 
-	skinlist = sorted(skinlist, key=lambda x: x[0].lower())
+    skinlist = sorted(skinlist, key=lambda x: x[0].lower())
 
-	# clear lists
-	context.scene.mcprep_skins_list.clear()
-	env.skin_list = []
+    # clear lists
+    context.scene.mcprep_skins_list.clear()
+    env.skin_list = []
 
-	# recreate
-	for i, (skin, description) in enumerate(skinlist, 1):
-		item = context.scene.mcprep_skins_list.add()
-		env.skin_list.append(
-			(skin, os.path.join(skinfolder, skin))
-		)
-		item.label = description
-		item.description = description
-		item.name = skin
+    # recreate
+    for i, (skin, description) in enumerate(skinlist, 1):
+        item = context.scene.mcprep_skins_list.add()
+        env.skin_list.append((skin, os.path.join(skinfolder, skin)))
+        item.label = description
+        item.description = description
+        item.name = skin
 
 
 def update_skin_path(self, context):
-	"""For UI list path callback"""
-	env.log("Updating rig path", vv_only=True)
-	reloadSkinList(context)
+    """For UI list path callback"""
+    env.log("Updating rig path", vv_only=True)
+    reloadSkinList(context)
 
 
 def handler_skins_enablehack(scene):
-	"""Scene update to auto load skins on load after new file."""
-	try:
-		bpy.app.handlers.scene_update_pre.remove(handler_skins_enablehack)
-	except:
-		pass
-	env.log("Triggering Handler_skins_load from first enable", vv_only=True)
-	handler_skins_load(scene)
+    """Scene update to auto load skins on load after new file."""
+    try:
+        bpy.app.handlers.scene_update_pre.remove(handler_skins_enablehack)
+    except:
+        pass
+    env.log("Triggering Handler_skins_load from first enable", vv_only=True)
+    handler_skins_load(scene)
 
 
 @persistent
 def handler_skins_load(scene):
-	try:
-		env.log("Reloading skins", vv_only=True)
-		reloadSkinList(bpy.context)
-	except:
-		env.log("Didn't run skin reloading callback", vv_only=True)
+    try:
+        env.log("Reloading skins", vv_only=True)
+        reloadSkinList(bpy.context)
+    except:
+        env.log("Didn't run skin reloading callback", vv_only=True)
 
 
 def loadSkinFile(self, context, filepath, new_material=False):
-	if not os.path.isfile(filepath):
-		self.report({'ERROR'}, "Image file not found")
-		return 1
-		# special message for library linking?
+    if not os.path.isfile(filepath):
+        self.report({"ERROR"}, "Image file not found")
+        return 1
+        # special message for library linking?
 
-	# always create a new image block, even if the name already existed
-	image = util.loadTexture(filepath)
+    # always create a new image block, even if the name already existed
+    image = util.loadTexture(filepath)
 
-	if image.channels == 0:
-		self.report({'ERROR'}, "Failed to properly load image")
-		return 1
+    if image.channels == 0:
+        self.report({"ERROR"}, "Failed to properly load image")
+        return 1
 
-	mats, skipped = getMatsFromSelected(context.selected_objects, new_material)
-	if not mats:
-		self.report({'ERROR'}, "No materials found to update")
-		# special message for library linking?
-		return 1
-	if skipped > 0:
-		self.report(
-			{'WARNING'}, "Skinswap skipped {} linked objects".format(skipped))
+    mats, skipped = getMatsFromSelected(context.selected_objects, new_material)
+    if not mats:
+        self.report({"ERROR"}, "No materials found to update")
+        # special message for library linking?
+        return 1
+    if skipped > 0:
+        self.report({"WARNING"}, "Skinswap skipped {} linked objects".format(skipped))
 
-	status = generate.assert_textures_on_materials(image, mats)
-	if status is False:
-		self.report({'ERROR'}, "No image textures found to update")
-		return 1
-	else:
-		pass
+    status = generate.assert_textures_on_materials(image, mats)
+    if status is False:
+        self.report({"ERROR"}, "No image textures found to update")
+        return 1
+    else:
+        pass
 
-	if not util.bv28():
-		setUVimage(context.selected_objects, image)
+    if not util.bv28():
+        setUVimage(context.selected_objects, image)
 
-	# TODO: adjust the UVs if appropriate, and fix eyes
-	if image.size[0] != 0 and image.size[1] / image.size[0] != 1:
-		self.report({'INFO'}, "Skin swapper works best on 1.8 skins")
-		return 0
-	return 0
+    # TODO: adjust the UVs if appropriate, and fix eyes
+    if image.size[0] != 0 and image.size[1] / image.size[0] != 1:
+        self.report({"INFO"}, "Skin swapper works best on 1.8 skins")
+        return 0
+    return 0
 
 
 def convert_skin_layout(image_file):
-	"""Convert skin to 1.8+ layout if old format detected
+    """Convert skin to 1.8+ layout if old format detected
 
-	Could be improved using numpy, but avoiding the dependency.
-	"""
+    Could be improved using numpy, but avoiding the dependency.
+    """
 
-	if not os.path.isfile(image_file):
-		env.log("Error! Image file does not exist: " + image_file)
-		return False
+    if not os.path.isfile(image_file):
+        env.log("Error! Image file does not exist: " + image_file)
+        return False
 
-	img = bpy.data.images.load(image_file)
-	if img.size[0] == img.size[1]:
-		return False
-	elif img.size[0] != img.size[1] * 2:
-		# some image that isn't the normal 64x32 of old skin formats
-		env.log("Unknown skin image format, not converting layout")
-		return False
-	elif img.size[0] / 64 != int(img.size[0] / 64):
-		env.log("Non-regular scaling of skin image, can't process")
-		return False
+    img = bpy.data.images.load(image_file)
+    if img.size[0] == img.size[1]:
+        return False
+    elif img.size[0] != img.size[1] * 2:
+        # some image that isn't the normal 64x32 of old skin formats
+        env.log("Unknown skin image format, not converting layout")
+        return False
+    elif img.size[0] / 64 != int(img.size[0] / 64):
+        env.log("Non-regular scaling of skin image, can't process")
+        return False
 
-	env.log("Old image format detected, converting to post 1.8 layout")
+    env.log("Old image format detected, converting to post 1.8 layout")
 
-	scale = int(img.size[0] / 64)
-	has_alpha = img.channels == 4
-	new_image = bpy.data.images.new(
-		name=os.path.basename(image_file),
-		width=img.size[0],
-		height=img.size[1] * 2,
-		alpha=has_alpha)
+    scale = int(img.size[0] / 64)
+    has_alpha = img.channels == 4
+    new_image = bpy.data.images.new(
+        name=os.path.basename(image_file),
+        width=img.size[0],
+        height=img.size[1] * 2,
+        alpha=has_alpha,
+    )
 
-	# copy pixels of old format into top half of new format, and save to file
-	# and copy the right arm and leg pixels to the lower half
-	upper_half = list(img.pixels)
-	lower_half_quarter = [0] * int(len(new_image.pixels) / 4)
-	lower_half = []
-	failout = False
+    # copy pixels of old format into top half of new format, and save to file
+    # and copy the right arm and leg pixels to the lower half
+    upper_half = list(img.pixels)
+    lower_half_quarter = [0] * int(len(new_image.pixels) / 4)
+    lower_half = []
+    failout = False
 
-	# Copy over the arm and leg to lower half, accounting for image scale
-	# Take it in strips of 16 units at a time per row
-	block_width = int(img.size[0] * img.channels / 4)  # quarter of image width
-	for i in range(int(len(lower_half_quarter) / block_width)):
-		# pixel row rounds down, row 0 = bottom row
-		row = int(i * block_width / (64 * scale * img.channels))
-		# virtual column, not pixel column
-		col = (i * block_width) % (64 * scale * img.channels)
-		# 0-3 index, L->R order: blank, leg, arm, blank
-		block = int(col / 64)
-		if block == 0 or block == 3:
-			lower_half += [0] * block_width
-		elif block == 1:
-			# Here we are copying the leg from block 1/4 (src) into block 2/4
-			start = row * block_width * 4
-			end = row * block_width * 4 + block_width
-			lower_half += upper_half[int(start):int(end)]
-		elif block == 2:
-			# Here we are copying the arm from block 2.5 (src) into block 3/4
-			start = row * block_width * 4 + block_width * 2.5
-			end = (row * block_width * 4) + block_width + (block_width * 2.5)
-			lower_half += upper_half[int(start):int(end)]
-		else:
-			env.log("Bad math! Should never go above 4 blocks")
-			failout = True
-			break
+    # Copy over the arm and leg to lower half, accounting for image scale
+    # Take it in strips of 16 units at a time per row
+    block_width = int(img.size[0] * img.channels / 4)  # quarter of image width
+    for i in range(int(len(lower_half_quarter) / block_width)):
+        # pixel row rounds down, row 0 = bottom row
+        row = int(i * block_width / (64 * scale * img.channels))
+        # virtual column, not pixel column
+        col = (i * block_width) % (64 * scale * img.channels)
+        # 0-3 index, L->R order: blank, leg, arm, blank
+        block = int(col / 64)
+        if block == 0 or block == 3:
+            lower_half += [0] * block_width
+        elif block == 1:
+            # Here we are copying the leg from block 1/4 (src) into block 2/4
+            start = row * block_width * 4
+            end = row * block_width * 4 + block_width
+            lower_half += upper_half[int(start) : int(end)]
+        elif block == 2:
+            # Here we are copying the arm from block 2.5 (src) into block 3/4
+            start = row * block_width * 4 + block_width * 2.5
+            end = (row * block_width * 4) + block_width + (block_width * 2.5)
+            lower_half += upper_half[int(start) : int(end)]
+        else:
+            env.log("Bad math! Should never go above 4 blocks")
+            failout = True
+            break
 
-	# Do final combinations of quarters and halves
-	if not failout:
-		lower_half += lower_half_quarter
-		new_pixels = lower_half + upper_half
-		new_image.pixels = new_pixels
-		new_image.filepath_raw = image_file
-		new_image.save()
-		env.log("Saved out post 1.8 converted skin file")
+    # Do final combinations of quarters and halves
+    if not failout:
+        lower_half += lower_half_quarter
+        new_pixels = lower_half + upper_half
+        new_image.pixels = new_pixels
+        new_image.filepath_raw = image_file
+        new_image.save()
+        env.log("Saved out post 1.8 converted skin file")
 
-	# cleanup files
-	img.user_clear()
-	new_image.user_clear()
-	bpy.data.images.remove(img)
-	bpy.data.images.remove(new_image)
+    # cleanup files
+    img.user_clear()
+    new_image.user_clear()
+    bpy.data.images.remove(img)
+    bpy.data.images.remove(new_image)
 
-	if not failout:
-		return True
-	else:
-		return False
+    if not failout:
+        return True
+    else:
+        return False
 
 
 def getMatsFromSelected(selected, new_material=False):
-	"""Get materials; if new material provided, ensure material slot is added
+    """Get materials; if new material provided, ensure material slot is added
 
-	Used by skin swapping, to either update existing material or create new one
-	"""
-	obj_list = []
-	for ob in selected:
-		if ob.type == 'MESH':
-			obj_list.append(ob)
-		elif ob.type == 'ARMATURE':
-			for ch in ob.children:
-				if ch.type == 'MESH':
-					obj_list.append(ch)
-		else:
-			continue
+    Used by skin swapping, to either update existing material or create new one
+    """
+    obj_list = []
+    for ob in selected:
+        if ob.type == "MESH":
+            obj_list.append(ob)
+        elif ob.type == "ARMATURE":
+            for ch in ob.children:
+                if ch.type == "MESH":
+                    obj_list.append(ch)
+        else:
+            continue
 
-	obj_list = list(set(obj_list))
-	mat_list = []
-	mat_ret = []
-	linked_objs = 0
+    obj_list = list(set(obj_list))
+    mat_list = []
+    mat_ret = []
+    linked_objs = 0
 
-	for ob in obj_list:
-		if ob.data.library:
-			env.log("Library object, skipping")
-			linked_objs += 1
-			continue
-		elif new_material is False:
-			for slot in ob.material_slots:
-				if slot.material is None:
-					continue
-				if slot.material not in mat_ret:
-					mat_ret.append(slot.material)
-		else:
-			for slot in ob.material_slots:
-				if slot.material not in mat_list:
-					if slot.material is None:
-						continue
-					mat_list.append(slot.material)
-					new_mat = slot.material.copy()
-					mat_ret.append(new_mat)
-					slot.material = new_mat
-				else:
-					# if already created, re-assign with new material
-					slot.material = mat_ret[mat_list.index(slot.material)]
+    for ob in obj_list:
+        if ob.data.library:
+            env.log("Library object, skipping")
+            linked_objs += 1
+            continue
+        elif new_material is False:
+            for slot in ob.material_slots:
+                if slot.material is None:
+                    continue
+                if slot.material not in mat_ret:
+                    mat_ret.append(slot.material)
+        else:
+            for slot in ob.material_slots:
+                if slot.material not in mat_list:
+                    if slot.material is None:
+                        continue
+                    mat_list.append(slot.material)
+                    new_mat = slot.material.copy()
+                    mat_ret.append(new_mat)
+                    slot.material = new_mat
+                else:
+                    # if already created, re-assign with new material
+                    slot.material = mat_ret[mat_list.index(slot.material)]
 
-	# if internal, also ensure textures are made unique per new mat
-	engine = bpy.context.scene.render.engine
-	if new_material and (engine == 'BLENDER_RENDER' or engine == 'BLENDER_GAME'):
-		for m in mat_ret:
-			for tx in m.texture_slots:
-				if tx is None or tx.texture is None:
-					continue
-				tx.texture = tx.texture.copy()
+    # if internal, also ensure textures are made unique per new mat
+    engine = bpy.context.scene.render.engine
+    if new_material and (engine == "BLENDER_RENDER" or engine == "BLENDER_GAME"):
+        for m in mat_ret:
+            for tx in m.texture_slots:
+                if tx is None or tx.texture is None:
+                    continue
+                tx.texture = tx.texture.copy()
 
-	return mat_ret, linked_objs
+    return mat_ret, linked_objs
 
 
 def setUVimage(objs, image):
-	"""Set image for each face for viewport displaying (2.7 only)"""
-	for obj in objs:
-		if obj.type != "MESH":
-			continue
-		if not hasattr(obj.data, "uv_textures"):
-			env.log("Called setUVimage on object with no uv_textures, 2.8?")
-			return
-		if obj.data.uv_textures.active is None:
-			continue
-		for uv_face in obj.data.uv_textures.active.data:
-			uv_face.image = image
+    """Set image for each face for viewport displaying (2.7 only)"""
+    for obj in objs:
+        if obj.type != "MESH":
+            continue
+        if not hasattr(obj.data, "uv_textures"):
+            env.log("Called setUVimage on object with no uv_textures, 2.8?")
+            return
+        if obj.data.uv_textures.active is None:
+            continue
+        for uv_face in obj.data.uv_textures.active.data:
+            uv_face.image = image
 
 
 def download_user(self, context, username):
-	"""Download user skin from online.
+    """Download user skin from online.
 
-	Reusable function from within two common operators for downloading skin.
-	Example link: http://minotar.net/skin/theduckcow
-	"""
-	env.log("Downloading skin: " + username)
+    Reusable function from within two common operators for downloading skin.
+    Example link: http://minotar.net/skin/theduckcow
+    """
+    env.log("Downloading skin: " + username)
 
-	src_link = "http://minotar.net/skin/"
-	saveloc = os.path.join(
-		bpy.path.abspath(context.scene.mcprep_skin_path),
-		username.lower() + ".png")
+    src_link = "http://minotar.net/skin/"
+    saveloc = os.path.join(
+        bpy.path.abspath(context.scene.mcprep_skin_path), username.lower() + ".png"
+    )
 
-	try:
-		if env.very_verbose:
-			print("Download starting with url: " + src_link + username.lower())
-			print("to save location: " + saveloc)
-		urllib.request.urlretrieve(src_link + username.lower(), saveloc)
-	except urllib.error.HTTPError as e:
-		print(e)
-		self.report({"ERROR"}, "Could not find username")
-		return None
-	except urllib.error.URLError as e:
-		print(e)
-		self.report({"ERROR"}, "URL error, check internet connection")
-		return None
-	except Exception as e:
-		print("Error occured while downloading skin: " + str(e))
-		self.report({"ERROR"}, "Error occured while downloading skin: " + str(e))
-		return None
+    try:
+        if env.very_verbose:
+            print("Download starting with url: " + src_link + username.lower())
+            print("to save location: " + saveloc)
+        urllib.request.urlretrieve(src_link + username.lower(), saveloc)
+    except urllib.error.HTTPError as e:
+        print(e)
+        self.report({"ERROR"}, "Could not find username")
+        return None
+    except urllib.error.URLError as e:
+        print(e)
+        self.report({"ERROR"}, "URL error, check internet connection")
+        return None
+    except Exception as e:
+        print("Error occured while downloading skin: " + str(e))
+        self.report({"ERROR"}, "Error occured while downloading skin: " + str(e))
+        return None
 
-	# convert to 1.8 skin as needed (double height)
-	converted = False
-	if self.convert_layout:
-		converted = convert_skin_layout(saveloc)
-	if converted:
-		self.track_param = "username + 1.8 convert"
-	else:
-		self.track_param = "username"
-	return saveloc
+    # convert to 1.8 skin as needed (double height)
+    converted = False
+    if self.convert_layout:
+        converted = convert_skin_layout(saveloc)
+    if converted:
+        self.track_param = "username + 1.8 convert"
+    else:
+        self.track_param = "username"
+    return saveloc
 
 
 # -----------------------------------------------------------------------------
@@ -339,424 +339,456 @@ def download_user(self, context, username):
 
 
 class MCPREP_UL_skins(bpy.types.UIList):
-	"""For asset listing UIList drawing"""
-	bl_idname = "MCPREP_UL_skins"
-	def draw_item(
-		self, context, layout, data, set, icon, active_data, active_propname, index):
-		layout.prop(set, "name", text="", emboss=False)
-		# extra code for placing warning if skin is
-		# not square, ie old texture and reocmmend converting it
-		# would need to load all images first though.
+    """For asset listing UIList drawing"""
+
+    bl_idname = "MCPREP_UL_skins"
+
+    def draw_item(
+        self, context, layout, data, set, icon, active_data, active_propname, index
+    ):
+        layout.prop(set, "name", text="", emboss=False)
+        # extra code for placing warning if skin is
+        # not square, ie old texture and reocmmend converting it
+        # would need to load all images first though.
 
 
 class ListColl(bpy.types.PropertyGroup):
-	"""For asset listing"""
-	label: bpy.props.StringProperty()
-	description: bpy.props.StringProperty()
+    """For asset listing"""
+
+    label: bpy.props.StringProperty()
+    description: bpy.props.StringProperty()
 
 
 class MCPREP_OT_swap_skin_from_file(bpy.types.Operator, ImportHelper):
-	"""Swap the skin of a rig (character, mob, etc) with another file"""
-	bl_idname = "mcprep.skin_swapper"
-	bl_label = "Swap skin"
-	bl_options = {'REGISTER', 'UNDO'}
+    """Swap the skin of a rig (character, mob, etc) with another file"""
 
-	filter_glob: bpy.props.StringProperty(
-		default="",
-		options={'HIDDEN'})
-	fileselectparams = "use_filter_blender"
-	files: bpy.props.CollectionProperty(
-		type=bpy.types.PropertyGroup,
-		options={'HIDDEN', 'SKIP_SAVE'})
-	filter_image: bpy.props.BoolProperty(
-		default=True,
-		options={'HIDDEN', 'SKIP_SAVE'})
-	new_material: bpy.props.BoolProperty(
-		name="New Material",
-		description="Create a new material instead of overwriting existing one",
-		default=True)
-	skipUsage: bpy.props.BoolProperty(default=False, options={'HIDDEN'})
+    bl_idname = "mcprep.skin_swapper"
+    bl_label = "Swap skin"
+    bl_options = {"REGISTER", "UNDO"}
 
-	track_function = "skin"
-	track_param = "file import"
-	@tracking.report_error
-	def execute(self, context):
-		res = loadSkinFile(self, context, self.filepath, self.new_material)
-		if res != 0:
-			return {'CANCELLED'}
+    filter_glob: bpy.props.StringProperty(default="", options={"HIDDEN"})
+    fileselectparams = "use_filter_blender"
+    files: bpy.props.CollectionProperty(
+        type=bpy.types.PropertyGroup, options={"HIDDEN", "SKIP_SAVE"}
+    )
+    filter_image: bpy.props.BoolProperty(default=True, options={"HIDDEN", "SKIP_SAVE"})
+    new_material: bpy.props.BoolProperty(
+        name="New Material",
+        description="Create a new material instead of overwriting existing one",
+        default=True,
+    )
+    skipUsage: bpy.props.BoolProperty(default=False, options={"HIDDEN"})
 
-		return {'FINISHED'}
+    track_function = "skin"
+    track_param = "file import"
+
+    @tracking.report_error
+    def execute(self, context):
+        res = loadSkinFile(self, context, self.filepath, self.new_material)
+        if res != 0:
+            return {"CANCELLED"}
+
+        return {"FINISHED"}
 
 
 class MCPREP_OT_apply_skin(bpy.types.Operator):
-	"""Apply the active UIlist skin to select characters"""
-	bl_idname = "mcprep.applyskin"
-	bl_label = "Apply skin"
-	bl_description = "Apply the active UV image to selected character materials"
-	bl_options = {'REGISTER', 'UNDO'}
+    """Apply the active UIlist skin to select characters"""
 
-	filepath: bpy.props.StringProperty(
-		name="Skin",
-		description="selected",
-		options={'HIDDEN'})
-	new_material: bpy.props.BoolProperty(
-		name="New Material",
-		description="Create a new material instead of overwriting existing one",
-		default=True)
-	skipUsage: bpy.props.BoolProperty(
-		default=False,
-		options={'HIDDEN'})
+    bl_idname = "mcprep.applyskin"
+    bl_label = "Apply skin"
+    bl_description = "Apply the active UV image to selected character materials"
+    bl_options = {"REGISTER", "UNDO"}
 
-	track_function = "skin"
-	track_param = "ui list"
-	@tracking.report_error
-	def execute(self, context):
-		res = loadSkinFile(self, context, self.filepath, self.new_material)
-		if res != 0:
-			return {'CANCELLED'}
+    filepath: bpy.props.StringProperty(
+        name="Skin", description="selected", options={"HIDDEN"}
+    )
+    new_material: bpy.props.BoolProperty(
+        name="New Material",
+        description="Create a new material instead of overwriting existing one",
+        default=True,
+    )
+    skipUsage: bpy.props.BoolProperty(default=False, options={"HIDDEN"})
 
-		return {'FINISHED'}
+    track_function = "skin"
+    track_param = "ui list"
+
+    @tracking.report_error
+    def execute(self, context):
+        res = loadSkinFile(self, context, self.filepath, self.new_material)
+        if res != 0:
+            return {"CANCELLED"}
+
+        return {"FINISHED"}
 
 
 class MCPREP_OT_apply_username_skin(bpy.types.Operator):
-	"""Apply the active UIlist skin to select characters"""
-	bl_idname = "mcprep.applyusernameskin"
-	bl_label = "Skin from user"
-	bl_description = "Download and apply skin from specific username"
-	bl_options = {'REGISTER', 'UNDO'}
+    """Apply the active UIlist skin to select characters"""
 
-	username: bpy.props.StringProperty(
-		name="Username",
-		description="Exact name of user to get texture from",
-		default="")
-	skip_redownload: bpy.props.BoolProperty(
-		name="Skip download if skin already local",
-		description="Avoid re-downloading skin and apply local file instead",
-		default=True)
-	new_material: bpy.props.BoolProperty(
-		name="New Material",
-		description="Create a new material instead of overwriting existing one",
-		default=True)
-	convert_layout: bpy.props.BoolProperty(
-		name="Convert pre 1.8 skins",
-		description=(
-			"If an older skin layout (pre Minecraft 1.8) is detected, convert "
-			"to new format (with clothing layers)"),
-		default=True)
-	skipUsage: bpy.props.BoolProperty(default=False, options={'HIDDEN'})
+    bl_idname = "mcprep.applyusernameskin"
+    bl_label = "Skin from user"
+    bl_description = "Download and apply skin from specific username"
+    bl_options = {"REGISTER", "UNDO"}
 
-	def invoke(self, context, event):
-		return context.window_manager.invoke_props_dialog(
-			self, width=400 * util.ui_scale())
+    username: bpy.props.StringProperty(
+        name="Username",
+        description="Exact name of user to get texture from",
+        default="",
+    )
+    skip_redownload: bpy.props.BoolProperty(
+        name="Skip download if skin already local",
+        description="Avoid re-downloading skin and apply local file instead",
+        default=True,
+    )
+    new_material: bpy.props.BoolProperty(
+        name="New Material",
+        description="Create a new material instead of overwriting existing one",
+        default=True,
+    )
+    convert_layout: bpy.props.BoolProperty(
+        name="Convert pre 1.8 skins",
+        description=(
+            "If an older skin layout (pre Minecraft 1.8) is detected, convert "
+            "to new format (with clothing layers)"
+        ),
+        default=True,
+    )
+    skipUsage: bpy.props.BoolProperty(default=False, options={"HIDDEN"})
 
-	def draw(self, context):
-		self.layout.label(text="Enter exact Minecraft username below")
-		self.layout.prop(self, "username", text="")
-		self.layout.prop(self, "skip_redownload")
-		self.layout.label(
-			text="and then press OK; blender may pause briefly to download")
+    def invoke(self, context, event):
+        return context.window_manager.invoke_props_dialog(
+            self, width=400 * util.ui_scale()
+        )
 
-	track_function = "skin"
-	track_param = "username"
-	@tracking.report_error
-	def execute(self, context):
-		if self.username == "":
-			self.report({"ERROR"}, "Invalid username")
-			return {'CANCELLED'}
+    def draw(self, context):
+        self.layout.label(text="Enter exact Minecraft username below")
+        self.layout.prop(self, "username", text="")
+        self.layout.prop(self, "skip_redownload")
+        self.layout.label(
+            text="and then press OK; blender may pause briefly to download"
+        )
 
-		skins = [str(skin[0]).lower() for skin in env.skin_list]
-		paths = [skin[1] for skin in env.skin_list]
-		if self.username.lower() not in skins or not self.skip_redownload:
-			# Do the download
-			saveloc = download_user(self, context, self.username)
-			if not saveloc:
-				return {'CANCELLED'}
+    track_function = "skin"
+    track_param = "username"
 
-			# Now load the skin
-			res = loadSkinFile(self, context, saveloc, self.new_material)
-			if res != 0:
-				return {'CANCELLED'}
-			bpy.ops.mcprep.reload_skins()
-			return {'FINISHED'}
-		else:
-			env.log("Reusing downloaded skin")
-			ind = skins.index(self.username.lower())
-			res = loadSkinFile(self, context, paths[ind][1], self.new_material)
-			if res != 0:
-				return {'CANCELLED'}
-			return {'FINISHED'}
+    @tracking.report_error
+    def execute(self, context):
+        if self.username == "":
+            self.report({"ERROR"}, "Invalid username")
+            return {"CANCELLED"}
+
+        skins = [str(skin[0]).lower() for skin in env.skin_list]
+        paths = [skin[1] for skin in env.skin_list]
+        if self.username.lower() not in skins or not self.skip_redownload:
+            # Do the download
+            saveloc = download_user(self, context, self.username)
+            if not saveloc:
+                return {"CANCELLED"}
+
+            # Now load the skin
+            res = loadSkinFile(self, context, saveloc, self.new_material)
+            if res != 0:
+                return {"CANCELLED"}
+            bpy.ops.mcprep.reload_skins()
+            return {"FINISHED"}
+        else:
+            env.log("Reusing downloaded skin")
+            ind = skins.index(self.username.lower())
+            res = loadSkinFile(self, context, paths[ind][1], self.new_material)
+            if res != 0:
+                return {"CANCELLED"}
+            return {"FINISHED"}
 
 
-class MCPREP_OT_skin_fix_eyes():  # bpy.types.Operator
-	"""Fix the eyes of a rig to fit a rig"""
-	bl_idname = "mcprep.fix_skin_eyes"
-	bl_label = "Fix eyes"
-	bl_description = "Fix the eyes of a rig to fit a rig"
-	bl_options = {'REGISTER', 'UNDO'}
+class MCPREP_OT_skin_fix_eyes:  # bpy.types.Operator
+    """Fix the eyes of a rig to fit a rig"""
 
-	# initial_eye_type: unknown (default), 2x2 square, 1x2 wide.
+    bl_idname = "mcprep.fix_skin_eyes"
+    bl_label = "Fix eyes"
+    bl_description = "Fix the eyes of a rig to fit a rig"
+    bl_options = {"REGISTER", "UNDO"}
 
-	@tracking.report_error
-	def execute(self, context):
-		# take the active texture input (based on selection)
-		print("fix eyes")
-		self.report({'ERROR'}, "Work in progress operator")
-		return {'CANCELLED'}
+    # initial_eye_type: unknown (default), 2x2 square, 1x2 wide.
+
+    @tracking.report_error
+    def execute(self, context):
+        # take the active texture input (based on selection)
+        print("fix eyes")
+        self.report({"ERROR"}, "Work in progress operator")
+        return {"CANCELLED"}
 
 
 class MCPREP_OT_add_skin(bpy.types.Operator, ImportHelper):
-	bl_idname = "mcprep.add_skin"
-	bl_label = "Add skin"
-	bl_description = "Add a new skin to the active folder"
+    bl_idname = "mcprep.add_skin"
+    bl_label = "Add skin"
+    bl_description = "Add a new skin to the active folder"
 
-	# filename_ext = ".zip" # needs to be only tinder
-	filter_glob: bpy.props.StringProperty(default="*", options={'HIDDEN'})
-	fileselectparams = "use_filter_blender"
-	files: bpy.props.CollectionProperty(type=bpy.types.PropertyGroup)
+    # filename_ext = ".zip" # needs to be only tinder
+    filter_glob: bpy.props.StringProperty(default="*", options={"HIDDEN"})
+    fileselectparams = "use_filter_blender"
+    files: bpy.props.CollectionProperty(type=bpy.types.PropertyGroup)
 
-	convert_layout: bpy.props.BoolProperty(
-		name="Convert pre 1.8 skins",
-		description=(
-			"If an older skin layout (pre Minecraft 1.8) is detected, convert "
-			"to new format (with clothing layers)"),
-		default=True)
-	skipUsage: bpy.props.BoolProperty(default=False, options={'HIDDEN'})
+    convert_layout: bpy.props.BoolProperty(
+        name="Convert pre 1.8 skins",
+        description=(
+            "If an older skin layout (pre Minecraft 1.8) is detected, convert "
+            "to new format (with clothing layers)"
+        ),
+        default=True,
+    )
+    skipUsage: bpy.props.BoolProperty(default=False, options={"HIDDEN"})
 
-	track_function = "add_skin"
-	track_param = None
-	@tracking.report_error
-	def execute(self, context):
-		source_location = bpy.path.abspath(self.filepath)
-		base = os.path.basename(source_location)
-		new_location = os.path.join(context.scene.mcprep_skin_path, base)
-		new_location = bpy.path.abspath(new_location)
-		if os.path.isfile(source_location) is False:
-			self.report({"ERROR"}, "Not a image file path")
-			return {'CANCELLED'}
-		elif source_location == new_location:
-			self.report({"WARNING"}, "File already installed")
-			return {'CANCELLED'}
-		elif os.path.isdir(os.path.dirname(new_location)) is False:
-			self.report({"ERROR"}, "Target folder for installing does not exist")
-			return {'CANCELLED'}
+    track_function = "add_skin"
+    track_param = None
 
-		# copy the skin file, overwritting if appropriate
-		if os.path.isfile(new_location):
-			os.remove(new_location)
-		shutil.copy2(source_location, new_location)
+    @tracking.report_error
+    def execute(self, context):
+        source_location = bpy.path.abspath(self.filepath)
+        base = os.path.basename(source_location)
+        new_location = os.path.join(context.scene.mcprep_skin_path, base)
+        new_location = bpy.path.abspath(new_location)
+        if os.path.isfile(source_location) is False:
+            self.report({"ERROR"}, "Not a image file path")
+            return {"CANCELLED"}
+        elif source_location == new_location:
+            self.report({"WARNING"}, "File already installed")
+            return {"CANCELLED"}
+        elif os.path.isdir(os.path.dirname(new_location)) is False:
+            self.report({"ERROR"}, "Target folder for installing does not exist")
+            return {"CANCELLED"}
 
-		# convert to 1.8 skin as needed (double height)
-		converted = False
-		if self.convert_layout:
-			converted = convert_skin_layout(new_location)
-		if converted is True:
-			self.track_param = "1.8 convert"
-		else:
-			self.track_param = None
+        # copy the skin file, overwritting if appropriate
+        if os.path.isfile(new_location):
+            os.remove(new_location)
+        shutil.copy2(source_location, new_location)
 
-		# in future, select multiple
-		bpy.ops.mcprep.reload_skins()
-		self.report({"INFO"}, "Added 1 skin")  # more in the future
+        # convert to 1.8 skin as needed (double height)
+        converted = False
+        if self.convert_layout:
+            converted = convert_skin_layout(new_location)
+        if converted is True:
+            self.track_param = "1.8 convert"
+        else:
+            self.track_param = None
 
-		return {'FINISHED'}
+        # in future, select multiple
+        bpy.ops.mcprep.reload_skins()
+        self.report({"INFO"}, "Added 1 skin")  # more in the future
+
+        return {"FINISHED"}
 
 
 class MCPREP_OT_remove_skin(bpy.types.Operator):
-	bl_idname = "mcprep.remove_skin"
-	bl_label = "Remove skin"
-	bl_description = "Remove a skin from the active folder (will delete file)"
+    bl_idname = "mcprep.remove_skin"
+    bl_label = "Remove skin"
+    bl_description = "Remove a skin from the active folder (will delete file)"
 
-	def invoke(self, context, event):
-		return context.window_manager.invoke_props_dialog(
-			self, width=400 * util.ui_scale())
+    def invoke(self, context, event):
+        return context.window_manager.invoke_props_dialog(
+            self, width=400 * util.ui_scale()
+        )
 
-	def draw(self, context):
-		skin_path = env.skin_list[context.scene.mcprep_skins_list_index]
-		col = self.layout.column()
-		col.scale_y = 0.7
-		col.label(text="Warning, will delete file {} from".format(
-			os.path.basename(skin_path[0])))
-		col.label(text=os.path.dirname(skin_path[-1]))
+    def draw(self, context):
+        skin_path = env.skin_list[context.scene.mcprep_skins_list_index]
+        col = self.layout.column()
+        col.scale_y = 0.7
+        col.label(
+            text="Warning, will delete file {} from".format(
+                os.path.basename(skin_path[0])
+            )
+        )
+        col.label(text=os.path.dirname(skin_path[-1]))
 
-	@tracking.report_error
-	def execute(self, context):
+    @tracking.report_error
+    def execute(self, context):
+        if not env.skin_list:
+            self.report({"ERROR"}, "No skins loaded in memory, try reloading")
+            return {"CANCELLED"}
+        if context.scene.mcprep_skins_list_index >= len(env.skin_list):
+            self.report({"ERROR"}, "Indexing error")
+            return {"CANCELLED"}
 
-		if not env.skin_list:
-			self.report({"ERROR"}, "No skins loaded in memory, try reloading")
-			return {'CANCELLED'}
-		if context.scene.mcprep_skins_list_index >= len(env.skin_list):
-			self.report({"ERROR"}, "Indexing error")
-			return {'CANCELLED'}
+        file = env.skin_list[context.scene.mcprep_skins_list_index][-1]
 
-		file = env.skin_list[context.scene.mcprep_skins_list_index][-1]
+        if os.path.isfile(file) is False:
+            self.report({"ERROR"}, "Skin not found to delete")
+            return {"CANCELLED"}
+        os.remove(file)
 
-		if os.path.isfile(file) is False:
-			self.report({"ERROR"}, "Skin not found to delete")
-			return {'CANCELLED'}
-		os.remove(file)
+        # refresh the folder
+        bpy.ops.mcprep.reload_skins()
+        if context.scene.mcprep_skins_list_index >= len(env.skin_list):
+            context.scene.mcprep_skins_list_index = len(env.skin_list) - 1
 
-		# refresh the folder
-		bpy.ops.mcprep.reload_skins()
-		if context.scene.mcprep_skins_list_index >= len(env.skin_list):
-			context.scene.mcprep_skins_list_index = len(env.skin_list) - 1
+        # in future, select multiple
+        self.report({"INFO"}, "Removed " + bpy.path.basename(file))
 
-		# in future, select multiple
-		self.report({"INFO"}, "Removed " + bpy.path.basename(file))
-
-		return {'FINISHED'}
+        return {"FINISHED"}
 
 
 class MCPREP_OT_reload_skin(bpy.types.Operator):
-	bl_idname = "mcprep.reload_skins"
-	bl_label = "Reload skins"
-	bl_description = "Reload the skins folder"
+    bl_idname = "mcprep.reload_skins"
+    bl_label = "Reload skins"
+    bl_description = "Reload the skins folder"
 
-	@tracking.report_error
-	def execute(self, context):
-		skinfolder = context.scene.mcprep_skin_path
-		skinfolder = bpy.path.abspath(skinfolder)
-		reloadSkinList(context)  # run load even if none found
-		if not os.path.isdir(skinfolder):
-			self.report({'ERROR'}, "Skin directory does not exist")
-			return {'CANCELLED'}
-		return {'FINISHED'}
+    @tracking.report_error
+    def execute(self, context):
+        skinfolder = context.scene.mcprep_skin_path
+        skinfolder = bpy.path.abspath(skinfolder)
+        reloadSkinList(context)  # run load even if none found
+        if not os.path.isdir(skinfolder):
+            self.report({"ERROR"}, "Skin directory does not exist")
+            return {"CANCELLED"}
+        return {"FINISHED"}
 
 
 class MCPREP_OT_reset_skin_path(bpy.types.Operator):
-	bl_idname = "mcprep.skin_path_reset"
-	bl_label = "Reset skin path"
-	bl_description = "Reset the skins folder"
+    bl_idname = "mcprep.skin_path_reset"
+    bl_label = "Reset skin path"
+    bl_description = "Reset the skins folder"
 
-	@tracking.report_error
-	def execute(self, context):
-		addon_prefs = util.get_user_preferences(context)
-		context.scene.mcprep_skin_path = addon_prefs.skin_path
-		return {'FINISHED'}
+    @tracking.report_error
+    def execute(self, context):
+        addon_prefs = util.get_user_preferences(context)
+        context.scene.mcprep_skin_path = addon_prefs.skin_path
+        return {"FINISHED"}
 
 
 class MCPREP_OT_spawn_mob_with_skin(bpy.types.Operator):
-	bl_idname = "mcprep.spawn_with_skin"
-	bl_label = "Spawn with skin"
-	bl_description = "Spawn rig and apply selected skin"
+    bl_idname = "mcprep.spawn_with_skin"
+    bl_label = "Spawn with skin"
+    bl_description = "Spawn rig and apply selected skin"
 
-	relocation: bpy.props.EnumProperty(
-		items=[
-			('Cursor', 'Cursor', 'No relocation'),
-			('Clear', 'Origin', 'Move the rig to the origin'),
-			('Offset', 'Offset root', (
-				'Offset the root bone to curse while moving the rest pose to '
-				'the origin'))],
-		name="Relocation")
-	toLink: bpy.props.BoolProperty(
-		name="Library Link",
-		description="Library link instead of append the group",
-		default=False)
-	clearPose: bpy.props.BoolProperty(
-		name="Clear Pose",
-		description="Clear the pose to rest position",
-		default=True)
-	skipUsage: bpy.props.BoolProperty(default=False, options={'HIDDEN'})
+    relocation: bpy.props.EnumProperty(
+        items=[
+            ("Cursor", "Cursor", "No relocation"),
+            ("Clear", "Origin", "Move the rig to the origin"),
+            (
+                "Offset",
+                "Offset root",
+                (
+                    "Offset the root bone to curse while moving the rest pose to "
+                    "the origin"
+                ),
+            ),
+        ],
+        name="Relocation",
+    )
+    toLink: bpy.props.BoolProperty(
+        name="Library Link",
+        description="Library link instead of append the group",
+        default=False,
+    )
+    clearPose: bpy.props.BoolProperty(
+        name="Clear Pose", description="Clear the pose to rest position", default=True
+    )
+    skipUsage: bpy.props.BoolProperty(default=False, options={"HIDDEN"})
 
-	track_function = "spawn_with_skin"
-	track_param = None
-	@tracking.report_error
-	def execute(self, context):
-		scn_props = context.scene.mcprep_props
-		if not env.skin_list:
-			self.report({'ERROR'}, "No skins found")
-			return {'CANCELLED'}
+    track_function = "spawn_with_skin"
+    track_param = None
 
-		mob = scn_props.mob_list[scn_props.mob_list_index]
-		self.track_param = mob.name
+    @tracking.report_error
+    def execute(self, context):
+        scn_props = context.scene.mcprep_props
+        if not env.skin_list:
+            self.report({"ERROR"}, "No skins found")
+            return {"CANCELLED"}
 
-		bpy.ops.mcprep.mob_spawner(
-			mcmob_type=mob.mcmob_type,
-			relocation=self.relocation,
-			toLink=self.toLink,
-			clearPose=self.clearPose,
-			skipUsage=True)
+        mob = scn_props.mob_list[scn_props.mob_list_index]
+        self.track_param = mob.name
 
-		# bpy.ops.mcprep.spawn_with_skin() spawn based on active mob
-		ind = context.scene.mcprep_skins_list_index
-		_ = loadSkinFile(self, context, env.skin_list[ind][1])
+        bpy.ops.mcprep.mob_spawner(
+            mcmob_type=mob.mcmob_type,
+            relocation=self.relocation,
+            toLink=self.toLink,
+            clearPose=self.clearPose,
+            skipUsage=True,
+        )
 
-		return {'FINISHED'}
+        # bpy.ops.mcprep.spawn_with_skin() spawn based on active mob
+        ind = context.scene.mcprep_skins_list_index
+        _ = loadSkinFile(self, context, env.skin_list[ind][1])
+
+        return {"FINISHED"}
 
 
 class MCPREP_OT_download_username_list(bpy.types.Operator):
-	"""Apply the active UIlist skin to select characters"""
-	bl_idname = "mcprep.download_username_list"
-	bl_label = "Download username list"
-	bl_description = "Download a list of skins from comma-separated usernames"
-	bl_options = {'REGISTER', 'UNDO'}
+    """Apply the active UIlist skin to select characters"""
 
-	username_list: bpy.props.StringProperty(
-		name="Username list",
-		description="Comma-separated list of usernames to download.",
-		default=""
-	)
-	skip_redownload: bpy.props.BoolProperty(
-		name="Skip download if skin already local",
-		description="Avoid re-downloading skin and apply local file instead",
-		default=True
-	)
-	convert_layout: bpy.props.BoolProperty(
-		name="Convert pre 1.8 skins",
-		description=(
-			"If an older skin layout (pre Minecraft 1.8) is detected, convert "
-			"to new format (with clothing layers)"),
-		default=True
-	)
-	skipUsage: bpy.props.BoolProperty(
-		default=False,
-		options={'HIDDEN'}
-	)
+    bl_idname = "mcprep.download_username_list"
+    bl_label = "Download username list"
+    bl_description = "Download a list of skins from comma-separated usernames"
+    bl_options = {"REGISTER", "UNDO"}
 
-	def invoke(self, context, event):
-		return context.window_manager.invoke_props_dialog(
-			self, width=400 * util.ui_scale())
+    username_list: bpy.props.StringProperty(
+        name="Username list",
+        description="Comma-separated list of usernames to download.",
+        default="",
+    )
+    skip_redownload: bpy.props.BoolProperty(
+        name="Skip download if skin already local",
+        description="Avoid re-downloading skin and apply local file instead",
+        default=True,
+    )
+    convert_layout: bpy.props.BoolProperty(
+        name="Convert pre 1.8 skins",
+        description=(
+            "If an older skin layout (pre Minecraft 1.8) is detected, convert "
+            "to new format (with clothing layers)"
+        ),
+        default=True,
+    )
+    skipUsage: bpy.props.BoolProperty(default=False, options={"HIDDEN"})
 
-	def draw(self, context):
-		self.layout.label(text="Enter comma-separted list of usernames below")
-		self.layout.prop(self, "username_list", text="")
-		self.layout.prop(self, "skip_redownload")
-		self.layout.label(
-			text="and then press OK; blender may pause briefly to download")
+    def invoke(self, context, event):
+        return context.window_manager.invoke_props_dialog(
+            self, width=400 * util.ui_scale()
+        )
 
-	track_function = "skin"
-	track_param = "username_list"
-	@tracking.report_error
-	def execute(self, context):
-		if self.username_list == "":
-			self.report({"ERROR"}, "Username list is empty!")
-			return {'CANCELLED'}
-		# Take comma-separated string, split into list and remove whitespace.
-		user_list = [skn.strip() for skn in self.username_list.split(",")]
-		user_list = list(set(user_list))  # Make list unique.
+    def draw(self, context):
+        self.layout.label(text="Enter comma-separted list of usernames below")
+        self.layout.prop(self, "username_list", text="")
+        self.layout.prop(self, "skip_redownload")
+        self.layout.label(
+            text="and then press OK; blender may pause briefly to download"
+        )
 
-		# Currently loaded
-		skins = [str(skin[0]).lower() for skin in env.skin_list]
-		issue_skins = []
-		for username in user_list:
-			if username.lower() not in skins or not self.skip_redownload:
-				saveloc = download_user(self, context, username)
-				if not saveloc:
-					issue_skins.append(username)
+    track_function = "skin"
+    track_param = "username_list"
 
-		bpy.ops.mcprep.reload_skins()
+    @tracking.report_error
+    def execute(self, context):
+        if self.username_list == "":
+            self.report({"ERROR"}, "Username list is empty!")
+            return {"CANCELLED"}
+        # Take comma-separated string, split into list and remove whitespace.
+        user_list = [skn.strip() for skn in self.username_list.split(",")]
+        user_list = list(set(user_list))  # Make list unique.
 
-		if issue_skins and len(issue_skins) == len(user_list):
-			self.report({"ERROR"}, "Failed to download any skins, see console.")
-			return {'CANCELLED'}
-		elif issue_skins and len(issue_skins) < len(user_list):
-			self.report(
-				{"WARNING"},
-				"Could not download {} of {} skins, see console".format(
-					len(issue_skins), len(user_list)))
-			return {'FINISHED'}
-		else:
-			self.report({"INFO"}, "Downloaded {} skins".format(len(user_list)))
-			return {'FINISHED'}
+        # Currently loaded
+        skins = [str(skin[0]).lower() for skin in env.skin_list]
+        issue_skins = []
+        for username in user_list:
+            if username.lower() not in skins or not self.skip_redownload:
+                saveloc = download_user(self, context, username)
+                if not saveloc:
+                    issue_skins.append(username)
+
+        bpy.ops.mcprep.reload_skins()
+
+        if issue_skins and len(issue_skins) == len(user_list):
+            self.report({"ERROR"}, "Failed to download any skins, see console.")
+            return {"CANCELLED"}
+        elif issue_skins and len(issue_skins) < len(user_list):
+            self.report(
+                {"WARNING"},
+                "Could not download {} of {} skins, see console".format(
+                    len(issue_skins), len(user_list)
+                ),
+            )
+            return {"FINISHED"}
+        else:
+            self.report({"INFO"}, "Downloaded {} skins".format(len(user_list)))
+            return {"FINISHED"}
 
 
 # -----------------------------------------------------------------------------
@@ -765,47 +797,46 @@ class MCPREP_OT_download_username_list(bpy.types.Operator):
 
 
 classes = (
-	MCPREP_UL_skins,
-	ListColl,
-	MCPREP_OT_swap_skin_from_file,
-	MCPREP_OT_apply_skin,
-	MCPREP_OT_apply_username_skin,
-	MCPREP_OT_download_username_list,
-	# MCPREP_OT_skin_fix_eyes,
-	MCPREP_OT_add_skin,
-	MCPREP_OT_remove_skin,
-	MCPREP_OT_reload_skin,
-	MCPREP_OT_reset_skin_path,
-	MCPREP_OT_spawn_mob_with_skin,
+    MCPREP_UL_skins,
+    ListColl,
+    MCPREP_OT_swap_skin_from_file,
+    MCPREP_OT_apply_skin,
+    MCPREP_OT_apply_username_skin,
+    MCPREP_OT_download_username_list,
+    # MCPREP_OT_skin_fix_eyes,
+    MCPREP_OT_add_skin,
+    MCPREP_OT_remove_skin,
+    MCPREP_OT_reload_skin,
+    MCPREP_OT_reset_skin_path,
+    MCPREP_OT_spawn_mob_with_skin,
 )
 
 
 def register():
-	for cls in classes:
-		bpy.utils.register_class(cls)
+    for cls in classes:
+        bpy.utils.register_class(cls)
 
-	bpy.types.Scene.mcprep_skins_list = bpy.props.CollectionProperty(
-		type=ListColl)
-	bpy.types.Scene.mcprep_skins_list_index = bpy.props.IntProperty(default=0)
+    bpy.types.Scene.mcprep_skins_list = bpy.props.CollectionProperty(type=ListColl)
+    bpy.types.Scene.mcprep_skins_list_index = bpy.props.IntProperty(default=0)
 
-	# to auto-load the skins
-	env.log("Adding reload skin handler to scene", vv_only=True)
-	try:
-		bpy.app.handlers.scene_update_pre.append(handler_skins_enablehack)
-	except:
-		print("Failed to register scene update handler")
-	bpy.app.handlers.load_post.append(handler_skins_load)
+    # to auto-load the skins
+    env.log("Adding reload skin handler to scene", vv_only=True)
+    try:
+        bpy.app.handlers.scene_update_pre.append(handler_skins_enablehack)
+    except:
+        print("Failed to register scene update handler")
+    bpy.app.handlers.load_post.append(handler_skins_load)
 
 
 def unregister():
-	for cls in reversed(classes):
-		bpy.utils.unregister_class(cls)
+    for cls in reversed(classes):
+        bpy.utils.unregister_class(cls)
 
-	del bpy.types.Scene.mcprep_skins_list
-	del bpy.types.Scene.mcprep_skins_list_index
+    del bpy.types.Scene.mcprep_skins_list
+    del bpy.types.Scene.mcprep_skins_list_index
 
-	try:
-		bpy.app.handlers.load_post.remove(handler_skins_load)
-		bpy.app.handlers.scene_update_pre.remove(handler_skins_enablehack)
-	except:
-		pass
+    try:
+        bpy.app.handlers.load_post.remove(handler_skins_load)
+        bpy.app.handlers.scene_update_pre.remove(handler_skins_enablehack)
+    except:
+        pass

--- a/MCprep_addon/materials/sync.py
+++ b/MCprep_addon/materials/sync.py
@@ -33,79 +33,80 @@ from ..conf import env
 # Utilities
 # -----------------------------------------------------------------------------
 
+
 @persistent
 def clear_sync_cache(scene):
-	env.log("Resetting sync mat cache", vv_only=True)
-	env.material_sync_cache = None
+    env.log("Resetting sync mat cache", vv_only=True)
+    env.material_sync_cache = None
 
 
 def get_sync_blend(context):
-	"""Return the sync blend file path that might exist, based on active pack"""
-	resource_pack = bpy.path.abspath(context.scene.mcprep_texturepack_path)
-	return os.path.join(resource_pack, "materials.blend")
+    """Return the sync blend file path that might exist, based on active pack"""
+    resource_pack = bpy.path.abspath(context.scene.mcprep_texturepack_path)
+    return os.path.join(resource_pack, "materials.blend")
 
 
 def reload_material_sync_library(context):
-	"""Reloads the library and cache"""
-	sync_file = get_sync_blend(context)
-	if not os.path.isfile(sync_file):
-		env.material_sync_cache = []
-		return
+    """Reloads the library and cache"""
+    sync_file = get_sync_blend(context)
+    if not os.path.isfile(sync_file):
+        env.material_sync_cache = []
+        return
 
-	with bpy.data.libraries.load(sync_file) as (data_from, _):
-		env.material_sync_cache = list(data_from.materials)
-	env.log("Updated sync cache", vv_only=True)
+    with bpy.data.libraries.load(sync_file) as (data_from, _):
+        env.material_sync_cache = list(data_from.materials)
+    env.log("Updated sync cache", vv_only=True)
 
 
 def material_in_sync_library(mat_name, context):
-	"""Returns true if the material is in the sync mat library blend file"""
-	if env.material_sync_cache is None:
-		reload_material_sync_library(context)
-	if util.nameGeneralize(mat_name) in env.material_sync_cache:
-		return True
-	elif mat_name in env.material_sync_cache:
-		return True
-	return False
+    """Returns true if the material is in the sync mat library blend file"""
+    if env.material_sync_cache is None:
+        reload_material_sync_library(context)
+    if util.nameGeneralize(mat_name) in env.material_sync_cache:
+        return True
+    elif mat_name in env.material_sync_cache:
+        return True
+    return False
 
 
 def sync_material(context, source_mat, sync_mat_name, link, replace):
-	"""If found, load and apply the material found in a library.
+    """If found, load and apply the material found in a library.
 
-	Args:
-		context: Current bpy context.
-		source_mat: bpy.Types.Material in the current open blend file
-		sync_mat_name: str of the mat to try to replace in.
-		link: Bool, if true then new material is linkd instead of appended.
-		replace: If true, the old material in this file is immediately rm'd.
+    Args:
+            context: Current bpy context.
+            source_mat: bpy.Types.Material in the current open blend file
+            sync_mat_name: str of the mat to try to replace in.
+            link: Bool, if true then new material is linkd instead of appended.
+            replace: If true, the old material in this file is immediately rm'd.
 
-	Returns:
-		0 if nothing modified, 1 if modified
-		None if no error or string if error
-	"""
-	if sync_mat_name in env.material_sync_cache:
-		import_name = sync_mat_name
-	elif util.nameGeneralize(sync_mat_name) in env.material_sync_cache:
-		import_name = util.nameGeneralize(sync_mat_name)
+    Returns:
+            0 if nothing modified, 1 if modified
+            None if no error or string if error
+    """
+    if sync_mat_name in env.material_sync_cache:
+        import_name = sync_mat_name
+    elif util.nameGeneralize(sync_mat_name) in env.material_sync_cache:
+        import_name = util.nameGeneralize(sync_mat_name)
 
-	# if link is true, check library material not already linked
-	sync_file = get_sync_blend(context)
-	init_mats = bpy.data.materials[:]
-	util.bAppendLink(os.path.join(sync_file, "Material"), import_name, link)
+    # if link is true, check library material not already linked
+    sync_file = get_sync_blend(context)
+    init_mats = bpy.data.materials[:]
+    util.bAppendLink(os.path.join(sync_file, "Material"), import_name, link)
 
-	imported = set(bpy.data.materials[:]) - set(init_mats)
-	if not imported:
-		return 0, "Could not import {}".format(import_name)
-	new_material = list(imported)[0]
+    imported = set(bpy.data.materials[:]) - set(init_mats)
+    if not imported:
+        return 0, "Could not import {}".format(import_name)
+    new_material = list(imported)[0]
 
-	# 2.78+ only, else silent failure
-	res = util.remap_users(source_mat, new_material)
-	if res != 0:
-		# try a fallback where we at least go over the selected objects
-		return 0, res
-	if replace is True:
-		bpy.data.materials.remove(source_mat)
+    # 2.78+ only, else silent failure
+    res = util.remap_users(source_mat, new_material)
+    if res != 0:
+        # try a fallback where we at least go over the selected objects
+        return 0, res
+    if replace is True:
+        bpy.data.materials.remove(source_mat)
 
-	return 1, None
+    return 1, None
 
 
 # -----------------------------------------------------------------------------
@@ -114,143 +115,155 @@ def sync_material(context, source_mat, sync_mat_name, link, replace):
 
 
 class MCPREP_OT_sync_materials(bpy.types.Operator):
-	"""Synchronize materials with those in the active pack's materials.blend file"""
-	bl_idname = "mcprep.sync_materials"
-	bl_label = "Sync Materials"
-	bl_options = {'REGISTER', 'UNDO'}
+    """Synchronize materials with those in the active pack's materials.blend file"""
 
-	selected: bpy.props.BoolProperty(
-		name="Only selected",
-		description=(
-			"Affect only the materials on selected objects, otherwise "
-			"sync all materials in blend file"),
-		default=True)
-	link: bpy.props.BoolProperty(
-		name="Link",
-		description="Link instead of appending material",
-		default=False)
-	replace_materials: bpy.props.BoolProperty(
-		name="Replace",
-		description="Delete the local materials being synced, where matched",
-		default=False)
-	skipUsage: bpy.props.BoolProperty(
-		default=False,
-		options={'HIDDEN'})
+    bl_idname = "mcprep.sync_materials"
+    bl_label = "Sync Materials"
+    bl_options = {"REGISTER", "UNDO"}
 
-	track_function = "sync_materials"
-	track_param = None
-	@tracking.report_error
-	def execute(self, context):
-		inital_selection = context.selected_objects
-		initial_active = context.object
+    selected: bpy.props.BoolProperty(
+        name="Only selected",
+        description=(
+            "Affect only the materials on selected objects, otherwise "
+            "sync all materials in blend file"
+        ),
+        default=True,
+    )
+    link: bpy.props.BoolProperty(
+        name="Link", description="Link instead of appending material", default=False
+    )
+    replace_materials: bpy.props.BoolProperty(
+        name="Replace",
+        description="Delete the local materials being synced, where matched",
+        default=False,
+    )
+    skipUsage: bpy.props.BoolProperty(default=False, options={"HIDDEN"})
 
-		sync_file = get_sync_blend(context)
-		if not os.path.isfile(sync_file):
-			if not self.skipUsage:
-				self.report({'ERROR'}, "Sync file not found: " + sync_file)
-			return {'CANCELLED'}
+    track_function = "sync_materials"
+    track_param = None
 
-		if sync_file == bpy.data.filepath:
-			if not self.skipUsage:
-				self.report({'ERROR'}, "This IS the sync file - can't sync with itself!")
-			return {'CANCELLED'}
+    @tracking.report_error
+    def execute(self, context):
+        inital_selection = context.selected_objects
+        initial_active = context.object
 
-		# get list of selected objects
-		if self.selected is True:
-			obj_list = context.selected_objects
-			if not obj_list:
-				if not self.skipUsage:
-					self.report({'ERROR'}, "No objects selected")
-				return {'CANCELLED'}
+        sync_file = get_sync_blend(context)
+        if not os.path.isfile(sync_file):
+            if not self.skipUsage:
+                self.report({"ERROR"}, "Sync file not found: " + sync_file)
+            return {"CANCELLED"}
 
-			# gets the list of materials (without repetition) from selected
-			mat_list = util.materialsFromObj(obj_list)
-		else:
-			mat_list = list(bpy.data.materials)
+        if sync_file == bpy.data.filepath:
+            if not self.skipUsage:
+                self.report(
+                    {"ERROR"}, "This IS the sync file - can't sync with itself!"
+                )
+            return {"CANCELLED"}
 
-		if not mat_list:
-			if not self.skipUsage:
-				self.report({'ERROR'}, "No materials to sync")
-			return {'CANCELLED'}
+        # get list of selected objects
+        if self.selected is True:
+            obj_list = context.selected_objects
+            if not obj_list:
+                if not self.skipUsage:
+                    self.report({"ERROR"}, "No objects selected")
+                return {"CANCELLED"}
 
-		# consider force reloading the material library blend
-		eligible = 0
-		modified = 0
-		last_err = None
-		for mat in mat_list:
-			# Match either exact name, or translated name.
-			lookup_match, _ = generate.get_mc_canonical_name(mat.name)
-			if material_in_sync_library(mat.name, context) is True:
-				sync_mat_name = mat.name
-			elif material_in_sync_library(lookup_match, context) is True:
-				sync_mat_name = lookup_match
-			else:
-				continue
-			affected, err = sync_material(
-				context,
-				source_mat=mat,
-				sync_mat_name=sync_mat_name,
-				link=self.link,
-				replace=self.replace_materials)
-			eligible += 1
-			modified += affected
-			if err:
-				last_err = err
+            # gets the list of materials (without repetition) from selected
+            mat_list = util.materialsFromObj(obj_list)
+        else:
+            mat_list = list(bpy.data.materials)
 
-		if last_err:
-			env.log("Most recent error during sync:" + str(last_err))
+        if not mat_list:
+            if not self.skipUsage:
+                self.report({"ERROR"}, "No materials to sync")
+            return {"CANCELLED"}
 
-		# Re-establish initial state, as append material clears selections
-		for obj in inital_selection:
-			util.select_set(obj, True)
-		util.set_active_object(context, initial_active)
+        # consider force reloading the material library blend
+        eligible = 0
+        modified = 0
+        last_err = None
+        for mat in mat_list:
+            # Match either exact name, or translated name.
+            lookup_match, _ = generate.get_mc_canonical_name(mat.name)
+            if material_in_sync_library(mat.name, context) is True:
+                sync_mat_name = mat.name
+            elif material_in_sync_library(lookup_match, context) is True:
+                sync_mat_name = lookup_match
+            else:
+                continue
+            affected, err = sync_material(
+                context,
+                source_mat=mat,
+                sync_mat_name=sync_mat_name,
+                link=self.link,
+                replace=self.replace_materials,
+            )
+            eligible += 1
+            modified += affected
+            if err:
+                last_err = err
 
-		if eligible == 0:
-			self.report({'INFO'}, "No materials matched the sync library")
-			return {'CANCELLED'}
-		elif modified == 0:
-			if not self.skipUsage:
-				self.report({'ERROR'}, (
-					"No materials modified, though some "
-					"detected in the sync library: ") + last_err)
-			# raise exception? This shouldn't occur
-			return {'CANCELLED'}
-		elif modified == 1:
-			self.report({'INFO'}, "Synced 1 material")
-		else:
-			self.report({'INFO'}, "Synced {} materials".format(modified))
-		return {'FINISHED'}
+        if last_err:
+            env.log("Most recent error during sync:" + str(last_err))
+
+        # Re-establish initial state, as append material clears selections
+        for obj in inital_selection:
+            util.select_set(obj, True)
+        util.set_active_object(context, initial_active)
+
+        if eligible == 0:
+            self.report({"INFO"}, "No materials matched the sync library")
+            return {"CANCELLED"}
+        elif modified == 0:
+            if not self.skipUsage:
+                self.report(
+                    {"ERROR"},
+                    (
+                        "No materials modified, though some "
+                        "detected in the sync library: "
+                    )
+                    + last_err,
+                )
+            # raise exception? This shouldn't occur
+            return {"CANCELLED"}
+        elif modified == 1:
+            self.report({"INFO"}, "Synced 1 material")
+        else:
+            self.report({"INFO"}, "Synced {} materials".format(modified))
+        return {"FINISHED"}
 
 
 class MCPREP_OT_edit_sync_materials_file(bpy.types.Operator):
-	"""Open the the file used fo syncrhonization."""
-	bl_idname = "mcprep.edit_sync_materials_file"
-	bl_label = "Edit sync file"
-	bl_options = {'REGISTER', 'UNDO'}
+    """Open the the file used fo syncrhonization."""
 
-	track_function = "edit_sync_materials"
-	track_param = None
-	@tracking.report_error
-	def execute(self, context):
-		file = get_sync_blend(context)
-		if not bpy.data.is_saved:
-			self.report({'ERROR'}, "Save your blend file first")
-			return {'CANCELLED'}
+    bl_idname = "mcprep.edit_sync_materials_file"
+    bl_label = "Edit sync file"
+    bl_options = {"REGISTER", "UNDO"}
 
-		# Will open without saving or prompting!
-		# TODO: Perform action more similar to the asset browser, which opens
-		# a new instance of blender.
-		if os.path.isfile(file):
-			bpy.ops.wm.open_mainfile(filepath=file)
-		else:
-			# Open and save a new sync file instead.
-			bpy.ops.wm.read_homefile(use_empty=True)
+    track_function = "edit_sync_materials"
+    track_param = None
 
-			# Set the local resource pack to match this generated file.
-			bpy.context.scene.mcprep_texturepack_path = "//"
+    @tracking.report_error
+    def execute(self, context):
+        file = get_sync_blend(context)
+        if not bpy.data.is_saved:
+            self.report({"ERROR"}, "Save your blend file first")
+            return {"CANCELLED"}
 
-			bpy.ops.wm.save_as_mainfile(filepath=file)
-		return {'FINISHED'}
+        # Will open without saving or prompting!
+        # TODO: Perform action more similar to the asset browser, which opens
+        # a new instance of blender.
+        if os.path.isfile(file):
+            bpy.ops.wm.open_mainfile(filepath=file)
+        else:
+            # Open and save a new sync file instead.
+            bpy.ops.wm.read_homefile(use_empty=True)
+
+            # Set the local resource pack to match this generated file.
+            bpy.context.scene.mcprep_texturepack_path = "//"
+
+            bpy.ops.wm.save_as_mainfile(filepath=file)
+        return {"FINISHED"}
 
 
 # -----------------------------------------------------------------------------
@@ -259,21 +272,21 @@ class MCPREP_OT_edit_sync_materials_file(bpy.types.Operator):
 
 
 classes = (
-	MCPREP_OT_sync_materials,
-	MCPREP_OT_edit_sync_materials_file,
+    MCPREP_OT_sync_materials,
+    MCPREP_OT_edit_sync_materials_file,
 )
 
 
 def register():
-	for cls in classes:
-		bpy.utils.register_class(cls)
-	bpy.app.handlers.load_post.append(clear_sync_cache)
+    for cls in classes:
+        bpy.utils.register_class(cls)
+    bpy.app.handlers.load_post.append(clear_sync_cache)
 
 
 def unregister():
-	for cls in reversed(classes):
-		bpy.utils.unregister_class(cls)
-	try:
-		bpy.app.handlers.load_post.remove(clear_sync_cache)
-	except Exception as e:
-		print("Unregister post handler error: ", e)
+    for cls in reversed(classes):
+        bpy.utils.unregister_class(cls)
+    try:
+        bpy.app.handlers.load_post.remove(clear_sync_cache)
+    except Exception as e:
+        print("Unregister post handler error: ", e)

--- a/MCprep_addon/materials/uv_tools.py
+++ b/MCprep_addon/materials/uv_tools.py
@@ -31,99 +31,101 @@ from .. import util
 # UV functions
 # -----------------------------------------------------------------------------
 
+
 def get_uv_bounds_per_material(obj):
-	"""Return the maximum uv bounds per object, split per material
+    """Return the maximum uv bounds per object, split per material
 
-	Returns:
-		dict: index of material name, value list of minx, maxx, miny, maxy,
-			where values are in UV terms (0-1, unless wrapping)
-	"""
-	if not obj or obj.type != 'MESH':
-		return {}
-	mats = util.materialsFromObj([obj])
-	if not mats:
-		return {}
+    Returns:
+            dict: index of material name, value list of minx, maxx, miny, maxy,
+                    where values are in UV terms (0-1, unless wrapping)
+    """
+    if not obj or obj.type != "MESH":
+        return {}
+    mats = util.materialsFromObj([obj])
+    if not mats:
+        return {}
 
-	active_uv = obj.data.uv_layers.active
-	if not active_uv or not active_uv.data:
-		return {}
+    active_uv = obj.data.uv_layers.active
+    if not active_uv or not active_uv.data:
+        return {}
 
-	# order of minx, maxx, miny, maxy,
-	# min's start with 1 so comparisons can go lower,
-	# max's start with 0 so comparisons can go higher
-	res = {mat.name: [1, 0, 1, 0] for mat in mats}
+    # order of minx, maxx, miny, maxy,
+    # min's start with 1 so comparisons can go lower,
+    # max's start with 0 so comparisons can go higher
+    res = {mat.name: [1, 0, 1, 0] for mat in mats}
 
-	# TODO: add other key for max_uvsize, to detect cases like lava and water
-	# where multiple materials are in one but UVs split over multiple blocks.
-	# In the meantime, threshold of 0.25 set by parent function is a sweetspot
-	for poly in obj.data.polygons:
-		m_index = poly.material_index
-		mslot = obj.material_slots[m_index]
-		if not mslot or not mslot.material:
-			continue
+    # TODO: add other key for max_uvsize, to detect cases like lava and water
+    # where multiple materials are in one but UVs split over multiple blocks.
+    # In the meantime, threshold of 0.25 set by parent function is a sweetspot
+    for poly in obj.data.polygons:
+        m_index = poly.material_index
+        mslot = obj.material_slots[m_index]
+        if not mslot or not mslot.material:
+            continue
 
-		# TODO: Consider breaking early after reaching the first N hits of a
-		# given material face within the same object, to avoid slowdown for
-		# very large worlds. Butm early tests show that UV check is still small
-		# compared to overall process time of either swap tex or anim tex.
+        # TODO: Consider breaking early after reaching the first N hits of a
+        # given material face within the same object, to avoid slowdown for
+        # very large worlds. Butm early tests show that UV check is still small
+        # compared to overall process time of either swap tex or anim tex.
 
-		mkey = mslot.material.name
-		for loop_ind in poly.loop_indices:
-			# a loop could be an edge or face
-			# loop = obj.data.loops[i] # This polygon/edge
-			uvx, uvy = active_uv.data[loop_ind].uv
-			if uvx < res[mkey][0]:  # min x
-				res[mkey][0] = uvx
-			if uvx > res[mkey][1]:  # max x
-				res[mkey][1] = uvx
-			if uvy < res[mkey][2]:  # min y
-				res[mkey][2] = uvy
-			if uvy > res[mkey][3]:  # max y
-				res[mkey][3] = uvy
-	return res
+        mkey = mslot.material.name
+        for loop_ind in poly.loop_indices:
+            # a loop could be an edge or face
+            # loop = obj.data.loops[i] # This polygon/edge
+            uvx, uvy = active_uv.data[loop_ind].uv
+            if uvx < res[mkey][0]:  # min x
+                res[mkey][0] = uvx
+            if uvx > res[mkey][1]:  # max x
+                res[mkey][1] = uvx
+            if uvy < res[mkey][2]:  # min y
+                res[mkey][2] = uvy
+            if uvy > res[mkey][3]:  # max y
+                res[mkey][3] = uvy
+    return res
 
 
 def detect_invalid_uvs_from_objs(obj_list):
-	"""Detect all-in one combined images from concentrated UV layouts.
+    """Detect all-in one combined images from concentrated UV layouts.
 
-	Returns:
-		bool: True for invalid layout, False of ok layout
-		list: Of objects which appear to have invalid UVs
-	"""
-	invalid = False
-	invalid_objects = []
+    Returns:
+            bool: True for invalid layout, False of ok layout
+            list: Of objects which appear to have invalid UVs
+    """
+    invalid = False
+    invalid_objects = []
 
-	# if bounded coverage is less on either axis, treat invalid.
-	# This threshold is slightly arbitrary, can't use 1.0 as some meshes are
-	# rightfully not up against bounds of image. But generally, for combined
-	# images the area covered is closer to 0.05
-	thresh = 0.25
-	env.log("Doing check for invalid UV faces", vv_only=True)
-	t0 = time.time()
+    # if bounded coverage is less on either axis, treat invalid.
+    # This threshold is slightly arbitrary, can't use 1.0 as some meshes are
+    # rightfully not up against bounds of image. But generally, for combined
+    # images the area covered is closer to 0.05
+    thresh = 0.25
+    env.log("Doing check for invalid UV faces", vv_only=True)
+    t0 = time.time()
 
-	for obj in obj_list:
-		uv_bounds = get_uv_bounds_per_material(obj)
-		mis_mats = [
-			mt for mt in uv_bounds
-			if uv_bounds[mt][1] - uv_bounds[mt][0] < thresh
-			and uv_bounds[mt][3] - uv_bounds[mt][2] < thresh
-		]
+    for obj in obj_list:
+        uv_bounds = get_uv_bounds_per_material(obj)
+        mis_mats = [
+            mt
+            for mt in uv_bounds
+            if uv_bounds[mt][1] - uv_bounds[mt][0] < thresh
+            and uv_bounds[mt][3] - uv_bounds[mt][2] < thresh
+        ]
 
-		# if multiple materials on object and others don't alert, then toss
-		# out as 'valid'; example scenario of the bottom face of a sign will
-		# alert on its own (and is its own material), but rest of the sign is
-		# indeed beyond and valid.
-		if len(mis_mats) < len(uv_bounds):
-			continue
+        # if multiple materials on object and others don't alert, then toss
+        # out as 'valid'; example scenario of the bottom face of a sign will
+        # alert on its own (and is its own material), but rest of the sign is
+        # indeed beyond and valid.
+        if len(mis_mats) < len(uv_bounds):
+            continue
 
-		# otherwise, alert that this obj appears to have invalid UVs
-		if mis_mats:
-			invalid = True
-			invalid_objects.append(obj)
-	t1 = time.time()
-	t_diff = t1 - t0  # round to .1s
-	env.log("UV check took {}s".format(t_diff), vv_only=True)
-	return invalid, invalid_objects
+        # otherwise, alert that this obj appears to have invalid UVs
+        if mis_mats:
+            invalid = True
+            invalid_objects.append(obj)
+    t1 = time.time()
+    t_diff = t1 - t0  # round to .1s
+    env.log("UV check took {}s".format(t_diff), vv_only=True)
+    return invalid, invalid_objects
 
 
 # -----------------------------------------------------------------------------
@@ -132,249 +134,261 @@ def detect_invalid_uvs_from_objs(obj_list):
 
 
 class MCPREP_OT_scale_uv(bpy.types.Operator):
-	bl_idname = "mcprep.scale_uv"
-	bl_label = "Scale UV Faces"
-	bl_description = "Scale all selected UV faces. See F6 or redo-last panel to adjust factor"
-	bl_options = {'REGISTER', 'UNDO'}
+    bl_idname = "mcprep.scale_uv"
+    bl_label = "Scale UV Faces"
+    bl_description = (
+        "Scale all selected UV faces. See F6 or redo-last panel to adjust factor"
+    )
+    bl_options = {"REGISTER", "UNDO"}
 
-	scale: bpy.props.FloatProperty(default=0.75, name="Scale")
-	selected_only: bpy.props.BoolProperty(default=True, name="Seleced only")
-	skipUsage: bpy.props.BoolProperty(default=False, options={'HIDDEN'})
+    scale: bpy.props.FloatProperty(default=0.75, name="Scale")
+    selected_only: bpy.props.BoolProperty(default=True, name="Seleced only")
+    skipUsage: bpy.props.BoolProperty(default=False, options={"HIDDEN"})
 
-	@classmethod
-	def poll(cls, context):
-		return context.mode == 'EDIT_MESH' or (
-			context.mode == 'OBJECT' and context.object)
+    @classmethod
+    def poll(cls, context):
+        return context.mode == "EDIT_MESH" or (
+            context.mode == "OBJECT" and context.object
+        )
 
-	track_function = "scale_uv"
-	@tracking.report_error
-	def execute(self, context):
+    track_function = "scale_uv"
 
-		# INITIAL WIP
-		"""
-		# WIP
-		ob = context.active_object
-		# copied from elsewhere
-		uvs = ob.data.uv_layers[0].data
-		matchingVertIndex = list(chain.from_iterable(polyIndices))
-		# example, matching list of uv coord and 3dVert coord:
-		uvs_XY = [i.uv for i in Object.data.uv_layers[0].data]
-		vertXYZ= [v.co for v in Object.data.vertices]
-		matchingVertIndex = list(chain.from_iterable(
-			[p.vertices for p in Object.data.polygons]))
-		# and now, the coord to pair with uv coord:
-		matchingVertsCoord = [vertsXYZ[i] for i in matchingVertIndex]
-		"""
-		if not context.object:
-			self.report({'ERROR'}, "No active object found")
-			return {'CANCELLED'}
-		elif context.object.type != 'MESH':
-			self.report({'ERROR'}, "Active object must be a mesh")
-			return {'CANCELLED'}
-		elif not context.object.data.polygons:
-			self.report({'WARNING'}, "Active object has no faces")
-			return {'CANCELLED'}
+    @tracking.report_error
+    def execute(self, context):
+        # INITIAL WIP
+        """
+        # WIP
+        ob = context.active_object
+        # copied from elsewhere
+        uvs = ob.data.uv_layers[0].data
+        matchingVertIndex = list(chain.from_iterable(polyIndices))
+        # example, matching list of uv coord and 3dVert coord:
+        uvs_XY = [i.uv for i in Object.data.uv_layers[0].data]
+        vertXYZ= [v.co for v in Object.data.vertices]
+        matchingVertIndex = list(chain.from_iterable(
+                [p.vertices for p in Object.data.polygons]))
+        # and now, the coord to pair with uv coord:
+        matchingVertsCoord = [vertsXYZ[i] for i in matchingVertIndex]
+        """
+        if not context.object:
+            self.report({"ERROR"}, "No active object found")
+            return {"CANCELLED"}
+        elif context.object.type != "MESH":
+            self.report({"ERROR"}, "Active object must be a mesh")
+            return {"CANCELLED"}
+        elif not context.object.data.polygons:
+            self.report({"WARNING"}, "Active object has no faces")
+            return {"CANCELLED"}
 
-		if not context.object.data.uv_layers.active:
-			self.report({'ERROR'}, "No active UV map found")
-			return {'CANCELLED'}
+        if not context.object.data.uv_layers.active:
+            self.report({"ERROR"}, "No active UV map found")
+            return {"CANCELLED"}
 
-		mode_initial = context.mode
-		bpy.ops.object.mode_set(mode="OBJECT")
-		ret = self.scale_uv_faces(context.object, self.scale)
-		if mode_initial != 'OBJECT':
-			bpy.ops.object.mode_set(mode="EDIT")
+        mode_initial = context.mode
+        bpy.ops.object.mode_set(mode="OBJECT")
+        ret = self.scale_uv_faces(context.object, self.scale)
+        if mode_initial != "OBJECT":
+            bpy.ops.object.mode_set(mode="EDIT")
 
-		if ret is not None:
-			self.report({'ERROR'}, ret)
-			env.log("Error, " + ret)
-			return {'CANCELLED'}
+        if ret is not None:
+            self.report({"ERROR"}, ret)
+            env.log("Error, " + ret)
+            return {"CANCELLED"}
 
-		return {'FINISHED'}
+        return {"FINISHED"}
 
-	def scale_uv_faces(self, ob, factor):
-		"""Scale all UV face centers of an object by a given factor."""
+    def scale_uv_faces(self, ob, factor):
+        """Scale all UV face centers of an object by a given factor."""
 
-		factor *= -1
-		factor += 1
-		modified = False
+        factor *= -1
+        factor += 1
+        modified = False
 
-		uv = ob.data.uv_layers.active
-		# initial_UV = [(d.uv[0], d.uv[1])
-		# 				for d in ob.data.uv_layers.active.data]
+        uv = ob.data.uv_layers.active
+        # initial_UV = [(d.uv[0], d.uv[1])
+        # 				for d in ob.data.uv_layers.active.data]
 
-		for f in ob.data.polygons:
-			if not f.select and self.selected_only is True:
-				continue  # if not selected, won't show up in UV editor
+        for f in ob.data.polygons:
+            if not f.select and self.selected_only is True:
+                continue  # if not selected, won't show up in UV editor
 
-			# initialize for avergae center on polygon
-			x = y = n = 0  # x,y,number of verts in loop for average purpose
-			for loop_ind in f.loop_indices:
-				# a loop could be an edge or face
-				# The vertex data that loop entry refers to:
-				# v = ob.data.vertices[l.vertex_index]
-				# isolate to specific UV already used
-				if not uv.data[loop_ind].select and self.selected_only is True:
-					continue
-				x += uv.data[loop_ind].uv[0]
-				y += uv.data[loop_ind].uv[1]
-				n += 1
-			for loop_ind in f.loop_indices:
-				if not uv.data[loop_ind].select and self.selected_only is True:
-					continue
-				uv.data[loop_ind].uv[0] = uv.data[loop_ind].uv[0]*(1-factor)+x/n*(factor)
-				uv.data[loop_ind].uv[1] = uv.data[loop_ind].uv[1]*(1-factor)+y/n*(factor)
-				modified = True
-		if not modified:
-			return "No UV faces selected"
+            # initialize for avergae center on polygon
+            x = y = n = 0  # x,y,number of verts in loop for average purpose
+            for loop_ind in f.loop_indices:
+                # a loop could be an edge or face
+                # The vertex data that loop entry refers to:
+                # v = ob.data.vertices[l.vertex_index]
+                # isolate to specific UV already used
+                if not uv.data[loop_ind].select and self.selected_only is True:
+                    continue
+                x += uv.data[loop_ind].uv[0]
+                y += uv.data[loop_ind].uv[1]
+                n += 1
+            for loop_ind in f.loop_indices:
+                if not uv.data[loop_ind].select and self.selected_only is True:
+                    continue
+                uv.data[loop_ind].uv[0] = uv.data[loop_ind].uv[0] * (
+                    1 - factor
+                ) + x / n * (factor)
+                uv.data[loop_ind].uv[1] = uv.data[loop_ind].uv[1] * (
+                    1 - factor
+                ) + y / n * (factor)
+                modified = True
+        if not modified:
+            return "No UV faces selected"
 
-		return None
+        return None
 
 
 class MCPREP_OT_select_alpha_faces(bpy.types.Operator):
-	bl_idname = "mcprep.select_alpha_faces"
-	bl_label = "Select alpha faces"
-	bl_description = "Select or delete transparent UV faces of a mesh"
-	bl_options = {'REGISTER', 'UNDO'}
+    bl_idname = "mcprep.select_alpha_faces"
+    bl_label = "Select alpha faces"
+    bl_description = "Select or delete transparent UV faces of a mesh"
+    bl_options = {"REGISTER", "UNDO"}
 
-	delete: bpy.props.BoolProperty(
-		name="Delete faces",
-		description="Delete detected transparent mesh faces",
-		default=False)
-	threshold: bpy.props.FloatProperty(
-		name="Threshold",
-		description="How transparent pixels need to be to select",
-		default=0.2,
-		min=0.0,
-		max=1.0)
-	skipUsage: bpy.props.BoolProperty(default=False, options={'HIDDEN'})
+    delete: bpy.props.BoolProperty(
+        name="Delete faces",
+        description="Delete detected transparent mesh faces",
+        default=False,
+    )
+    threshold: bpy.props.FloatProperty(
+        name="Threshold",
+        description="How transparent pixels need to be to select",
+        default=0.2,
+        min=0.0,
+        max=1.0,
+    )
+    skipUsage: bpy.props.BoolProperty(default=False, options={"HIDDEN"})
 
-	@classmethod
-	def poll(cls, context):
-		return context.mode == 'EDIT_MESH'
+    @classmethod
+    def poll(cls, context):
+        return context.mode == "EDIT_MESH"
 
-	track_function = "alpha_faces"
-	@tracking.report_error
-	def execute(self, context):
+    track_function = "alpha_faces"
 
-		ob = context.object
-		if ob is None:
-			self.report({"ERROR"}, "No active object found")
-			return {"CANCELLED"}
-		elif ob.type != 'MESH':
-			self.report({"ERROR"}, "Active object must be a mesh")
-			return {"CANCELLED"}
-		elif not ob.data.polygons:
-			self.report({"WARNING"}, "Active object has no faces")
-			return {"CANCELLED"}
-		elif not ob.material_slots:
-			self.report({"ERROR"}, "Active object has no materials to check image for.")
-			return {"CANCELLED"}
-		if ob.data.uv_layers.active is None:
-			self.report({"ERROR"}, "No active UV map found")
+    @tracking.report_error
+    def execute(self, context):
+        ob = context.object
+        if ob is None:
+            self.report({"ERROR"}, "No active object found")
+            return {"CANCELLED"}
+        elif ob.type != "MESH":
+            self.report({"ERROR"}, "Active object must be a mesh")
+            return {"CANCELLED"}
+        elif not ob.data.polygons:
+            self.report({"WARNING"}, "Active object has no faces")
+            return {"CANCELLED"}
+        elif not ob.material_slots:
+            self.report({"ERROR"}, "Active object has no materials to check image for.")
+            return {"CANCELLED"}
+        if ob.data.uv_layers.active is None:
+            self.report({"ERROR"}, "No active UV map found")
 
-		# if doing multiple objects, iterate over loop of this function
-		bpy.ops.mesh.select_mode(type='FACE')
+        # if doing multiple objects, iterate over loop of this function
+        bpy.ops.mesh.select_mode(type="FACE")
 
-		# UV data only available in object mode, have to switch there and back
-		bpy.ops.object.mode_set(mode="OBJECT")
-		ret = self.select_alpha(ob, self.threshold)
-		bpy.ops.object.mode_set(mode="EDIT")
-		if ret:
-			self.report({"ERROR"}, ret)
-			return {"CANCELLED"}
+        # UV data only available in object mode, have to switch there and back
+        bpy.ops.object.mode_set(mode="OBJECT")
+        ret = self.select_alpha(ob, self.threshold)
+        bpy.ops.object.mode_set(mode="EDIT")
+        if ret:
+            self.report({"ERROR"}, ret)
+            return {"CANCELLED"}
 
-		if not ret and self.delete:
-			env.log("Delet faces")
-			bpy.ops.mesh.delete(type='FACE')
+        if not ret and self.delete:
+            env.log("Delet faces")
+            bpy.ops.mesh.delete(type="FACE")
 
-		return {"FINISHED"}
+        return {"FINISHED"}
 
-	def select_alpha(self, ob, threshold):
-		"""Core function to select alpha faces based on active material/image."""
-		if not ob.material_slots:
-			env.log("No materials, skipping.")
-			return "No materials"
+    def select_alpha(self, ob, threshold):
+        """Core function to select alpha faces based on active material/image."""
+        if not ob.material_slots:
+            env.log("No materials, skipping.")
+            return "No materials"
 
-		# pre-cache the materials and their respective images for comparing
-		textures = []
-		for index in range(len(ob.material_slots)):
-			mat = ob.material_slots[index].material
-			if not mat:
-				textures.append(None)
-				continue
-			image = generate.get_textures(mat)["diffuse"]
-			if not image:
-				textures.append(None)
-				continue
-			elif image.channels != 4:
-				textures.append(None)  # no alpha channel anyways
-				env.log("No alpha channel for: " + image.name)
-				continue
-			textures.append(image)
-		data = [None for tex in textures]
+        # pre-cache the materials and their respective images for comparing
+        textures = []
+        for index in range(len(ob.material_slots)):
+            mat = ob.material_slots[index].material
+            if not mat:
+                textures.append(None)
+                continue
+            image = generate.get_textures(mat)["diffuse"]
+            if not image:
+                textures.append(None)
+                continue
+            elif image.channels != 4:
+                textures.append(None)  # no alpha channel anyways
+                env.log("No alpha channel for: " + image.name)
+                continue
+            textures.append(image)
+        data = [None for tex in textures]
 
-		uv = ob.data.uv_layers.active
-		for f in ob.data.polygons:
-			if len(f.loop_indices) < 3:
-				continue  # don't select edges or vertices
-			fnd = f.material_index
-			image = textures[fnd]
-			if not image:
-				env.log("Could not get image from face's material")
-				return "Could not get image from face's material"
+        uv = ob.data.uv_layers.active
+        for f in ob.data.polygons:
+            if len(f.loop_indices) < 3:
+                continue  # don't select edges or vertices
+            fnd = f.material_index
+            image = textures[fnd]
+            if not image:
+                env.log("Could not get image from face's material")
+                return "Could not get image from face's material"
 
-			# lazy load alpha part of image to memory, hold for whole operator
-			if not data[fnd]:
-				data[fnd] = list(image.pixels)[3::4]
+            # lazy load alpha part of image to memory, hold for whole operator
+            if not data[fnd]:
+                data[fnd] = list(image.pixels)[3::4]
 
-			# relate the polygon to the UV layer to the image coordinates
-			shape = []
-			for i in f.loop_indices:
-				loop = ob.data.loops[i]
-				x = uv.data[loop.index].uv[0] % 1  # TODO: fix this wraparound hack
-				y = uv.data[loop.index].uv[1] % 1
-				shape.append((x, y))
+            # relate the polygon to the UV layer to the image coordinates
+            shape = []
+            for i in f.loop_indices:
+                loop = ob.data.loops[i]
+                x = uv.data[loop.index].uv[0] % 1  # TODO: fix this wraparound hack
+                y = uv.data[loop.index].uv[1] % 1
+                shape.append((x, y))
 
-			# print("The shape coords:")
-			# print(shape)
-			# could just do "the closest" pixel... but better is weighted area
-			if not shape:
-				continue
+            # print("The shape coords:")
+            # print(shape)
+            # could just do "the closest" pixel... but better is weighted area
+            if not shape:
+                continue
 
-			xlist, ylist = tuple([list(tup) for tup in zip(*shape)])
-			# not sure if I actually want to +0.5 to the values to get middle..
-			xmin = round(min(xlist) * image.size[0]) - 0.5
-			xmax = round(max(xlist) * image.size[0]) - 0.5
-			ymin = round(min(ylist) * image.size[1]) - 0.5
-			ymax = round(max(ylist) * image.size[1]) - 0.5
-			env.log(["\tSet size:", xmin, xmax, ymin, ymax], vv_only=True)
+            xlist, ylist = tuple([list(tup) for tup in zip(*shape)])
+            # not sure if I actually want to +0.5 to the values to get middle..
+            xmin = round(min(xlist) * image.size[0]) - 0.5
+            xmax = round(max(xlist) * image.size[0]) - 0.5
+            ymin = round(min(ylist) * image.size[1]) - 0.5
+            ymax = round(max(ylist) * image.size[1]) - 0.5
+            env.log(["\tSet size:", xmin, xmax, ymin, ymax], vv_only=True)
 
-			# assuming faces are roughly rectangular, sum pixels a face covers
-			asum = 0
-			acount = 0
-			for row in range(image.size[1]):
-				if row < ymin or row > ymax:
-					continue
-				for col in range(image.size[0]):
-					if col >= xmin and col <= xmax:
-						try:
-							asum += data[fnd][image.size[1] * row + col]
-							acount += 1
-						except IndexError as err:
-							print("Index error while parsing col {}, row {}: {}".format(
-								col, row, err))
+            # assuming faces are roughly rectangular, sum pixels a face covers
+            asum = 0
+            acount = 0
+            for row in range(image.size[1]):
+                if row < ymin or row > ymax:
+                    continue
+                for col in range(image.size[0]):
+                    if col >= xmin and col <= xmax:
+                        try:
+                            asum += data[fnd][image.size[1] * row + col]
+                            acount += 1
+                        except IndexError as err:
+                            print(
+                                "Index error while parsing col {}, row {}: {}".format(
+                                    col, row, err
+                                )
+                            )
 
-			if acount == 0:
-				acount = 1
-			ratio = float(asum) / float(acount)
-			if ratio < float(threshold):
-				print("\t{} - Below threshold, select".format(ratio))
-				f.select = True
-			else:
-				print("\t{} - above thresh, NO select".format(ratio))
-				f.select = False
-		return
+            if acount == 0:
+                acount = 1
+            ratio = float(asum) / float(acount)
+            if ratio < float(threshold):
+                print("\t{} - Below threshold, select".format(ratio))
+                f.select = True
+            else:
+                print("\t{} - above thresh, NO select".format(ratio))
+                f.select = False
+        return
 
 
 # -----------------------------------------------------------------------------
@@ -383,16 +397,16 @@ class MCPREP_OT_select_alpha_faces(bpy.types.Operator):
 
 
 classes = (
-	MCPREP_OT_scale_uv,
-	MCPREP_OT_select_alpha_faces,
+    MCPREP_OT_scale_uv,
+    MCPREP_OT_select_alpha_faces,
 )
 
 
 def register():
-	for cls in classes:
-		bpy.utils.register_class(cls)
+    for cls in classes:
+        bpy.utils.register_class(cls)
 
 
 def unregister():
-	for cls in reversed(classes):
-		bpy.utils.unregister_class(cls)
+    for cls in reversed(classes):
+        bpy.utils.unregister_class(cls)

--- a/MCprep_addon/mcprep_ui.py
+++ b/MCprep_addon/mcprep_ui.py
@@ -38,1818 +38,1860 @@ from .spawner import meshswap
 from .spawner import mobs
 from .spawner import spawn_util
 from .conf import env
+
 # from .import_bridge import bridge
 
 # blender 2.8 icon selections
-LOAD_FACTORY = 'LOOP_BACK'
-HAND_ICON = 'FILE_REFRESH'
-OPT_IN = 'URL'
+LOAD_FACTORY = "LOOP_BACK"
+HAND_ICON = "FILE_REFRESH"
+OPT_IN = "URL"
 
 
 def addon_just_updated():
-	"""Indicates an addon was updated mid session, to force a user restart.
+    """Indicates an addon was updated mid session, to force a user restart.
 
-	Put into UI calls, therefore called often and should lightweight.
-	"""
-	if addon_updater_ops.updater.invalid_updater:
-		return False
-	if not addon_updater_ops.updater.json:
-		return False
-	did_update = addon_updater_ops.updater.json.get("just_updated") is True
-	if did_update:
-		return True
+    Put into UI calls, therefore called often and should lightweight.
+    """
+    if addon_updater_ops.updater.invalid_updater:
+        return False
+    if not addon_updater_ops.updater.json:
+        return False
+    did_update = addon_updater_ops.updater.json.get("just_updated") is True
+    if did_update:
+        return True
 
-	# If not alreaedy flipped to be recongized as an update, do a slightly more
-	# thorough check by seeing if the mcprep_data_update.json exists (ie it
-	# hasn't been renamed yet to mcprep_data.json, which happens on init after
-	# an install/update)
-	check_interval = 5  # Time in seconds
-	if time.time() - check_interval > env.last_check_for_updated:
-		check_for_updated_files()
-		env.last_check_for_updated = time.time()
-	return
+    # If not alreaedy flipped to be recongized as an update, do a slightly more
+    # thorough check by seeing if the mcprep_data_update.json exists (ie it
+    # hasn't been renamed yet to mcprep_data.json, which happens on init after
+    # an install/update)
+    check_interval = 5  # Time in seconds
+    if time.time() - check_interval > env.last_check_for_updated:
+        check_for_updated_files()
+        env.last_check_for_updated = time.time()
+    return
 
 
 def check_for_updated_files():
-	"""Checks for a file which would only exist after an auto/manual update.
+    """Checks for a file which would only exist after an auto/manual update.
 
-	We check for the mcprep_data_update.json file, which would only exist after
-	an automated or manual update and before blender has been restarted. This
-	file is auto renamed to overwrite any existing mcprep_data.json file, but
-	that only runs on addon startup, so it's a good flag to use to force users
-	to restart.
+    We check for the mcprep_data_update.json file, which would only exist after
+    an automated or manual update and before blender has been restarted. This
+    file is auto renamed to overwrite any existing mcprep_data.json file, but
+    that only runs on addon startup, so it's a good flag to use to force users
+    to restart.
 
-	This covers the scenario where someone used the native blender install
-	addon *instead* of the auto updater route to update the addon.
-	"""
-	if os.path.isfile(env.json_path_update):
-		addon_updater_ops.updater.json["just_updated"] = True
+    This covers the scenario where someone used the native blender install
+    addon *instead* of the auto updater route to update the addon.
+    """
+    if os.path.isfile(env.json_path_update):
+        addon_updater_ops.updater.json["just_updated"] = True
 
 
 def restart_layout(layout):
-	"""Draws a restart button, used when addon_just_updated is true."""
-	box = layout.box()
-	col = box.column()
-	alert_row = col.row()
-	alert_row.alert = True
-	alert_row.operator(
-		"wm.quit_blender",
-		text="Restart blender",
-		icon="ERROR")
-	col.label(text="to complete update")
+    """Draws a restart button, used when addon_just_updated is true."""
+    box = layout.box()
+    col = box.column()
+    alert_row = col.row()
+    alert_row.alert = True
+    alert_row.operator("wm.quit_blender", text="Restart blender", icon="ERROR")
+    col.label(text="to complete update")
 
 
 # -----------------------------------------------------------------------------
 # UI class functions
 # -----------------------------------------------------------------------------
 
+
 class MCPREP_MT_mob_spawner(bpy.types.Menu):
-	"""Shift-A menu in the 3D view"""
-	bl_label = "Mob Spawner"
-	bl_idname = "MCPREP_MT_mob_spawner"
-	bl_description = "Menu for placing in the shift-A add object menu"
+    """Shift-A menu in the 3D view"""
 
-	def draw(self, context):
-		layout = self.layout
-		scn_props = context.scene.mcprep_props
+    bl_label = "Mob Spawner"
+    bl_idname = "MCPREP_MT_mob_spawner"
+    bl_description = "Menu for placing in the shift-A add object menu"
 
-		# if mobs not loaded yet
-		if not scn_props.mob_list_all:
-			row = layout.row()
-			row.operator(
-				"mcprep.reload_mobs", text="Load mobs", icon=HAND_ICON)
-			row.scale_y = 2
-			row.alignment = 'CENTER'
-			return
+    def draw(self, context):
+        layout = self.layout
+        scn_props = context.scene.mcprep_props
 
-		keys = sorted(scn_props.mob_list_all.keys())
-		for mobkey in keys:
-			# show icon if available
-			mob = scn_props.mob_list_all[mobkey]
-			icn = "mob-{}".format(mob.index)
-			if env.use_icons and icn in env.preview_collections["mobs"]:
-				ops = layout.operator(
-					"mcprep.mob_spawner",
-					text=mob.name,
-					icon_value=env.preview_collections["mobs"][icn].icon_id)
-			elif env.use_icons:
-				ops = layout.operator(
-					"mcprep.mob_spawner", text=mob.name, icon="BLANK1")
-			else:
-				ops = layout.operator("mcprep.mob_spawner", text=mob.name)
-			ops.mcmob_type = mob.mcmob_type
+        # if mobs not loaded yet
+        if not scn_props.mob_list_all:
+            row = layout.row()
+            row.operator("mcprep.reload_mobs", text="Load mobs", icon=HAND_ICON)
+            row.scale_y = 2
+            row.alignment = "CENTER"
+            return
 
-			# Skip prep materials in case of unique shader.
-			if env.json_data and mob.name in env.json_data.get("mob_skip_prep", []):
-				ops.prep_materials = False
+        keys = sorted(scn_props.mob_list_all.keys())
+        for mobkey in keys:
+            # show icon if available
+            mob = scn_props.mob_list_all[mobkey]
+            icn = "mob-{}".format(mob.index)
+            if env.use_icons and icn in env.preview_collections["mobs"]:
+                ops = layout.operator(
+                    "mcprep.mob_spawner",
+                    text=mob.name,
+                    icon_value=env.preview_collections["mobs"][icn].icon_id,
+                )
+            elif env.use_icons:
+                ops = layout.operator(
+                    "mcprep.mob_spawner", text=mob.name, icon="BLANK1"
+                )
+            else:
+                ops = layout.operator("mcprep.mob_spawner", text=mob.name)
+            ops.mcmob_type = mob.mcmob_type
+
+            # Skip prep materials in case of unique shader.
+            if env.json_data and mob.name in env.json_data.get("mob_skip_prep", []):
+                ops.prep_materials = False
 
 
 class MCPREP_MT_meshswap_place(bpy.types.Menu):
-	"""Menu for all the meshswap objects"""
-	bl_label = "Meshswap Objects"
-	bl_idname = "MCPREP_MT_meshswap_place"
+    """Menu for all the meshswap objects"""
 
-	def draw(self, context):
-		layout = self.layout
-		meshswap_blocks = meshswap.getMeshswapList(context)
-		if not meshswap_blocks:
-			layout.label(text="No meshswap blocks found!")
-		for blockset in meshswap_blocks:
-			# do some kind of check for if no blocks found
-			icn = "BLANK1"
-			if blockset[0].startswith("Group"):
-				icn = "GROUP"
+    bl_label = "Meshswap Objects"
+    bl_idname = "MCPREP_MT_meshswap_place"
 
-			opr = layout.operator(
-				"mcprep.meshswap_spawner",
-				text=blockset[1],
-				icon=icn
-			)
-			opr.block = blockset[0]
-			opr.location = util.get_cuser_location(context)
+    def draw(self, context):
+        layout = self.layout
+        meshswap_blocks = meshswap.getMeshswapList(context)
+        if not meshswap_blocks:
+            layout.label(text="No meshswap blocks found!")
+        for blockset in meshswap_blocks:
+            # do some kind of check for if no blocks found
+            icn = "BLANK1"
+            if blockset[0].startswith("Group"):
+                icn = "GROUP"
 
-			# Ensure meshswap with rigs is made real, so the rigs can be used.
-			if env.json_data and blockset[1] in env.json_data.get("make_real", []):
-				opr.make_real = True
+            opr = layout.operator("mcprep.meshswap_spawner", text=blockset[1], icon=icn)
+            opr.block = blockset[0]
+            opr.location = util.get_cuser_location(context)
+
+            # Ensure meshswap with rigs is made real, so the rigs can be used.
+            if env.json_data and blockset[1] in env.json_data.get("make_real", []):
+                opr.make_real = True
 
 
 class MCPREP_MT_item_spawn(bpy.types.Menu):
-	"""Menu for loaded item spawners"""
-	bl_label = "Item Spawner"
-	bl_idname = "MCPREP_MT_item_spawn"
+    """Menu for loaded item spawners"""
 
-	def draw(self, context):
-		layout = self.layout
-		if not context.scene.mcprep_props.item_list:
-			layout.label(text="No items found!")
-		for item in context.scene.mcprep_props.item_list:
-			icn = "item-{}".format(item.index)
-			if env.use_icons and icn in env.preview_collections["items"]:
-				ops = layout.operator(
-					"mcprep.spawn_item", text=item.name,
-					icon_value=env.preview_collections["items"][icn].icon_id)
-			elif env.use_icons:
-				ops = layout.operator(
-					"mcprep.spawn_item", text=item.name, icon="BLANK1")
-			else:
-				ops = layout.operator("mcprep.spawn_item", text=item.name)
-			ops.filepath = item.path
+    bl_label = "Item Spawner"
+    bl_idname = "MCPREP_MT_item_spawn"
+
+    def draw(self, context):
+        layout = self.layout
+        if not context.scene.mcprep_props.item_list:
+            layout.label(text="No items found!")
+        for item in context.scene.mcprep_props.item_list:
+            icn = "item-{}".format(item.index)
+            if env.use_icons and icn in env.preview_collections["items"]:
+                ops = layout.operator(
+                    "mcprep.spawn_item",
+                    text=item.name,
+                    icon_value=env.preview_collections["items"][icn].icon_id,
+                )
+            elif env.use_icons:
+                ops = layout.operator(
+                    "mcprep.spawn_item", text=item.name, icon="BLANK1"
+                )
+            else:
+                ops = layout.operator("mcprep.spawn_item", text=item.name)
+            ops.filepath = item.path
 
 
 class MCPREP_MT_effect_spawn(bpy.types.Menu):
-	"""Menu for loaded effect spawners"""
-	bl_label = "Effects Spawner"
-	bl_idname = "MCPREP_MT_effect_spawn"
+    """Menu for loaded effect spawners"""
 
-	def draw(self, context):
-		col = self.layout.column()
-		loc = util.get_cuser_location(context)
-		for effect in context.scene.mcprep_props.effects_list:
-			if effect.effect_type in (effects.GEO_AREA, effects.PARTICLE_AREA):
-				if effect.effect_type == effects.GEO_AREA:
-					icon = "NODETREE"
-				else:
-					icon = "PARTICLES"
-				ops = col.operator(
-					"mcprep.spawn_global_effect",
-					text=effect.name,
-					icon=icon)
-				ops.effect_id = str(effect.index)
-			elif effect.effect_type == effects.COLLECTION:
-				ops = col.operator(
-					"mcprep.spawn_instant_effect",
-					text=effect.name, icon=spawn_util.COLL_ICON)
-				ops.effect_id = str(effect.index)
-				ops.location = loc
-				ops.frame = context.scene.frame_current
-			elif effect.effect_type == effects.IMG_SEQ:
-				icon = "effects-{}".format(effect.index)
-				if env.use_icons and icon in env.preview_collections["effects"]:
-					ops = col.operator(
-						"mcprep.spawn_instant_effect",
-						text=effect.name,
-						icon_value=env.preview_collections["effects"][icon].icon_id)
-				else:
-					ops = col.operator(
-						"mcprep.spawn_instant_effect",
-						text=effect.name,
-						icon="RENDER_RESULT")
-				ops.effect_id = str(effect.index)
-				ops.location = loc
-				ops.frame = context.scene.frame_current
+    bl_label = "Effects Spawner"
+    bl_idname = "MCPREP_MT_effect_spawn"
+
+    def draw(self, context):
+        col = self.layout.column()
+        loc = util.get_cuser_location(context)
+        for effect in context.scene.mcprep_props.effects_list:
+            if effect.effect_type in (effects.GEO_AREA, effects.PARTICLE_AREA):
+                if effect.effect_type == effects.GEO_AREA:
+                    icon = "NODETREE"
+                else:
+                    icon = "PARTICLES"
+                ops = col.operator(
+                    "mcprep.spawn_global_effect", text=effect.name, icon=icon
+                )
+                ops.effect_id = str(effect.index)
+            elif effect.effect_type == effects.COLLECTION:
+                ops = col.operator(
+                    "mcprep.spawn_instant_effect",
+                    text=effect.name,
+                    icon=spawn_util.COLL_ICON,
+                )
+                ops.effect_id = str(effect.index)
+                ops.location = loc
+                ops.frame = context.scene.frame_current
+            elif effect.effect_type == effects.IMG_SEQ:
+                icon = "effects-{}".format(effect.index)
+                if env.use_icons and icon in env.preview_collections["effects"]:
+                    ops = col.operator(
+                        "mcprep.spawn_instant_effect",
+                        text=effect.name,
+                        icon_value=env.preview_collections["effects"][icon].icon_id,
+                    )
+                else:
+                    ops = col.operator(
+                        "mcprep.spawn_instant_effect",
+                        text=effect.name,
+                        icon="RENDER_RESULT",
+                    )
+                ops.effect_id = str(effect.index)
+                ops.location = loc
+                ops.frame = context.scene.frame_current
 
 
 class MCPREP_MT_entity_spawn(bpy.types.Menu):
-	"""Menu for loaded entity spawners"""
-	bl_label = "Entity Spawner"
-	bl_idname = "MCPREP_MT_entity_spawn"
+    """Menu for loaded entity spawners"""
 
-	def draw(self, context):
-		layout = self.layout
-		entity_list = entities.getEntityList(context)
-		if not entity_list:
-			layout.label(text="No entities found!")
-		for entity in entity_list:
-			# do some kind of check for if no entities found
-			icn = "BLANK1"
-			if entity[0].startswith("Group"):
-				icn = "GROUP"
+    bl_label = "Entity Spawner"
+    bl_idname = "MCPREP_MT_entity_spawn"
 
-			opr = layout.operator(
-				"mcprep.entity_spawner",
-				text=entity[1],
-				icon=icn)
-			opr.entity = entity[0]
+    def draw(self, context):
+        layout = self.layout
+        entity_list = entities.getEntityList(context)
+        if not entity_list:
+            layout.label(text="No entities found!")
+        for entity in entity_list:
+            # do some kind of check for if no entities found
+            icn = "BLANK1"
+            if entity[0].startswith("Group"):
+                icn = "GROUP"
+
+            opr = layout.operator("mcprep.entity_spawner", text=entity[1], icon=icn)
+            opr.entity = entity[0]
 
 
 class MCPREP_MT_model_spawn(bpy.types.Menu):
-	"""Menu for loaded model spawners"""
-	bl_label = "Model Spawner"
-	bl_idname = "MCPREP_MT_model_spawn"
+    """Menu for loaded model spawners"""
 
-	def draw(self, context):
-		layout = self.layout
-		if not context.scene.mcprep_props.model_list:
-			layout.label(text="No models found!")
-		for model in context.scene.mcprep_props.model_list:
-			opr = layout.operator(
-				mcmodel.MCPREP_OT_spawn_minecraft_model.bl_idname,
-				text=model.name)
-			opr.filepath = model.filepath
-			opr.location = util.get_cuser_location(context)
+    bl_label = "Model Spawner"
+    bl_idname = "MCPREP_MT_model_spawn"
+
+    def draw(self, context):
+        layout = self.layout
+        if not context.scene.mcprep_props.model_list:
+            layout.label(text="No models found!")
+        for model in context.scene.mcprep_props.model_list:
+            opr = layout.operator(
+                mcmodel.MCPREP_OT_spawn_minecraft_model.bl_idname, text=model.name
+            )
+            opr.filepath = model.filepath
+            opr.location = util.get_cuser_location(context)
 
 
 class MCPREP_MT_3dview_add(bpy.types.Menu):
-	"""MCprep Shift-A menu for spawners"""
-	bl_label = "MCprep"
-	bl_idname = "MCPREP_MT_3dview_add"
+    """MCprep Shift-A menu for spawners"""
 
-	def draw(self, context):
-		if addon_just_updated():
-			restart_layout(self.layout)
-			return
-		layout = self.layout
-		props = context.scene.mcprep_props
+    bl_label = "MCprep"
+    bl_idname = "MCPREP_MT_3dview_add"
 
-		if env.preview_collections["main"] != "":
-			spawner_icon = env.preview_collections["main"].get("spawner_icon")
-			meshswap_icon = env.preview_collections["main"].get("meshswap_icon")
-			sword_icon = env.preview_collections["main"].get("sword_icon")
-			effects_icon = env.preview_collections["main"].get("effects_icon")
-			entity_icon = env.preview_collections["main"].get("entity_icon")
-			model_icon = env.preview_collections["main"].get("model_icon")
-		else:
-			spawner_icon = None
-			meshswap_icon = None
-			sword_icon = None
-			effects_icon = None
-			entity_icon = None
-			model_icon = None
+    def draw(self, context):
+        if addon_just_updated():
+            restart_layout(self.layout)
+            return
+        layout = self.layout
+        props = context.scene.mcprep_props
 
-		all_loaded = props.mob_list and props.meshswap_list and props.item_list
-		if not env.loaded_all_spawners and not all_loaded:
-			row = layout.row()
-			row.operator(
-				"mcprep.reload_spawners", text="Load spawners", icon=HAND_ICON)
-			row.scale_y = 2
-			row.alignment = 'CENTER'
-			return
+        if env.preview_collections["main"] != "":
+            spawner_icon = env.preview_collections["main"].get("spawner_icon")
+            meshswap_icon = env.preview_collections["main"].get("meshswap_icon")
+            sword_icon = env.preview_collections["main"].get("sword_icon")
+            effects_icon = env.preview_collections["main"].get("effects_icon")
+            entity_icon = env.preview_collections["main"].get("entity_icon")
+            model_icon = env.preview_collections["main"].get("model_icon")
+        else:
+            spawner_icon = None
+            meshswap_icon = None
+            sword_icon = None
+            effects_icon = None
+            entity_icon = None
+            model_icon = None
 
-		if spawner_icon is not None:
-			layout.menu(
-				MCPREP_MT_mob_spawner.bl_idname,
-				icon_value=spawner_icon.icon_id)
-		else:
-			layout.menu(MCPREP_MT_mob_spawner.bl_idname)
+        all_loaded = props.mob_list and props.meshswap_list and props.item_list
+        if not env.loaded_all_spawners and not all_loaded:
+            row = layout.row()
+            row.operator("mcprep.reload_spawners", text="Load spawners", icon=HAND_ICON)
+            row.scale_y = 2
+            row.alignment = "CENTER"
+            return
 
-		if model_icon is not None:
-			layout.menu(
-				MCPREP_MT_model_spawn.bl_idname, icon_value=model_icon.icon_id)
-		else:
-			layout.menu(MCPREP_MT_model_spawn.bl_idname)
+        if spawner_icon is not None:
+            layout.menu(
+                MCPREP_MT_mob_spawner.bl_idname, icon_value=spawner_icon.icon_id
+            )
+        else:
+            layout.menu(MCPREP_MT_mob_spawner.bl_idname)
 
-		if sword_icon is not None:
-			layout.menu(
-				MCPREP_MT_item_spawn.bl_idname, icon_value=sword_icon.icon_id)
-		else:
-			layout.menu(MCPREP_MT_item_spawn.bl_idname)
+        if model_icon is not None:
+            layout.menu(MCPREP_MT_model_spawn.bl_idname, icon_value=model_icon.icon_id)
+        else:
+            layout.menu(MCPREP_MT_model_spawn.bl_idname)
 
-		if effects_icon is not None:
-			layout.menu(
-				MCPREP_MT_effect_spawn.bl_idname, icon_value=effects_icon.icon_id)
-		else:
-			layout.menu(MCPREP_MT_effect_spawn.bl_idname)
+        if sword_icon is not None:
+            layout.menu(MCPREP_MT_item_spawn.bl_idname, icon_value=sword_icon.icon_id)
+        else:
+            layout.menu(MCPREP_MT_item_spawn.bl_idname)
 
-		if entity_icon is not None:
-			layout.menu(
-				MCPREP_MT_entity_spawn.bl_idname, icon_value=entity_icon.icon_id)
-		else:
-			layout.menu(MCPREP_MT_entity_spawn.bl_idname)
+        if effects_icon is not None:
+            layout.menu(
+                MCPREP_MT_effect_spawn.bl_idname, icon_value=effects_icon.icon_id
+            )
+        else:
+            layout.menu(MCPREP_MT_effect_spawn.bl_idname)
 
-		if meshswap_icon is not None:
-			layout.menu(
-				MCPREP_MT_meshswap_place.bl_idname,
-				icon_value=meshswap_icon.icon_id)
-		else:
-			layout.menu(MCPREP_MT_meshswap_place.bl_idname)
+        if entity_icon is not None:
+            layout.menu(
+                MCPREP_MT_entity_spawn.bl_idname, icon_value=entity_icon.icon_id
+            )
+        else:
+            layout.menu(MCPREP_MT_entity_spawn.bl_idname)
+
+        if meshswap_icon is not None:
+            layout.menu(
+                MCPREP_MT_meshswap_place.bl_idname, icon_value=meshswap_icon.icon_id
+            )
+        else:
+            layout.menu(MCPREP_MT_meshswap_place.bl_idname)
 
 
 def mineways_update(self, context):
-	"""For updating the mineways path on OSX."""
-	if ".app/" in self.open_mineways_path:
-		# will run twice inherently
-		temp = self.open_mineways_path.split(".app/")[0]
-		self.open_mineways_path = temp + ".app"
+    """For updating the mineways path on OSX."""
+    if ".app/" in self.open_mineways_path:
+        # will run twice inherently
+        temp = self.open_mineways_path.split(".app/")[0]
+        self.open_mineways_path = temp + ".app"
 
 
 def feature_set_update(self, context):
-	tracking.Tracker.feature_set = self.feature_set
-	tracking.trackUsage("feature_set", param=self.feature_set)
+    tracking.Tracker.feature_set = self.feature_set
+    tracking.trackUsage("feature_set", param=self.feature_set)
 
 
 class McprepPreference(bpy.types.AddonPreferences):
-	bl_idname = __package__
-	scriptdir = bpy.path.abspath(os.path.dirname(__file__))
+    bl_idname = __package__
+    scriptdir = bpy.path.abspath(os.path.dirname(__file__))
 
-	def change_verbose(self, context):
-		env.verbose = self.verbose
+    def change_verbose(self, context):
+        env.verbose = self.verbose
 
-	meshswap_path: bpy.props.StringProperty(
-		name="Meshswap path",
-		description=(
-			"Default path to the meshswap asset file, for "
-			"meshswapable objects and groups"),
-		subtype='FILE_PATH',
-		default=scriptdir + "/MCprep_resources/mcprep_meshSwap.blend")
-	entity_path: bpy.props.StringProperty(
-		name="Entity path",
-		description="Default path to the entity asset file, for entities",
-		subtype='FILE_PATH',
-		default=os.path.join(scriptdir, "MCprep_resources", "mcprep_entities.blend"))
-	mob_path: bpy.props.StringProperty(
-		name="Mob path",
-		description="Default folder for rig loads/spawns in new blender instances",
-		subtype='DIR_PATH',
-		default=scriptdir + "/MCprep_resources/rigs/")
-	custom_texturepack_path: bpy.props.StringProperty(
-		name="Texture pack path",
-		description=(
-			"Path to a folder containing resources and textures to use "
-			"with material prepping"),
-		subtype='DIR_PATH',
-		default=scriptdir + "/MCprep_resources/resourcepacks/mcprep_default/")
-	skin_path: bpy.props.StringProperty(
-		name="Skin path",
-		description="Folder for skin textures, used in skin swapping",
-		subtype='DIR_PATH',
-		default=scriptdir + "/MCprep_resources/skins/")
-	effects_path: bpy.props.StringProperty(
-		name="Effects path",
-		description="Folder for effects blend files and assets",
-		subtype='DIR_PATH',
-		default=scriptdir + "/MCprep_resources/effects/")
-	world_obj_path: bpy.props.StringProperty(
-		name="World Folder",
-		description=(
-			"Default folder for opening world objs from programs "
-			"like jmc2obj or Mineways"),
-		subtype='DIR_PATH',
-		default="//")
-	MCprep_groupAppendLayer: bpy.props.IntProperty(
-		name="Group Append Layer",
-		description=(
-			"When groups are appended instead of linked, "
-			"the objects part of the group will be placed in this "
-			"layer, 0 means same as active layer"),
-		min=0,
-		max=20,
-		default=20)
-	MCprep_exporter_type: bpy.props.EnumProperty(
-		items=[
-			('(choose)', '(choose)', 'Select your exporter'),
-			('jmc2obj', 'jmc2obj', 'Select if exporter used was jmc2obj'),
-			('Mineways', 'Mineways', 'Select if exporter used was Mineways')],
-		name="Exporter")
-	preferences_tab: bpy.props.EnumProperty(
-		items=[
-			('settings', 'Settings', 'Change MCprep settings'),
-			('tutorials', 'Tutorials', 'View MCprep tutorials & other help'),
-			('tracker_updater', 'Tracking/Updater',
-				'Change tracking and updating settings')],
-		name="Exporter")
-	verbose: bpy.props.BoolProperty(
-		name="Verbose logging",
-		description="Print out more information in the console",
-		default=False,
-		update=change_verbose)
-	open_jmc2obj_path: bpy.props.StringProperty(
-		name="jmc2obj path",
-		description="Path to the jmc2obj executable",
-		subtype='FILE_PATH',
-		default="jmc2obj.jar")
-	open_mineways_path: bpy.props.StringProperty(
-		name="Mineways path",
-		description="Path to the Mineways executable",
-		subtype='FILE_PATH',
-		update=mineways_update,
-		default="Mineways")
-	save_folder: bpy.props.StringProperty(
-		name="MC saves folder",
-		description=(
-			"Folder containing Minecraft world saves directories, "
-			"for the direct import bridge"),
-		subtype='FILE_PATH',
-		default='')
-	feature_set: bpy.props.EnumProperty(
-		items=[
-			('supported', 'Supported', 'Use only supported features'),
-			('experimental', 'Experimental', 'Enable experimental features')],
-		name="Feature set",
-		update=feature_set_update)
+    meshswap_path: bpy.props.StringProperty(
+        name="Meshswap path",
+        description=(
+            "Default path to the meshswap asset file, for "
+            "meshswapable objects and groups"
+        ),
+        subtype="FILE_PATH",
+        default=scriptdir + "/MCprep_resources/mcprep_meshSwap.blend",
+    )
+    entity_path: bpy.props.StringProperty(
+        name="Entity path",
+        description="Default path to the entity asset file, for entities",
+        subtype="FILE_PATH",
+        default=os.path.join(scriptdir, "MCprep_resources", "mcprep_entities.blend"),
+    )
+    mob_path: bpy.props.StringProperty(
+        name="Mob path",
+        description="Default folder for rig loads/spawns in new blender instances",
+        subtype="DIR_PATH",
+        default=scriptdir + "/MCprep_resources/rigs/",
+    )
+    custom_texturepack_path: bpy.props.StringProperty(
+        name="Texture pack path",
+        description=(
+            "Path to a folder containing resources and textures to use "
+            "with material prepping"
+        ),
+        subtype="DIR_PATH",
+        default=scriptdir + "/MCprep_resources/resourcepacks/mcprep_default/",
+    )
+    skin_path: bpy.props.StringProperty(
+        name="Skin path",
+        description="Folder for skin textures, used in skin swapping",
+        subtype="DIR_PATH",
+        default=scriptdir + "/MCprep_resources/skins/",
+    )
+    effects_path: bpy.props.StringProperty(
+        name="Effects path",
+        description="Folder for effects blend files and assets",
+        subtype="DIR_PATH",
+        default=scriptdir + "/MCprep_resources/effects/",
+    )
+    world_obj_path: bpy.props.StringProperty(
+        name="World Folder",
+        description=(
+            "Default folder for opening world objs from programs "
+            "like jmc2obj or Mineways"
+        ),
+        subtype="DIR_PATH",
+        default="//",
+    )
+    MCprep_groupAppendLayer: bpy.props.IntProperty(
+        name="Group Append Layer",
+        description=(
+            "When groups are appended instead of linked, "
+            "the objects part of the group will be placed in this "
+            "layer, 0 means same as active layer"
+        ),
+        min=0,
+        max=20,
+        default=20,
+    )
+    MCprep_exporter_type: bpy.props.EnumProperty(
+        items=[
+            ("(choose)", "(choose)", "Select your exporter"),
+            ("jmc2obj", "jmc2obj", "Select if exporter used was jmc2obj"),
+            ("Mineways", "Mineways", "Select if exporter used was Mineways"),
+        ],
+        name="Exporter",
+    )
+    preferences_tab: bpy.props.EnumProperty(
+        items=[
+            ("settings", "Settings", "Change MCprep settings"),
+            ("tutorials", "Tutorials", "View MCprep tutorials & other help"),
+            (
+                "tracker_updater",
+                "Tracking/Updater",
+                "Change tracking and updating settings",
+            ),
+        ],
+        name="Exporter",
+    )
+    verbose: bpy.props.BoolProperty(
+        name="Verbose logging",
+        description="Print out more information in the console",
+        default=False,
+        update=change_verbose,
+    )
+    open_jmc2obj_path: bpy.props.StringProperty(
+        name="jmc2obj path",
+        description="Path to the jmc2obj executable",
+        subtype="FILE_PATH",
+        default="jmc2obj.jar",
+    )
+    open_mineways_path: bpy.props.StringProperty(
+        name="Mineways path",
+        description="Path to the Mineways executable",
+        subtype="FILE_PATH",
+        update=mineways_update,
+        default="Mineways",
+    )
+    save_folder: bpy.props.StringProperty(
+        name="MC saves folder",
+        description=(
+            "Folder containing Minecraft world saves directories, "
+            "for the direct import bridge"
+        ),
+        subtype="FILE_PATH",
+        default="",
+    )
+    feature_set: bpy.props.EnumProperty(
+        items=[
+            ("supported", "Supported", "Use only supported features"),
+            ("experimental", "Experimental", "Enable experimental features"),
+        ],
+        name="Feature set",
+        update=feature_set_update,
+    )
 
-	# addon updater preferences
+    # addon updater preferences
 
-	auto_check_update: bpy.props.BoolProperty(
-		name="Auto-check for Update",
-		description="If enabled, auto-check for updates using an interval",
-		default=True,
-	)
-	updater_interval_months: bpy.props.IntProperty(
-		name='Months',
-		description="Number of months between checking for updates",
-		default=0,
-		min=0
-	)
-	updater_interval_days: bpy.props.IntProperty(
-		name='Days',
-		description="Number of days between checking for updates",
-		default=1,
-		min=0,
-	)
-	updater_interval_hours: bpy.props.IntProperty(
-		name='Hours',
-		description="Number of hours between checking for updates",
-		default=0,
-		min=0,
-		max=23
-	)
-	updater_interval_minutes: bpy.props.IntProperty(
-		name='Minutes',
-		description="Number of minutes between checking for updates",
-		default=0,
-		min=0,
-		max=59
-	)
+    auto_check_update: bpy.props.BoolProperty(
+        name="Auto-check for Update",
+        description="If enabled, auto-check for updates using an interval",
+        default=True,
+    )
+    updater_interval_months: bpy.props.IntProperty(
+        name="Months",
+        description="Number of months between checking for updates",
+        default=0,
+        min=0,
+    )
+    updater_interval_days: bpy.props.IntProperty(
+        name="Days",
+        description="Number of days between checking for updates",
+        default=1,
+        min=0,
+    )
+    updater_interval_hours: bpy.props.IntProperty(
+        name="Hours",
+        description="Number of hours between checking for updates",
+        default=0,
+        min=0,
+        max=23,
+    )
+    updater_interval_minutes: bpy.props.IntProperty(
+        name="Minutes",
+        description="Number of minutes between checking for updates",
+        default=0,
+        min=0,
+        max=59,
+    )
 
-	def draw(self, context):
-		layout = self.layout
-		row = layout.row()
-		row.prop(self, "preferences_tab", expand=True)
+    def draw(self, context):
+        layout = self.layout
+        row = layout.row()
+        row.prop(self, "preferences_tab", expand=True)
 
-		factor_width = 0.3
+        factor_width = 0.3
 
-		if self.preferences_tab == "settings":
+        if self.preferences_tab == "settings":
+            row = layout.row()
+            row.scale_y = 0.7
+            row.label(text="World Importing & Meshswapping")
+            box = layout.box()
+            split = util.layout_split(box, factor=factor_width)
+            col = split.column()
+            col.label(text="Default Exporter:")
+            col = split.column()
+            col.prop(self, "MCprep_exporter_type", text="")
+            split = util.layout_split(box, factor=factor_width)
+            col = split.column()
+            col.label(text="jmc2obj executable")
+            col = split.column()
+            col.prop(self, "open_jmc2obj_path", text="")
+            split = util.layout_split(box, factor=factor_width)
+            col = split.column()
+            col.label(text="Mineways executable")
+            col = split.column()
+            col.prop(self, "open_mineways_path", text="")
+            split = util.layout_split(box, factor=factor_width)
+            col = split.column()
+            col.label(text="World OBJ Exports Folder")
+            col = split.column()
+            col.prop(self, "world_obj_path", text="")
+            split = util.layout_split(box, factor=factor_width)
+            col = split.column()
+            col.label(text="Meshwap assets")
+            col = split.column()
+            col.prop(self, "meshswap_path", text="")
 
-			row = layout.row()
-			row.scale_y = 0.7
-			row.label(text="World Importing & Meshswapping")
-			box = layout.box()
-			split = util.layout_split(box, factor=factor_width)
-			col = split.column()
-			col.label(text="Default Exporter:")
-			col = split.column()
-			col.prop(self, "MCprep_exporter_type", text="")
-			split = util.layout_split(box, factor=factor_width)
-			col = split.column()
-			col.label(text="jmc2obj executable")
-			col = split.column()
-			col.prop(self, "open_jmc2obj_path", text="")
-			split = util.layout_split(box, factor=factor_width)
-			col = split.column()
-			col.label(text="Mineways executable")
-			col = split.column()
-			col.prop(self, "open_mineways_path", text="")
-			split = util.layout_split(box, factor=factor_width)
-			col = split.column()
-			col.label(text="World OBJ Exports Folder")
-			col = split.column()
-			col.prop(self, "world_obj_path", text="")
-			split = util.layout_split(box, factor=factor_width)
-			col = split.column()
-			col.label(text="Meshwap assets")
-			col = split.column()
-			col.prop(self, "meshswap_path", text="")
+            if not os.path.isfile(bpy.path.abspath(self.meshswap_path)):
+                row = box.row()
+                row.label(text="MeshSwap file not found", icon="ERROR")
 
-			if not os.path.isfile(bpy.path.abspath(self.meshswap_path)):
-				row = box.row()
-				row.label(text="MeshSwap file not found", icon="ERROR")
+            split = util.layout_split(box, factor=factor_width)
+            col = split.column()
+            col.label(text="Entity assets")
 
-			split = util.layout_split(box, factor=factor_width)
-			col = split.column()
-			col.label(text="Entity assets")
+            col = split.column()
+            col.prop(self, "entity_path", text="")
+            if not os.path.isfile(bpy.path.abspath(self.entity_path)):
+                row = box.row()
+                row.label(text="Entity file not found", icon="ERROR")
 
-			col = split.column()
-			col.prop(self, "entity_path", text="")
-			if not os.path.isfile(bpy.path.abspath(self.entity_path)):
-				row = box.row()
-				row.label(text="Entity file not found", icon="ERROR")
+            col = split.column()
+            col.prop(self, "effects_path", text="")
+            if not os.path.isdir(bpy.path.abspath(self.effects_path)):
+                row = box.row()
+                row.label(text="Effects folder not found", icon="ERROR")
 
-			col = split.column()
-			col.prop(self, "effects_path", text="")
-			if not os.path.isdir(bpy.path.abspath(self.effects_path)):
-				row = box.row()
-				row.label(text="Effects folder not found", icon="ERROR")
+            row = layout.row()
+            row.scale_y = 0.7
+            row.label(text="Texture / Resource packs")
+            box = layout.box()
+            split = util.layout_split(box, factor=factor_width)
+            col = split.column()
+            col.label(text="Texture pack folder")
+            col = split.column()
+            col.prop(self, "custom_texturepack_path", text="")
+            split = util.layout_split(box, factor=factor_width)
+            col = split.column()
+            col.label(text="Install to folder")
+            # col = split.column()
+            # col.operator("mcprep.skin_swapper", text="Install resource pack")
+            col = split.column()
+            p = col.operator("mcprep.openfolder", text="Open texture pack folder")
+            p.folder = self.custom_texturepack_path
 
-			row = layout.row()
-			row.scale_y = 0.7
-			row.label(text="Texture / Resource packs")
-			box = layout.box()
-			split = util.layout_split(box, factor=factor_width)
-			col = split.column()
-			col.label(text="Texture pack folder")
-			col = split.column()
-			col.prop(self, "custom_texturepack_path", text="")
-			split = util.layout_split(box, factor=factor_width)
-			col = split.column()
-			col.label(text="Install to folder")
-			# col = split.column()
-			# col.operator("mcprep.skin_swapper", text="Install resource pack")
-			col = split.column()
-			p = col.operator("mcprep.openfolder", text="Open texture pack folder")
-			p.folder = self.custom_texturepack_path
+            row = layout.row()
+            row.scale_y = 0.7
+            row.label(text="Mob spawning")
+            box = layout.box()
+            split = util.layout_split(box, factor=factor_width)
+            col = split.column()
+            col.label(text="Rig Folder")
+            col = split.column()
+            col.prop(self, "mob_path", text="")
+            split = util.layout_split(box, factor=factor_width)
+            col = split.column()
+            col.label(text="Select/install mobs")
+            col = split.column()
+            col.operator(
+                "mcprep.mob_install_menu", text="Install file for mob spawning"
+            )
+            col = split.column()
+            p = col.operator("mcprep.openfolder", text="Open rig folder")
+            p.folder = self.mob_path
 
-			row = layout.row()
-			row.scale_y = 0.7
-			row.label(text="Mob spawning")
-			box = layout.box()
-			split = util.layout_split(box, factor=factor_width)
-			col = split.column()
-			col.label(text="Rig Folder")
-			col = split.column()
-			col.prop(self, "mob_path", text="")
-			split = util.layout_split(box, factor=factor_width)
-			col = split.column()
-			col.label(text="Select/install mobs")
-			col = split.column()
-			col.operator(
-				"mcprep.mob_install_menu", text="Install file for mob spawning")
-			col = split.column()
-			p = col.operator("mcprep.openfolder", text="Open rig folder")
-			p.folder = self.mob_path
+            row = layout.row()
+            row.scale_y = 0.7
+            row.label(text="Skin swapping")
+            box = layout.box()
+            split = util.layout_split(box, factor=factor_width)
+            col = split.column()
+            col.label(text="Skin Folder")
+            col = split.column()
+            col.prop(self, "skin_path", text="")
+            split = util.layout_split(box, factor=factor_width)
+            col = split.column()
+            col.label(text="Install skins")
+            col = split.column()
+            col.operator("mcprep.add_skin", text="Install skin file for swapping")
+            col = split.column()
+            p = col.operator("mcprep.openfolder", text="Open skin folder")
+            p.folder = self.skin_path
 
-			row = layout.row()
-			row.scale_y = 0.7
-			row.label(text="Skin swapping")
-			box = layout.box()
-			split = util.layout_split(box, factor=factor_width)
-			col = split.column()
-			col.label(text="Skin Folder")
-			col = split.column()
-			col.prop(self, "skin_path", text="")
-			split = util.layout_split(box, factor=factor_width)
-			col = split.column()
-			col.label(text="Install skins")
-			col = split.column()
-			col.operator("mcprep.add_skin", text="Install skin file for swapping")
-			col = split.column()
-			p = col.operator("mcprep.openfolder", text="Open skin folder")
-			p.folder = self.skin_path
+            row = layout.row()
+            row.scale_y = 0.7
+            row.label(text="Effects")
+            box = layout.box()
+            split = util.layout_split(box, factor=factor_width)
+            col = split.column()
+            col.label(text="Effect folder")
+            col = split.column()
+            col.prop(self, "effects_path", text="")
+            split = util.layout_split(box, factor=factor_width)
+            col = split.column()
+            col = split.column()
+            p = col.operator("mcprep.openfolder", text="Open effects folder")
+            p.folder = self.effects_path
 
-			row = layout.row()
-			row.scale_y = 0.7
-			row.label(text="Effects")
-			box = layout.box()
-			split = util.layout_split(box, factor=factor_width)
-			col = split.column()
-			col.label(text="Effect folder")
-			col = split.column()
-			col.prop(self, "effects_path", text="")
-			split = util.layout_split(box, factor=factor_width)
-			col = split.column()
-			col = split.column()
-			p = col.operator("mcprep.openfolder", text="Open effects folder")
-			p.folder = self.effects_path
+            # misc settings
+            row = layout.row()
+            row.prop(self, "verbose")
+            row.prop(self, "feature_set")
 
-			# misc settings
-			row = layout.row()
-			row.prop(self, "verbose")
-			row.prop(self, "feature_set")
+            if self.feature_set != "supported":
+                row = layout.row()
+                box = row.box()
+                box.scale_y = 0.7
+                box.label(text="Using MCprep in experimental mode!", icon="ERROR")
+                box.label(text="Early access features and requests for feedback")
+                box.label(text="will be made visible. Thank you for contributing.")
 
-			if self.feature_set != "supported":
-				row = layout.row()
-				box = row.box()
-				box.scale_y = 0.7
-				box.label(text="Using MCprep in experimental mode!", icon="ERROR")
-				box.label(text="Early access features and requests for feedback")
-				box.label(text="will be made visible. Thank you for contributing.")
+        elif self.preferences_tab == "tutorials":
+            layout.label(
+                text="Unsure on how to use the addon? Check out these resources"
+            )
+            row = layout.row()
+            row.scale_y = 2
+            row.operator(
+                "wm.url_open",
+                text="MCprep page for instructions and updates",
+                icon="WORLD",
+            ).url = "https://theduckcow.com/dev/blender/mcprep/"
 
-		elif self.preferences_tab == "tutorials":
-			layout.label(
-				text="Unsure on how to use the addon? Check out these resources")
-			row = layout.row()
-			row.scale_y = 2
-			row.operator(
-				"wm.url_open",
-				text="MCprep page for instructions and updates",
-				icon="WORLD"
-			).url = "https://theduckcow.com/dev/blender/mcprep/"
+            row = layout.row()
+            row.scale_y = 2
+            row.operator(
+                "wm.url_open",
+                text="Learn MCprep + Blender, 1-minute tutorials",
+                icon="FILE_MOVIE",
+            ).url = "https://bit.ly/MCprepTutorials"
 
-			row = layout.row()
-			row.scale_y = 2
-			row.operator(
-				"wm.url_open",
-				text="Learn MCprep + Blender, 1-minute tutorials",
-				icon="FILE_MOVIE"
-			).url = "https://bit.ly/MCprepTutorials"
+            row = layout.row()
+            row.scale_y = 1.5
+            row.operator(
+                "wm.url_open", text="Import Minecraft worlds"
+            ).url = "https://theduckcow.com/dev/blender/mcprep/mcprep-minecraft-world-imports/"
+            row.operator(
+                "wm.url_open", text="Mob (rig) spawning"
+            ).url = "https://theduckcow.com/dev/blender/mcprep/mcprep-spawner/"
+            row.operator(
+                "wm.url_open", text="Skin swapping"
+            ).url = "https://theduckcow.com/dev/blender/mcprep/skin-swapping/"
 
-			row = layout.row()
-			row.scale_y = 1.5
-			row.operator(
-				"wm.url_open", text="Import Minecraft worlds"
-			).url = "https://theduckcow.com/dev/blender/mcprep/mcprep-minecraft-world-imports/"
-			row.operator(
-				"wm.url_open", text="Mob (rig) spawning"
-			).url = "https://theduckcow.com/dev/blender/mcprep/mcprep-spawner/"
-			row.operator(
-				"wm.url_open", text="Skin swapping"
-			).url = "https://theduckcow.com/dev/blender/mcprep/skin-swapping/"
+            row = layout.row()
+            row.scale_y = 1.5
+            row.operator(
+                "wm.url_open", text="jmc2obj/Mineways"
+            ).url = "https://theduckcow.com/dev/blender/mcprep/setup-world-exporters/"
+            row.operator(
+                "wm.url_open", text="World Tools"
+            ).url = "https://theduckcow.com/dev/blender/mcprep/world-tools/"
+            row.operator(
+                "wm.url_open", text="Tutorial Series"
+            ).url = "https://bit.ly/MCprepTutorials"
 
-			row = layout.row()
-			row.scale_y = 1.5
-			row.operator(
-				"wm.url_open", text="jmc2obj/Mineways"
-			).url = "https://theduckcow.com/dev/blender/mcprep/setup-world-exporters/"
-			row.operator(
-				"wm.url_open", text="World Tools"
-			).url = "https://theduckcow.com/dev/blender/mcprep/world-tools/"
-			row.operator(
-				"wm.url_open", text="Tutorial Series"
-			).url = "https://bit.ly/MCprepTutorials"
+        elif self.preferences_tab == "tracker_updater":
+            layout = self.layout
+            row = layout.row()
+            box = row.box()
+            brow = box.row()
+            brow.label(text="Anonymous user tracking settings")
 
-		elif self.preferences_tab == "tracker_updater":
-			layout = self.layout
-			row = layout.row()
-			box = row.box()
-			brow = box.row()
-			brow.label(text="Anonymous user tracking settings")
+            brow = box.row()
+            bcol = brow.column()
+            bcol.scale_y = 2
 
-			brow = box.row()
-			bcol = brow.column()
-			bcol.scale_y = 2
+            if tracking.Tracker.tracking_enabled is False:
+                bcol.operator(
+                    "mcprep.toggle_enable_tracking",
+                    text="Opt into anonymous usage tracking",
+                    icon=OPT_IN,
+                )
+            else:
+                bcol.operator(
+                    "mcprep.toggle_enable_tracking",
+                    text="Opt OUT of anonymous usage tracking",
+                    icon="CANCEL",
+                )
 
-			if tracking.Tracker.tracking_enabled is False:
-				bcol.operator(
-					"mcprep.toggle_enable_tracking",
-					text="Opt into anonymous usage tracking",
-					icon=OPT_IN)
-			else:
-				bcol.operator(
-					"mcprep.toggle_enable_tracking",
-					text="Opt OUT of anonymous usage tracking",
-					icon="CANCEL")
+            bcol = brow.column()
+            bcol.label(text="For info on anonymous usage tracking:")
+            brow = box.row()
+            bcol.operator(
+                "wm.url_open", text="Open the Privacy Policy"
+            ).url = "https://theduckcow.com/privacy-policy"
 
-			bcol = brow.column()
-			bcol.label(text="For info on anonymous usage tracking:")
-			brow = box.row()
-			bcol.operator(
-				"wm.url_open", text="Open the Privacy Policy"
-			).url = "https://theduckcow.com/privacy-policy"
-
-			# updater draw function
-			addon_updater_ops.update_settings_ui(self, context)
+            # updater draw function
+            addon_updater_ops.update_settings_ui(self, context)
 
 
 class MCPREP_PT_world_imports(bpy.types.Panel):
-	"""World importing related settings and tools"""
-	bl_label = "World Imports"
-	bl_space_type = 'VIEW_3D'
-	bl_region_type = 'UI'
-	# bl_context = "objectmode"
-	bl_category = "MCprep"
+    """World importing related settings and tools"""
 
-	def draw(self, context):
-		addon_prefs = util.get_user_preferences(context)
-		scn_props = context.scene.mcprep_props
+    bl_label = "World Imports"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
+    # bl_context = "objectmode"
+    bl_category = "MCprep"
 
-		# check for update in background thread if appropraite
-		addon_updater_ops.check_for_update_background()
+    def draw(self, context):
+        addon_prefs = util.get_user_preferences(context)
+        scn_props = context.scene.mcprep_props
 
-		# show update ready if available
-		addon_updater_ops.update_notice_box_ui(self, context)
-		if addon_just_updated():
-			# Don't draw restart_layout() here, as we already have a box
-			return
+        # check for update in background thread if appropraite
+        addon_updater_ops.check_for_update_background()
 
-		layout = self.layout
-		split = layout.split()
-		col = split.column(align=True)
-		row = col.row()
-		row.label(text="World exporter")
-		row.operator(
-			"mcprep.open_help", text="", icon="QUESTION", emboss=False
-		).url = "https://theduckcow.com/dev/blender/mcprep/mcprep-minecraft-world-imports/"
-		split = layout.split()
-		col = split.column(align=True)
-		row = col.row(align=True)
-		row.prop(addon_prefs, "MCprep_exporter_type", expand=True)
-		row = col.row(align=True)
-		if addon_prefs.MCprep_exporter_type == "(choose)":
-			row.operator(
-				"mcprep.open_jmc2obj", text="Select exporter!", icon='ERROR')
-			row.enabled = False
-		elif addon_prefs.MCprep_exporter_type == "Mineways":
-			row.operator("mcprep.open_mineways")
-		else:
-			row.operator("mcprep.open_jmc2obj")
+        # show update ready if available
+        addon_updater_ops.update_notice_box_ui(self, context)
+        if addon_just_updated():
+            # Don't draw restart_layout() here, as we already have a box
+            return
 
-		wpath = addon_prefs.world_obj_path
-		col.operator(
-			"mcprep.import_world_split",
-			text="OBJ world import").filepath = wpath
+        layout = self.layout
+        split = layout.split()
+        col = split.column(align=True)
+        row = col.row()
+        row.label(text="World exporter")
+        row.operator(
+            "mcprep.open_help", text="", icon="QUESTION", emboss=False
+        ).url = (
+            "https://theduckcow.com/dev/blender/mcprep/mcprep-minecraft-world-imports/"
+        )
+        split = layout.split()
+        col = split.column(align=True)
+        row = col.row(align=True)
+        row.prop(addon_prefs, "MCprep_exporter_type", expand=True)
+        row = col.row(align=True)
+        if addon_prefs.MCprep_exporter_type == "(choose)":
+            row.operator("mcprep.open_jmc2obj", text="Select exporter!", icon="ERROR")
+            row.enabled = False
+        elif addon_prefs.MCprep_exporter_type == "Mineways":
+            row.operator("mcprep.open_mineways")
+        else:
+            row.operator("mcprep.open_jmc2obj")
 
-		split = layout.split()
-		col = split.column(align=True)
-		col.label(text="MCprep tools")
-		col.operator("mcprep.prep_materials", text="Prep Materials")
+        wpath = addon_prefs.world_obj_path
+        col.operator(
+            "mcprep.import_world_split", text="OBJ world import"
+        ).filepath = wpath
 
-		if not util.is_atlas_export(context):
-			row = col.row()
-			row.operator(
-				"mcprep.open_help", text="", icon="QUESTION", emboss=False
-			).url = "https://github.com/TheDuckCow/MCprep/blob/master/docs/common_errors.md#common-error-messages-and-what-they-mean"
-			row.label(text="OBJ incompatible with textureswap")
-		p = col.operator("mcprep.swap_texture_pack")
-		p.filepath = context.scene.mcprep_texturepack_path
-		if context.mode == "OBJECT":
-			col.operator("mcprep.meshswap", text="Mesh Swap")
-			if addon_prefs.MCprep_exporter_type == "(choose)":
-				col.label(text="Select exporter!", icon='ERROR')
-		if context.mode == 'EDIT_MESH':
-			col.operator("mcprep.scale_uv")
-			col.operator("mcprep.select_alpha_faces")
+        split = layout.split()
+        col = split.column(align=True)
+        col.label(text="MCprep tools")
+        col.operator("mcprep.prep_materials", text="Prep Materials")
 
-		split = layout.split()
-		col = split.column(align=True)
+        if not util.is_atlas_export(context):
+            row = col.row()
+            row.operator(
+                "mcprep.open_help", text="", icon="QUESTION", emboss=False
+            ).url = "https://github.com/TheDuckCow/MCprep/blob/master/docs/common_errors.md#common-error-messages-and-what-they-mean"
+            row.label(text="OBJ incompatible with textureswap")
+        p = col.operator("mcprep.swap_texture_pack")
+        p.filepath = context.scene.mcprep_texturepack_path
+        if context.mode == "OBJECT":
+            col.operator("mcprep.meshswap", text="Mesh Swap")
+            if addon_prefs.MCprep_exporter_type == "(choose)":
+                col.label(text="Select exporter!", icon="ERROR")
+        if context.mode == "EDIT_MESH":
+            col.operator("mcprep.scale_uv")
+            col.operator("mcprep.select_alpha_faces")
 
-		# Indicate whether UI can be improved or not.
-		view28 = ['SOLID', 'MATERIAL', 'RENDERED']
-		
-		improved_28 = util.viewport_textured(context) is True
-		improved_28 &= context.scene.display.shading.type in view28
-		improved_28 &= context.scene.display.shading.background_type == "WORLD"
+        split = layout.split()
+        col = split.column(align=True)
 
-		if improved_28:
-			row = col.row(align=True)
-			row.enabled = False
-			row.operator(
-				"mcprep.improve_ui",
-				text="(UI already improved)", icon='SETTINGS')
-		else:
-			col.operator(
-				"mcprep.improve_ui", text="Improve UI", icon='SETTINGS')
+        # Indicate whether UI can be improved or not.
+        view28 = ["SOLID", "MATERIAL", "RENDERED"]
 
-		# Optimizer Panel (only for blender 2.80+)
-		row = col.row(align=True)
-		icon = "TRIA_DOWN" if scn_props.show_settings_optimizer else "TRIA_RIGHT"
-		row.prop(
-			scn_props, "show_settings_optimizer",
-			text="Cycles Optimizer", icon=icon)
-		if scn_props.show_settings_optimizer:
-			row = col.row(align=True)
-			optimize_scene.panel_draw(context, row)
+        improved_28 = util.viewport_textured(context) is True
+        improved_28 &= context.scene.display.shading.type in view28
+        improved_28 &= context.scene.display.shading.background_type == "WORLD"
 
-		# Advanced settings.
-		row = col.row(align=True)
-		if not scn_props.show_settings_material:
-			row.prop(
-				scn_props, "show_settings_material",
-				text="Advanced", icon="TRIA_RIGHT")
-			row.operator(
-				"mcprep.open_preferences",
-				text="", icon="PREFERENCES").tab = "settings"
-		else:
-			row.prop(
-				scn_props, "show_settings_material",
-				text="Advanced", icon="TRIA_DOWN")
-			row.operator(
-				"mcprep.open_preferences",
-				text="", icon="PREFERENCES").tab = "settings"
-			box = col.box()
-			b_row = box.row()
-			b_col = b_row.column(align=False)
-			b_col.label(text="Texture pack folder")
-			row = b_col.row(align=True)
-			row.prop(context.scene, "mcprep_texturepack_path", text="")
-			row.operator("mcprep.reset_texture_path", text="", icon=LOAD_FACTORY)
+        if improved_28:
+            row = col.row(align=True)
+            row.enabled = False
+            row.operator(
+                "mcprep.improve_ui", text="(UI already improved)", icon="SETTINGS"
+            )
+        else:
+            col.operator("mcprep.improve_ui", text="Improve UI", icon="SETTINGS")
 
-			b_row = box.row()
-			b_col = b_row.column(align=True)
-			sync_row = b_col.row(align=True)
-			sync_row.operator("mcprep.sync_materials")
-			sync_row.operator(
-				"mcprep.edit_sync_materials_file", text="", icon="FILE_TICK") # or TOOL_SETTINGS.
-			b_col.operator("mcprep.replace_missing_textures")
-			b_col.operator("mcprep.animate_textures")
-			# TODO: operator to make all local, all packed, or set to other location
-			b_col.operator(
-				"mcprep.combine_materials",
-				text="Combine Materials").selection_only = True
-			if bpy.app.version > (2, 77):
-				b_col.operator("mcprep.combine_images", text="Combine Images")
+        # Optimizer Panel (only for blender 2.80+)
+        row = col.row(align=True)
+        icon = "TRIA_DOWN" if scn_props.show_settings_optimizer else "TRIA_RIGHT"
+        row.prop(
+            scn_props, "show_settings_optimizer", text="Cycles Optimizer", icon=icon
+        )
+        if scn_props.show_settings_optimizer:
+            row = col.row(align=True)
+            optimize_scene.panel_draw(context, row)
 
-			b_col.label(text="Meshswap source:")
-			subrow = b_col.row(align=True)
-			subrow.prop(context.scene, "meshswap_path", text="")
-			subrow.operator(
-				"mcprep.meshswap_path_reset", icon=LOAD_FACTORY, text="")
-			if not context.scene.meshswap_path.lower().endswith('.blend'):
-				b_col.label(text="MeshSwap file must be .blend", icon="ERROR")
-			if not os.path.isfile(bpy.path.abspath(context.scene.meshswap_path)):
-				b_col.label(text="MeshSwap file not found", icon="ERROR")
+        # Advanced settings.
+        row = col.row(align=True)
+        if not scn_props.show_settings_material:
+            row.prop(
+                scn_props, "show_settings_material", text="Advanced", icon="TRIA_RIGHT"
+            )
+            row.operator(
+                "mcprep.open_preferences", text="", icon="PREFERENCES"
+            ).tab = "settings"
+        else:
+            row.prop(
+                scn_props, "show_settings_material", text="Advanced", icon="TRIA_DOWN"
+            )
+            row.operator(
+                "mcprep.open_preferences", text="", icon="PREFERENCES"
+            ).tab = "settings"
+            box = col.box()
+            b_row = box.row()
+            b_col = b_row.column(align=False)
+            b_col.label(text="Texture pack folder")
+            row = b_col.row(align=True)
+            row.prop(context.scene, "mcprep_texturepack_path", text="")
+            row.operator("mcprep.reset_texture_path", text="", icon=LOAD_FACTORY)
 
-		layout = self.layout  # clear out the box formatting
-		split = layout.split()
-		row = split.row(align=True)
+            b_row = box.row()
+            b_col = b_row.column(align=True)
+            sync_row = b_col.row(align=True)
+            sync_row.operator("mcprep.sync_materials")
+            sync_row.operator(
+                "mcprep.edit_sync_materials_file", text="", icon="FILE_TICK"
+            )  # or TOOL_SETTINGS.
+            b_col.operator("mcprep.replace_missing_textures")
+            b_col.operator("mcprep.animate_textures")
+            # TODO: operator to make all local, all packed, or set to other location
+            b_col.operator(
+                "mcprep.combine_materials", text="Combine Materials"
+            ).selection_only = True
+            if bpy.app.version > (2, 77):
+                b_col.operator("mcprep.combine_images", text="Combine Images")
+
+            b_col.label(text="Meshswap source:")
+            subrow = b_col.row(align=True)
+            subrow.prop(context.scene, "meshswap_path", text="")
+            subrow.operator("mcprep.meshswap_path_reset", icon=LOAD_FACTORY, text="")
+            if not context.scene.meshswap_path.lower().endswith(".blend"):
+                b_col.label(text="MeshSwap file must be .blend", icon="ERROR")
+            if not os.path.isfile(bpy.path.abspath(context.scene.meshswap_path)):
+                b_col.label(text="MeshSwap file not found", icon="ERROR")
+
+        layout = self.layout  # clear out the box formatting
+        split = layout.split()
+        row = split.row(align=True)
 
 
 class MCPREP_PT_bridge(bpy.types.Panel):
-	"""MCprep panel for directly importing and reloading minecraft saves"""
-	bl_label = "World Bridge"
-	bl_space_type = "VIEW_3D"
-	bl_region_type = 'UI'
-	bl_context = "objectmode"
-	bl_category = "MCprep"
+    """MCprep panel for directly importing and reloading minecraft saves"""
 
-	def draw(self, context):
-		if addon_just_updated():
-			restart_layout(self.layout)
-			return
+    bl_label = "World Bridge"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
+    bl_context = "objectmode"
+    bl_category = "MCprep"
 
-		# bridge.panel_draw(self, context)
-		pass
+    def draw(self, context):
+        if addon_just_updated():
+            restart_layout(self.layout)
+            return
+
+        # bridge.panel_draw(self, context)
+        pass
 
 
 class MCPREP_PT_world_tools(bpy.types.Panel):
-	"""World settings and tools"""
-	bl_label = "World Tools"
-	bl_space_type = 'VIEW_3D'
-	bl_region_type = 'UI'	
-	bl_category = "MCprep"
+    """World settings and tools"""
 
-	def draw(self, context):
-		layout = self.layout
-		if addon_just_updated():
-			restart_layout(layout)
-			return
+    bl_label = "World Tools"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
+    bl_category = "MCprep"
 
-		rw = layout.row()
-		col = rw.column()
-		row = col.row(align=True)
-		row.label(text="World settings and lighting")  # world time
-		row.operator(
-			"mcprep.open_help", text="", icon="QUESTION", emboss=False
-		).url = "https://theduckcow.com/dev/blender/mcprep/world-tools/"
+    def draw(self, context):
+        layout = self.layout
+        if addon_just_updated():
+            restart_layout(layout)
+            return
 
-		rw = layout.row()
-		col = rw.column(align=True)
-		col.operator("mcprep.add_mc_sky")
-		col.operator("mcprep.world")
-		col.operator("mcprep.render_panorama")
+        rw = layout.row()
+        col = rw.column()
+        row = col.row(align=True)
+        row.label(text="World settings and lighting")  # world time
+        row.operator(
+            "mcprep.open_help", text="", icon="QUESTION", emboss=False
+        ).url = "https://theduckcow.com/dev/blender/mcprep/world-tools/"
 
-		layout.split()
-		rw = layout.row()
-		col = rw.column(align=True)
-		obj = world_tools.get_time_object()
-		col.label(text="Time of day")
-		if obj and "MCprepHour" in obj:
-			time = obj["MCprepHour"]
-			col.prop(
-				obj,
-				'["MCprepHour"]',
-				text="")
-			col.label(text="{h}:{m}, day {d}".format(
-				h=str(int(time % 24 - time % 1)).zfill(2),
-				m=str(int(time % 1 * 60)).zfill(2),
-				d=int((time - time % 24) / 24)
-			))
-		else:
-			box = col.box()
-			subcol = box.column()
-			subcol.scale_y = 0.8
-			subcol.label(text="No time controller,")
-			subcol.label(text="add dynamic MC world.")
-		# col.label(text="World setup")
-		# col.operator("mcprep.world")
-		# col.operator("mcprep.world", text="Add clouds")
-		# col.operator("mcprep.world", text="Set Weather")
+        rw = layout.row()
+        col = rw.column(align=True)
+        col.operator("mcprep.add_mc_sky")
+        col.operator("mcprep.world")
+        col.operator("mcprep.render_panorama")
+
+        layout.split()
+        rw = layout.row()
+        col = rw.column(align=True)
+        obj = world_tools.get_time_object()
+        col.label(text="Time of day")
+        if obj and "MCprepHour" in obj:
+            time = obj["MCprepHour"]
+            col.prop(obj, '["MCprepHour"]', text="")
+            col.label(
+                text="{h}:{m}, day {d}".format(
+                    h=str(int(time % 24 - time % 1)).zfill(2),
+                    m=str(int(time % 1 * 60)).zfill(2),
+                    d=int((time - time % 24) / 24),
+                )
+            )
+        else:
+            box = col.box()
+            subcol = box.column()
+            subcol.scale_y = 0.8
+            subcol.label(text="No time controller,")
+            subcol.label(text="add dynamic MC world.")
+        # col.label(text="World setup")
+        # col.operator("mcprep.world")
+        # col.operator("mcprep.world", text="Add clouds")
+        # col.operator("mcprep.world", text="Set Weather")
 
 
 class MCPREP_PT_skins(bpy.types.Panel):
-	"""MCprep panel for skin swapping"""
-	bl_label = "Skin Swapper"
-	bl_space_type = 'VIEW_3D'
-	bl_region_type = 'UI'
-	bl_category = "MCprep"
+    """MCprep panel for skin swapping"""
 
-	def draw(self, context):
-		layout = self.layout
-		if addon_just_updated():
-			restart_layout(layout)
-			return
+    bl_label = "Skin Swapper"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
+    bl_category = "MCprep"
 
-		scn_props = context.scene.mcprep_props
-		sind = context.scene.mcprep_skins_list_index
-		mob_ind = context.scene.mcprep_props.mob_list_index
-		skinname = None
+    def draw(self, context):
+        layout = self.layout
+        if addon_just_updated():
+            restart_layout(layout)
+            return
 
-		row = layout.row()
-		row.label(text="Select skin")
-		row.operator(
-			"mcprep.open_help", text="", icon="QUESTION", emboss=False
-		).url = "https://theduckcow.com/dev/blender/mcprep/skin-swapping/"
+        scn_props = context.scene.mcprep_props
+        sind = context.scene.mcprep_skins_list_index
+        mob_ind = context.scene.mcprep_props.mob_list_index
+        skinname = None
 
-		# set size of UIlist
-		row = layout.row()
-		col = row.column()
+        row = layout.row()
+        row.label(text="Select skin")
+        row.operator(
+            "mcprep.open_help", text="", icon="QUESTION", emboss=False
+        ).url = "https://theduckcow.com/dev/blender/mcprep/skin-swapping/"
 
-		is_sortable = len(env.skin_list) > 1
-		rows = 1
-		if (is_sortable):
-			rows = 4
+        # set size of UIlist
+        row = layout.row()
+        col = row.column()
 
-		# any other conditions for needing reloading?
-		if not env.skin_list:
-			col = layout.column()
-			col.label(text="No skins found/loaded")
-			p = col.operator(
-				"mcprep.reload_skins", text="Press to reload", icon="ERROR")
-		elif env.skin_list and len(env.skin_list) <= sind:
-			col = layout.column()
-			col.label(text="Reload skins")
-			p = col.operator(
-				"mcprep.reload_skins", text="Press to reload", icon="ERROR")
-		else:
-			col.template_list(
-				"MCPREP_UL_skins", "",
-				context.scene, "mcprep_skins_list",
-				context.scene, "mcprep_skins_list_index",
-				rows=rows)
+        is_sortable = len(env.skin_list) > 1
+        rows = 1
+        if is_sortable:
+            rows = 4
 
-			col = layout.column(align=True)
+        # any other conditions for needing reloading?
+        if not env.skin_list:
+            col = layout.column()
+            col.label(text="No skins found/loaded")
+            p = col.operator(
+                "mcprep.reload_skins", text="Press to reload", icon="ERROR"
+            )
+        elif env.skin_list and len(env.skin_list) <= sind:
+            col = layout.column()
+            col.label(text="Reload skins")
+            p = col.operator(
+                "mcprep.reload_skins", text="Press to reload", icon="ERROR"
+            )
+        else:
+            col.template_list(
+                "MCPREP_UL_skins",
+                "",
+                context.scene,
+                "mcprep_skins_list",
+                context.scene,
+                "mcprep_skins_list_index",
+                rows=rows,
+            )
 
-			row = col.row(align=True)
-			row.scale_y = 1.5
-			if env.skin_list:
-				skinname = bpy.path.basename(env.skin_list[sind][0])
-				p = row.operator("mcprep.applyskin", text="Apply " + skinname)
-				p.filepath = env.skin_list[sind][1]
-			else:
-				row.enabled = False
-				p = row.operator("mcprep.skin_swapper", text="No skins found")
-			row = col.row(align=True)
-			row.operator("mcprep.skin_swapper", text="Skin from file")
-			row = col.row(align=True)
-			row.operator("mcprep.applyusernameskin", text="Skin from username")
+            col = layout.column(align=True)
 
-		split = layout.split()
-		col = split.column(align=True)
-		row = col.row(align=True)
-		if not scn_props.show_settings_skin:
-			row.prop(
-				scn_props, "show_settings_skin",
-				text="Advanced", icon="TRIA_RIGHT")
-			row.operator(
-				"mcprep.open_preferences",
-				text="", icon="PREFERENCES").tab = "settings"
-		else:
-			row.prop(
-				scn_props, "show_settings_skin",
-				text="Advanced", icon="TRIA_DOWN")
-			row.operator(
-				"mcprep.open_preferences",
-				text="", icon="PREFERENCES").tab = "settings"
-			box = col.box()
-			b_row = box.column(align=True)
-			b_row.label(text="Skin path")
-			b_subrow = b_row.row(align=True)
-			b_subrow.prop(context.scene, "mcprep_skin_path", text="")
-			b_subrow.operator(
-				"mcprep.skin_path_reset", icon=LOAD_FACTORY, text="")
-			b_row.operator("mcprep.add_skin")
-			b_row.operator("mcprep.remove_skin")
-			b_row.operator("mcprep.download_username_list")
-			b_row.operator("mcprep.reload_skins")
-			if context.mode == "OBJECT" and skinname:
-				row = b_row.row(align=True)
-				if not scn_props.mob_list:
-					row.enabled = False
-					row.operator(
-						"mcprep.spawn_with_skin", text="Reload mobs below")
-				elif not env.skin_list:
-					row.enabled = False
-					row.operator(
-						"mcprep.spawn_with_skin", text="Reload skins above")
-				else:
-					name = scn_props.mob_list[mob_ind].name
-					# datapass = scn_props.mob_list[mob_ind].mcmob_type
-					tx = "Spawn {x} with {y}".format(x=name, y=skinname)
-					row.operator("mcprep.spawn_with_skin", text=tx)
+            row = col.row(align=True)
+            row.scale_y = 1.5
+            if env.skin_list:
+                skinname = bpy.path.basename(env.skin_list[sind][0])
+                p = row.operator("mcprep.applyskin", text="Apply " + skinname)
+                p.filepath = env.skin_list[sind][1]
+            else:
+                row.enabled = False
+                p = row.operator("mcprep.skin_swapper", text="No skins found")
+            row = col.row(align=True)
+            row.operator("mcprep.skin_swapper", text="Skin from file")
+            row = col.row(align=True)
+            row.operator("mcprep.applyusernameskin", text="Skin from username")
+
+        split = layout.split()
+        col = split.column(align=True)
+        row = col.row(align=True)
+        if not scn_props.show_settings_skin:
+            row.prop(
+                scn_props, "show_settings_skin", text="Advanced", icon="TRIA_RIGHT"
+            )
+            row.operator(
+                "mcprep.open_preferences", text="", icon="PREFERENCES"
+            ).tab = "settings"
+        else:
+            row.prop(scn_props, "show_settings_skin", text="Advanced", icon="TRIA_DOWN")
+            row.operator(
+                "mcprep.open_preferences", text="", icon="PREFERENCES"
+            ).tab = "settings"
+            box = col.box()
+            b_row = box.column(align=True)
+            b_row.label(text="Skin path")
+            b_subrow = b_row.row(align=True)
+            b_subrow.prop(context.scene, "mcprep_skin_path", text="")
+            b_subrow.operator("mcprep.skin_path_reset", icon=LOAD_FACTORY, text="")
+            b_row.operator("mcprep.add_skin")
+            b_row.operator("mcprep.remove_skin")
+            b_row.operator("mcprep.download_username_list")
+            b_row.operator("mcprep.reload_skins")
+            if context.mode == "OBJECT" and skinname:
+                row = b_row.row(align=True)
+                if not scn_props.mob_list:
+                    row.enabled = False
+                    row.operator("mcprep.spawn_with_skin", text="Reload mobs below")
+                elif not env.skin_list:
+                    row.enabled = False
+                    row.operator("mcprep.spawn_with_skin", text="Reload skins above")
+                else:
+                    name = scn_props.mob_list[mob_ind].name
+                    # datapass = scn_props.mob_list[mob_ind].mcmob_type
+                    tx = "Spawn {x} with {y}".format(x=name, y=skinname)
+                    row.operator("mcprep.spawn_with_skin", text=tx)
 
 
 class MCPREP_PT_materials(bpy.types.Panel):
-	"""MCprep panel for materials"""
-	bl_label = "MCprep materials"
-	bl_space_type = "PROPERTIES"
-	bl_region_type = 'WINDOW'
-	bl_context = "material"
+    """MCprep panel for materials"""
 
-	def draw(self, context):
-		"""Code for drawing the material generator"""
-		scn_props = context.scene.mcprep_props
+    bl_label = "MCprep materials"
+    bl_space_type = "PROPERTIES"
+    bl_region_type = "WINDOW"
+    bl_context = "material"
 
-		layout = self.layout
-		if addon_just_updated():
-			restart_layout(layout)
-			return
+    def draw(self, context):
+        """Code for drawing the material generator"""
+        scn_props = context.scene.mcprep_props
 
-		row = layout.row()
-		# row.operator("mcprep.create_default_material")
-		split = layout.split()
-		col = split.column(align=True)
+        layout = self.layout
+        if addon_just_updated():
+            restart_layout(layout)
+            return
 
-		if scn_props.material_list:
-			col.template_list(
-				"MCPREP_UL_material", "",
-				scn_props, "material_list",
-				scn_props, "material_list_index",
-				rows=4)
-			col = layout.column(align=True)
-			row = col.row(align=True)
-			row.scale_y = 1.5
-			mat = scn_props.material_list[scn_props.material_list_index]
-			ops = row.operator("mcprep.load_material", text="Load: " + mat.name)
-			ops.filepath = mat.path
-		else:
-			box = col.box()
-			b_row = box.row()
-			b_row.label(text="No materials loaded")
-			b_row = box.row()
-			b_row.scale_y = 2
-			b_row.operator("mcprep.reload_materials", icon="ERROR")
+        row = layout.row()
+        # row.operator("mcprep.create_default_material")
+        split = layout.split()
+        col = split.column(align=True)
 
-			col = layout.column(align=True)
-			col.enabled = False
-			row = col.row(align=True)
-			row.scale_y = 1.5
-			ops = row.operator("mcprep.load_material", text="Load material")
+        if scn_props.material_list:
+            col.template_list(
+                "MCPREP_UL_material",
+                "",
+                scn_props,
+                "material_list",
+                scn_props,
+                "material_list_index",
+                rows=4,
+            )
+            col = layout.column(align=True)
+            row = col.row(align=True)
+            row.scale_y = 1.5
+            mat = scn_props.material_list[scn_props.material_list_index]
+            ops = row.operator("mcprep.load_material", text="Load: " + mat.name)
+            ops.filepath = mat.path
+        else:
+            box = col.box()
+            b_row = box.row()
+            b_row.label(text="No materials loaded")
+            b_row = box.row()
+            b_row.scale_y = 2
+            b_row.operator("mcprep.reload_materials", icon="ERROR")
+
+            col = layout.column(align=True)
+            col.enabled = False
+            row = col.row(align=True)
+            row.scale_y = 1.5
+            ops = row.operator("mcprep.load_material", text="Load material")
 
 
 class MCPREP_PT_materials_subsettings(bpy.types.Panel):
-	"""MCprep panel for advanced material settings and functions"""
-	bl_label = "Advanced"
-	bl_parent_id = "MCPREP_PT_materials"
-	bl_space_type = "PROPERTIES"
-	bl_region_type = 'WINDOW'
-	bl_context = "material"
+    """MCprep panel for advanced material settings and functions"""
 
-	def draw(self, context):
-		if addon_just_updated():
-			restart_layout(self.layout)
-			return
+    bl_label = "Advanced"
+    bl_parent_id = "MCPREP_PT_materials"
+    bl_space_type = "PROPERTIES"
+    bl_region_type = "WINDOW"
+    bl_context = "material"
 
-		b_row = self.layout.row()
-		b_col = b_row.column(align=False)
-		b_col.label(text="Resource pack")
-		subrow = b_col.row(align=True)
-		subrow.prop(context.scene, "mcprep_texturepack_path", text="")
-		subrow.operator(
-			"mcprep.reset_texture_path", icon=LOAD_FACTORY, text="")
-		b_row = self.layout.row()
-		b_col = b_row.column(align=True)
-		b_col.operator("mcprep.reload_materials")
+    def draw(self, context):
+        if addon_just_updated():
+            restart_layout(self.layout)
+            return
+
+        b_row = self.layout.row()
+        b_col = b_row.column(align=False)
+        b_col.label(text="Resource pack")
+        subrow = b_col.row(align=True)
+        subrow.prop(context.scene, "mcprep_texturepack_path", text="")
+        subrow.operator("mcprep.reset_texture_path", icon=LOAD_FACTORY, text="")
+        b_row = self.layout.row()
+        b_col = b_row.column(align=True)
+        b_col.operator("mcprep.reload_materials")
 
 
 # -----------------------------------------------------------------------------
 # Spawner related UI
 # -----------------------------------------------------------------------------
 
+
 def draw_mode_warning(ui_element):
-	col = ui_element.column(align=True)
-	col.label(text="Enter object mode", icon="ERROR")
-	col.label(text="to use spawner", icon="BLANK1")
-	col.operator("object.mode_set").mode = "OBJECT"
-	col.label(text="")
+    col = ui_element.column(align=True)
+    col.label(text="Enter object mode", icon="ERROR")
+    col.label(text="to use spawner", icon="BLANK1")
+    col.operator("object.mode_set").mode = "OBJECT"
+    col.label(text="")
 
 
 def mob_spawner(self, context):
-	scn_props = context.scene.mcprep_props
+    scn_props = context.scene.mcprep_props
 
-	layout = self.layout
-	layout.label(text="Import pre-rigged mobs & players")
-	split = layout.split()
-	col = split.column(align=True)
+    layout = self.layout
+    layout.label(text="Import pre-rigged mobs & players")
+    split = layout.split()
+    col = split.column(align=True)
 
-	row = col.row()
-	row.prop(scn_props, "spawn_rig_category", text="")
-	if scn_props.mob_list:
-		row = col.row()
-		row.template_list(
-			"MCPREP_UL_mob", "",
-			scn_props, "mob_list",
-			scn_props, "mob_list_index",
-			rows=4)
-	elif scn_props.mob_list_all:
-		box = col.box()
-		b_row = box.row()
-		b_row.label(text="")
-		b_col = box.column()
-		b_col.scale_y = 0.7
-		b_col.label(text="No mobs in category,")
-		b_col.label(text="install a rig below or")
-		b_col.label(text="copy file to folder.")
-		b_row = box.row()
-		b_row.label(text="")
-	else:
-		box = col.box()
-		b_row = box.row()
-		b_row.label(text="No mobs loaded")
-		b_row = box.row()
-		b_row.scale_y = 2
-		b_row.operator(
-			"mcprep.reload_spawners", text="Reload assets", icon="ERROR")
+    row = col.row()
+    row.prop(scn_props, "spawn_rig_category", text="")
+    if scn_props.mob_list:
+        row = col.row()
+        row.template_list(
+            "MCPREP_UL_mob",
+            "",
+            scn_props,
+            "mob_list",
+            scn_props,
+            "mob_list_index",
+            rows=4,
+        )
+    elif scn_props.mob_list_all:
+        box = col.box()
+        b_row = box.row()
+        b_row.label(text="")
+        b_col = box.column()
+        b_col.scale_y = 0.7
+        b_col.label(text="No mobs in category,")
+        b_col.label(text="install a rig below or")
+        b_col.label(text="copy file to folder.")
+        b_row = box.row()
+        b_row.label(text="")
+    else:
+        box = col.box()
+        b_row = box.row()
+        b_row.label(text="No mobs loaded")
+        b_row = box.row()
+        b_row.scale_y = 2
+        b_row.operator("mcprep.reload_spawners", text="Reload assets", icon="ERROR")
 
-	# get which rig is selected
-	if scn_props.mob_list:
-		name = scn_props.mob_list[scn_props.mob_list_index].name
-		mcmob_type = scn_props.mob_list[scn_props.mob_list_index].mcmob_type
-	else:
-		name = ""
-		mcmob_type = ""
-	col = layout.column(align=True)
-	row = col.row(align=True)
-	row.scale_y = 1.5
-	row.enabled = len(scn_props.mob_list) > 0
-	p = row.operator("mcprep.mob_spawner", text="Spawn " + name)
-	if mcmob_type:
-		p.mcmob_type = mcmob_type
+    # get which rig is selected
+    if scn_props.mob_list:
+        name = scn_props.mob_list[scn_props.mob_list_index].name
+        mcmob_type = scn_props.mob_list[scn_props.mob_list_index].mcmob_type
+    else:
+        name = ""
+        mcmob_type = ""
+    col = layout.column(align=True)
+    row = col.row(align=True)
+    row.scale_y = 1.5
+    row.enabled = len(scn_props.mob_list) > 0
+    p = row.operator("mcprep.mob_spawner", text="Spawn " + name)
+    if mcmob_type:
+        p.mcmob_type = mcmob_type
 
-	# Skip prep materials in case of unique shader.
-	if env.json_data and name in env.json_data.get("mob_skip_prep", []):
-		p.prep_materials = False
+    # Skip prep materials in case of unique shader.
+    if env.json_data and name in env.json_data.get("mob_skip_prep", []):
+        p.prep_materials = False
 
-	p = col.operator("mcprep.mob_install_menu")
-	p.mob_category = scn_props.spawn_rig_category
+    p = col.operator("mcprep.mob_install_menu")
+    p.mob_category = scn_props.spawn_rig_category
 
-	split = layout.split()
-	col = split.column(align=True)
-	row = col.row(align=True)
-	if not scn_props.show_settings_spawner:
-		row.prop(
-			scn_props, "show_settings_spawner",
-			text="Advanced", icon="TRIA_RIGHT")
-		row.operator(
-			"mcprep.open_preferences",
-			text="", icon="PREFERENCES").tab = "settings"
-	else:
-		row.prop(
-			scn_props, "show_settings_spawner",
-			text="Advanced", icon="TRIA_DOWN")
-		row.operator(
-			"mcprep.open_preferences",
-			text="", icon="PREFERENCES").tab = "settings"
-		box = col.box()
-		b_row = box.row()
-		b_col = b_row.column(align=False)
-		b_col.label(text="Mob spawner folder")
-		subrow = b_col.row(align=True)
-		subrow.prop(context.scene, "mcprep_mob_path", text="")
-		subrow.operator(
-			"mcprep.spawn_path_reset", icon=LOAD_FACTORY, text="")
-		b_row = box.row()
-		b_col = b_row.column(align=True)
-		ops = b_col.operator("mcprep.openfolder", text="Open mob folder")
-		ops.folder = context.scene.mcprep_mob_path
+    split = layout.split()
+    col = split.column(align=True)
+    row = col.row(align=True)
+    if not scn_props.show_settings_spawner:
+        row.prop(scn_props, "show_settings_spawner", text="Advanced", icon="TRIA_RIGHT")
+        row.operator(
+            "mcprep.open_preferences", text="", icon="PREFERENCES"
+        ).tab = "settings"
+    else:
+        row.prop(scn_props, "show_settings_spawner", text="Advanced", icon="TRIA_DOWN")
+        row.operator(
+            "mcprep.open_preferences", text="", icon="PREFERENCES"
+        ).tab = "settings"
+        box = col.box()
+        b_row = box.row()
+        b_col = b_row.column(align=False)
+        b_col.label(text="Mob spawner folder")
+        subrow = b_col.row(align=True)
+        subrow.prop(context.scene, "mcprep_mob_path", text="")
+        subrow.operator("mcprep.spawn_path_reset", icon=LOAD_FACTORY, text="")
+        b_row = box.row()
+        b_col = b_row.column(align=True)
+        ops = b_col.operator("mcprep.openfolder", text="Open mob folder")
+        ops.folder = context.scene.mcprep_mob_path
 
-		if not scn_props.mob_list:
-			b_col.operator("mcprep.mob_install_icon")
-		else:
-			icon_index = scn_props.mob_list[scn_props.mob_list_index].index
-			if "mob-{}".format(icon_index) in env.preview_collections["mobs"]:
-				b_col.operator(
-					"mcprep.mob_install_icon", text="Change mob icon")
-			else:
-				b_col.operator("mcprep.mob_install_icon")
-		b_col.operator("mcprep.mob_uninstall")
-		b_col.operator("mcprep.reload_mobs", text="Reload mobs")
-		b_col.label(text=mcmob_type)
+        if not scn_props.mob_list:
+            b_col.operator("mcprep.mob_install_icon")
+        else:
+            icon_index = scn_props.mob_list[scn_props.mob_list_index].index
+            if "mob-{}".format(icon_index) in env.preview_collections["mobs"]:
+                b_col.operator("mcprep.mob_install_icon", text="Change mob icon")
+            else:
+                b_col.operator("mcprep.mob_install_icon")
+        b_col.operator("mcprep.mob_uninstall")
+        b_col.operator("mcprep.reload_mobs", text="Reload mobs")
+        b_col.label(text=mcmob_type)
 
 
 def meshswap_spawner(self, context):
-	scn_props = context.scene.mcprep_props
+    scn_props = context.scene.mcprep_props
 
-	layout = self.layout
-	layout.label(text="Import pre-made blocks (e.g. lights)")
-	split = layout.split()
-	col = split.column(align=True)
+    layout = self.layout
+    layout.label(text="Import pre-made blocks (e.g. lights)")
+    split = layout.split()
+    col = split.column(align=True)
 
-	if scn_props.meshswap_list:
-		col.template_list(
-			"MCPREP_UL_meshswap", "",
-			scn_props, "meshswap_list",
-			scn_props, "meshswap_list_index",
-			rows=4)
-		# col.label(text=datapass.split("/")[0])
-	elif not context.scene.meshswap_path.lower().endswith('.blend'):
-		box = col.box()
-		b_row = box.row()
-		b_row.label(text="Meshswap file must be a .blend")
-		b_row = box.row()
-		b_row.scale_y = 2
-		b_row.operator(
-			"mcprep.meshswap_path_reset", icon=LOAD_FACTORY,
-			text="Reset meshswap path")
-	elif not os.path.isfile(bpy.path.abspath(context.scene.meshswap_path)):
-		box = col.box()
-		b_row = box.row()
-		b_row.label(text="Meshswap file not found")
-		b_row = box.row()
-		b_row.scale_y = 2
-		b_row.operator(
-			"mcprep.meshswap_path_reset", icon=LOAD_FACTORY,
-			text="Reset meshswap path")
-	else:
-		box = col.box()
-		b_row = box.row()
-		b_row.label(text="No blocks loaded")
-		b_row = box.row()
-		b_row.scale_y = 2
-		b_row.operator(
-			"mcprep.reload_spawners",
-			text="Reload assets", icon="ERROR")
+    if scn_props.meshswap_list:
+        col.template_list(
+            "MCPREP_UL_meshswap",
+            "",
+            scn_props,
+            "meshswap_list",
+            scn_props,
+            "meshswap_list_index",
+            rows=4,
+        )
+        # col.label(text=datapass.split("/")[0])
+    elif not context.scene.meshswap_path.lower().endswith(".blend"):
+        box = col.box()
+        b_row = box.row()
+        b_row.label(text="Meshswap file must be a .blend")
+        b_row = box.row()
+        b_row.scale_y = 2
+        b_row.operator(
+            "mcprep.meshswap_path_reset", icon=LOAD_FACTORY, text="Reset meshswap path"
+        )
+    elif not os.path.isfile(bpy.path.abspath(context.scene.meshswap_path)):
+        box = col.box()
+        b_row = box.row()
+        b_row.label(text="Meshswap file not found")
+        b_row = box.row()
+        b_row.scale_y = 2
+        b_row.operator(
+            "mcprep.meshswap_path_reset", icon=LOAD_FACTORY, text="Reset meshswap path"
+        )
+    else:
+        box = col.box()
+        b_row = box.row()
+        b_row.label(text="No blocks loaded")
+        b_row = box.row()
+        b_row.scale_y = 2
+        b_row.operator("mcprep.reload_spawners", text="Reload assets", icon="ERROR")
 
-	col = layout.column(align=True)
-	row = col.row()
-	row.scale_y = 1.5
-	row.enabled = len(scn_props.meshswap_list) > 0
-	if scn_props.meshswap_list:
-		name = scn_props.meshswap_list[scn_props.meshswap_list_index].name
-		block = scn_props.meshswap_list[scn_props.meshswap_list_index].block
-		method = scn_props.meshswap_list[scn_props.meshswap_list_index].method
-		p = row.operator("mcprep.meshswap_spawner", text="Place: " + name)
-		p.block = block
-		p.method = method
-		p.location = util.get_cuser_location(context)
-		# Ensure meshswap with rigs is made real, so the rigs can be used.
-		if env.json_data and block in env.json_data.get("make_real", []):
-			p.make_real = True
+    col = layout.column(align=True)
+    row = col.row()
+    row.scale_y = 1.5
+    row.enabled = len(scn_props.meshswap_list) > 0
+    if scn_props.meshswap_list:
+        name = scn_props.meshswap_list[scn_props.meshswap_list_index].name
+        block = scn_props.meshswap_list[scn_props.meshswap_list_index].block
+        method = scn_props.meshswap_list[scn_props.meshswap_list_index].method
+        p = row.operator("mcprep.meshswap_spawner", text="Place: " + name)
+        p.block = block
+        p.method = method
+        p.location = util.get_cuser_location(context)
+        # Ensure meshswap with rigs is made real, so the rigs can be used.
+        if env.json_data and block in env.json_data.get("make_real", []):
+            p.make_real = True
 
-	else:
-		row.operator("mcprep.meshswap_spawner", text="Place block")
-	# something to directly open meshswap file??
+    else:
+        row.operator("mcprep.meshswap_spawner", text="Place block")
+    # something to directly open meshswap file??
 
-	split = layout.split()
-	col = split.column(align=True)
-	row = col.row(align=True)
+    split = layout.split()
+    col = split.column(align=True)
+    row = col.row(align=True)
 
-	if not scn_props.show_settings_spawner:
-		col.prop(
-			scn_props, "show_settings_spawner",
-			text="Advanced", icon="TRIA_RIGHT")
-	else:
-		col.prop(
-			scn_props,
-			"show_settings_spawner",
-			text="Advanced", icon="TRIA_DOWN")
-		box = col.box()
-		b_row = box.row()
-		b_col = b_row.column(align=False)
-		b_col.label(text="Meshswap file")
-		subrow = b_col.row(align=True)
-		subrow.prop(context.scene, "meshswap_path", text="")
-		subrow.operator(
-			"mcprep.meshswap_path_reset", icon=LOAD_FACTORY, text="")
-		if not context.scene.meshswap_path.lower().endswith('.blend'):
-			b_col.label(text="MeshSwap file must be a .blend", icon="ERROR")
-		elif not os.path.isfile(bpy.path.abspath(context.scene.meshswap_path)):
-			b_col.label(text="MeshSwap file not found", icon="ERROR")
-		b_row = box.row()
-		b_col = b_row.column(align=True)
-		b_col.operator("mcprep.reload_meshswap")
+    if not scn_props.show_settings_spawner:
+        col.prop(scn_props, "show_settings_spawner", text="Advanced", icon="TRIA_RIGHT")
+    else:
+        col.prop(scn_props, "show_settings_spawner", text="Advanced", icon="TRIA_DOWN")
+        box = col.box()
+        b_row = box.row()
+        b_col = b_row.column(align=False)
+        b_col.label(text="Meshswap file")
+        subrow = b_col.row(align=True)
+        subrow.prop(context.scene, "meshswap_path", text="")
+        subrow.operator("mcprep.meshswap_path_reset", icon=LOAD_FACTORY, text="")
+        if not context.scene.meshswap_path.lower().endswith(".blend"):
+            b_col.label(text="MeshSwap file must be a .blend", icon="ERROR")
+        elif not os.path.isfile(bpy.path.abspath(context.scene.meshswap_path)):
+            b_col.label(text="MeshSwap file not found", icon="ERROR")
+        b_row = box.row()
+        b_col = b_row.column(align=True)
+        b_col.operator("mcprep.reload_meshswap")
 
 
 def item_spawner(self, context):
-	"""Code for drawing the item spawner"""
-	scn_props = context.scene.mcprep_props
-	
-	layout = self.layout
-	layout.label(text="Generate items from textures")
-	split = layout.split()
-	col = split.column(align=True)
+    """Code for drawing the item spawner"""
+    scn_props = context.scene.mcprep_props
 
-	if scn_props.item_list:
-		col.template_list(
-			"MCPREP_UL_item", "",
-			scn_props, "item_list",
-			scn_props, "item_list_index",
-			rows=4)
-		col = layout.column(align=True)
-		row = col.row(align=True)
-		row.scale_y = 1.5
-		name = scn_props.item_list[scn_props.item_list_index].name
-		row.operator("mcprep.spawn_item", text="Place: " + name)
-		row = col.row(align=True)
-		row.operator("mcprep.spawn_item_file")
-	else:
-		box = col.box()
-		b_row = box.row()
-		b_row.label(text="No items loaded")
-		b_row = box.row()
-		b_row.scale_y = 2
-		b_row.operator(
-			"mcprep.reload_spawners",
-			text="Reload assets", icon="ERROR")
+    layout = self.layout
+    layout.label(text="Generate items from textures")
+    split = layout.split()
+    col = split.column(align=True)
 
-		col = layout.column(align=True)
-		col.enabled = False
-		row = col.row(align=True)
-		row.scale_y = 1.5
-		row.operator("mcprep.spawn_item", text="Place item")
-		row = col.row(align=True)
-		row.operator("mcprep.spawn_item_file")
+    if scn_props.item_list:
+        col.template_list(
+            "MCPREP_UL_item",
+            "",
+            scn_props,
+            "item_list",
+            scn_props,
+            "item_list_index",
+            rows=4,
+        )
+        col = layout.column(align=True)
+        row = col.row(align=True)
+        row.scale_y = 1.5
+        name = scn_props.item_list[scn_props.item_list_index].name
+        row.operator("mcprep.spawn_item", text="Place: " + name)
+        row = col.row(align=True)
+        row.operator("mcprep.spawn_item_file")
+    else:
+        box = col.box()
+        b_row = box.row()
+        b_row.label(text="No items loaded")
+        b_row = box.row()
+        b_row.scale_y = 2
+        b_row.operator("mcprep.reload_spawners", text="Reload assets", icon="ERROR")
 
-	split = layout.split()
-	col = split.column(align=True)
-	row = col.row(align=True)
+        col = layout.column(align=True)
+        col.enabled = False
+        row = col.row(align=True)
+        row.scale_y = 1.5
+        row.operator("mcprep.spawn_item", text="Place item")
+        row = col.row(align=True)
+        row.operator("mcprep.spawn_item_file")
 
-	if not scn_props.show_settings_spawner:
-		col.prop(
-			scn_props, "show_settings_spawner",
-			text="Advanced", icon="TRIA_RIGHT")
-	else:
-		col.prop(
-			scn_props, "show_settings_spawner",
-			text="Advanced", icon="TRIA_DOWN")
-		box = col.box()
-		b_row = box.row()
-		b_col = b_row.column(align=False)
-		b_col.label(text="Resource pack")
-		subrow = b_col.row(align=True)
-		subrow.prop(context.scene, "mcprep_texturepack_path", text="")
-		subrow.operator(
-			"mcprep.reset_texture_path", icon=LOAD_FACTORY, text="")
-		b_row = box.row()
-		b_col = b_row.column(align=True)
-		b_col.operator("mcprep.reload_items")
+    split = layout.split()
+    col = split.column(align=True)
+    row = col.row(align=True)
+
+    if not scn_props.show_settings_spawner:
+        col.prop(scn_props, "show_settings_spawner", text="Advanced", icon="TRIA_RIGHT")
+    else:
+        col.prop(scn_props, "show_settings_spawner", text="Advanced", icon="TRIA_DOWN")
+        box = col.box()
+        b_row = box.row()
+        b_col = b_row.column(align=False)
+        b_col.label(text="Resource pack")
+        subrow = b_col.row(align=True)
+        subrow.prop(context.scene, "mcprep_texturepack_path", text="")
+        subrow.operator("mcprep.reset_texture_path", icon=LOAD_FACTORY, text="")
+        b_row = box.row()
+        b_col = b_row.column(align=True)
+        b_col.operator("mcprep.reload_items")
 
 
 def entity_spawner(self, context):
-	scn_props = context.scene.mcprep_props
+    scn_props = context.scene.mcprep_props
 
-	layout = self.layout
-	layout.label(text="Import pre-rigged entities")
-	split = layout.split()
-	col = split.column(align=True)
+    layout = self.layout
+    layout.label(text="Import pre-rigged entities")
+    split = layout.split()
+    col = split.column(align=True)
 
-	if scn_props.entity_list:
-		col.template_list(
-			"MCPREP_UL_entity", "",
-			scn_props, "entity_list",
-			scn_props, "entity_list_index",
-			rows=4)
+    if scn_props.entity_list:
+        col.template_list(
+            "MCPREP_UL_entity",
+            "",
+            scn_props,
+            "entity_list",
+            scn_props,
+            "entity_list_index",
+            rows=4,
+        )
 
-	elif not context.scene.entity_path.lower().endswith('.blend'):
-		box = col.box()
-		b_row = box.row()
-		b_row.label(text="Entity file must be a .blend")
-		b_row = box.row()
-		b_row.scale_y = 2
-		b_row.operator(
-			"mcprep.entity_path_reset", icon=LOAD_FACTORY,
-			text="Reset entity path")
-	elif not os.path.isfile(bpy.path.abspath(context.scene.entity_path)):
-		box = col.box()
-		b_row = box.row()
-		b_row.label(text="Entity file not found")
-		b_row = box.row()
-		b_row.scale_y = 2
-		b_row.operator(
-			"mcprep.entity_path_reset", icon=LOAD_FACTORY,
-			text="Reset entity path")
-	else:
-		box = col.box()
-		b_row = box.row()
-		b_row.label(text="No entities loaded")
-		b_row = box.row()
-		b_row.scale_y = 2
-		b_row.operator(
-			"mcprep.reload_spawners",
-			text="Reload assets", icon="ERROR")
+    elif not context.scene.entity_path.lower().endswith(".blend"):
+        box = col.box()
+        b_row = box.row()
+        b_row.label(text="Entity file must be a .blend")
+        b_row = box.row()
+        b_row.scale_y = 2
+        b_row.operator(
+            "mcprep.entity_path_reset", icon=LOAD_FACTORY, text="Reset entity path"
+        )
+    elif not os.path.isfile(bpy.path.abspath(context.scene.entity_path)):
+        box = col.box()
+        b_row = box.row()
+        b_row.label(text="Entity file not found")
+        b_row = box.row()
+        b_row.scale_y = 2
+        b_row.operator(
+            "mcprep.entity_path_reset", icon=LOAD_FACTORY, text="Reset entity path"
+        )
+    else:
+        box = col.box()
+        b_row = box.row()
+        b_row.label(text="No entities loaded")
+        b_row = box.row()
+        b_row.scale_y = 2
+        b_row.operator("mcprep.reload_spawners", text="Reload assets", icon="ERROR")
 
-	col = layout.column(align=True)
-	row = col.row()
-	row.scale_y = 1.5
-	row.enabled = len(scn_props.entity_list) > 0
-	if scn_props.entity_list:
-		name = scn_props.entity_list[scn_props.entity_list_index].name
-		entity = scn_props.entity_list[scn_props.entity_list_index].entity
-		p = row.operator("mcprep.entity_spawner", text="Spawn: " + name)
-		p.entity = entity
-	else:
-		row.operator("mcprep.entity_spawner", text="Spawn Entity")
+    col = layout.column(align=True)
+    row = col.row()
+    row.scale_y = 1.5
+    row.enabled = len(scn_props.entity_list) > 0
+    if scn_props.entity_list:
+        name = scn_props.entity_list[scn_props.entity_list_index].name
+        entity = scn_props.entity_list[scn_props.entity_list_index].entity
+        p = row.operator("mcprep.entity_spawner", text="Spawn: " + name)
+        p.entity = entity
+    else:
+        row.operator("mcprep.entity_spawner", text="Spawn Entity")
 
-	split = layout.split()
-	col = split.column(align=True)
-	row = col.row(align=True)
+    split = layout.split()
+    col = split.column(align=True)
+    row = col.row(align=True)
 
-	if not scn_props.show_settings_spawner:
-		col.prop(
-			scn_props, "show_settings_spawner",
-			text="Advanced", icon="TRIA_RIGHT")
-	else:
-		col.prop(
-			scn_props, "show_settings_spawner",
-			text="Advanced", icon="TRIA_DOWN")
-		box = col.box()
-		b_row = box.row()
-		b_col = b_row.column(align=False)
-		b_col.label(text="Entity file")
-		subrow = b_col.row(align=True)
-		subrow.prop(context.scene, "entity_path", text="")
-		subrow.operator("mcprep.entity_path_reset", icon=LOAD_FACTORY, text="")
-		if not context.scene.entity_path.lower().endswith('.blend'):
-			b_col.label(text="MeshSwap file must be a .blend", icon="ERROR")
-		elif not os.path.isfile(bpy.path.abspath(context.scene.entity_path)):
-			b_col.label(text="MeshSwap file not found", icon="ERROR")
-		b_row = box.row()
-		b_col = b_row.column(align=True)
-		b_col.operator("mcprep.reload_entities")
+    if not scn_props.show_settings_spawner:
+        col.prop(scn_props, "show_settings_spawner", text="Advanced", icon="TRIA_RIGHT")
+    else:
+        col.prop(scn_props, "show_settings_spawner", text="Advanced", icon="TRIA_DOWN")
+        box = col.box()
+        b_row = box.row()
+        b_col = b_row.column(align=False)
+        b_col.label(text="Entity file")
+        subrow = b_col.row(align=True)
+        subrow.prop(context.scene, "entity_path", text="")
+        subrow.operator("mcprep.entity_path_reset", icon=LOAD_FACTORY, text="")
+        if not context.scene.entity_path.lower().endswith(".blend"):
+            b_col.label(text="MeshSwap file must be a .blend", icon="ERROR")
+        elif not os.path.isfile(bpy.path.abspath(context.scene.entity_path)):
+            b_col.label(text="MeshSwap file not found", icon="ERROR")
+        b_row = box.row()
+        b_col = b_row.column(align=True)
+        b_col.operator("mcprep.reload_entities")
 
 
 def model_spawner(self, context):
-	"""Code for drawing the model block spawner"""
-	scn_props = context.scene.mcprep_props
-	addon_prefs = util.get_user_preferences(context)
+    """Code for drawing the model block spawner"""
+    scn_props = context.scene.mcprep_props
+    addon_prefs = util.get_user_preferences(context)
 
-	layout = self.layout
-	layout.label(text="Generate models from .json files")
-	split = layout.split()
-	col = split.column(align=True)
+    layout = self.layout
+    layout.label(text="Generate models from .json files")
+    split = layout.split()
+    col = split.column(align=True)
 
-	if scn_props.model_list:
-		col.template_list(
-			"MCPREP_UL_model", "",
-			scn_props, "model_list",
-			scn_props, "model_list_index",
-			rows=4)
+    if scn_props.model_list:
+        col.template_list(
+            "MCPREP_UL_model",
+            "",
+            scn_props,
+            "model_list",
+            scn_props,
+            "model_list_index",
+            rows=4,
+        )
 
-		col = layout.column(align=True)
-		row = col.row(align=True)
-		row.scale_y = 1.5
-		model = scn_props.model_list[scn_props.model_list_index]
-		ops = row.operator("mcprep.spawn_model", text="Place: " + model.name)
-		ops.location = util.get_cuser_location(context)
-		ops.filepath = model.filepath
-		if addon_prefs.MCprep_exporter_type == "Mineways":
-			ops.snapping = "offset"
-		elif addon_prefs.MCprep_exporter_type == "jmc2obj":
-			ops.snapping = "center"
-	else:
-		box = col.box()
-		b_row = box.row()
-		b_row.label(text="No models loaded")
-		b_row = box.row()
-		b_row.scale_y = 2
-		b_row.operator(
-			"mcprep.reload_spawners",
-			text="Reload assets", icon="ERROR")
+        col = layout.column(align=True)
+        row = col.row(align=True)
+        row.scale_y = 1.5
+        model = scn_props.model_list[scn_props.model_list_index]
+        ops = row.operator("mcprep.spawn_model", text="Place: " + model.name)
+        ops.location = util.get_cuser_location(context)
+        ops.filepath = model.filepath
+        if addon_prefs.MCprep_exporter_type == "Mineways":
+            ops.snapping = "offset"
+        elif addon_prefs.MCprep_exporter_type == "jmc2obj":
+            ops.snapping = "center"
+    else:
+        box = col.box()
+        b_row = box.row()
+        b_row.label(text="No models loaded")
+        b_row = box.row()
+        b_row.scale_y = 2
+        b_row.operator("mcprep.reload_spawners", text="Reload assets", icon="ERROR")
 
-		col = layout.column(align=True)
-		row = col.row(align=True)
-		row.enabled = False
-		row.scale_y = 1.5
-		row.operator(mcmodel.MCPREP_OT_spawn_minecraft_model.bl_idname)
+        col = layout.column(align=True)
+        row = col.row(align=True)
+        row.enabled = False
+        row.scale_y = 1.5
+        row.operator(mcmodel.MCPREP_OT_spawn_minecraft_model.bl_idname)
 
-	ops = col.operator("mcprep.import_model_file")
-	ops.location = util.get_cuser_location(context)
-	if addon_prefs.MCprep_exporter_type == "Mineways":
-		ops.snapping = "center"
-	elif addon_prefs.MCprep_exporter_type == "jmc2obj":
-		ops.snapping = "offset"
+    ops = col.operator("mcprep.import_model_file")
+    ops.location = util.get_cuser_location(context)
+    if addon_prefs.MCprep_exporter_type == "Mineways":
+        ops.snapping = "center"
+    elif addon_prefs.MCprep_exporter_type == "jmc2obj":
+        ops.snapping = "offset"
 
-	split = layout.split()
-	col = split.column(align=True)
-	row = col.row(align=True)
+    split = layout.split()
+    col = split.column(align=True)
+    row = col.row(align=True)
 
-	if not scn_props.show_settings_spawner:
-		col.prop(
-			scn_props, "show_settings_spawner",
-			text="Advanced", icon="TRIA_RIGHT")
-	else:
-		col.prop(
-			scn_props, "show_settings_spawner",
-			text="Advanced", icon="TRIA_DOWN")
-		box = col.box()
-		b_row = box.row()
-		b_col = b_row.column(align=False)
-		b_col.label(text="Resource pack")
-		subrow = b_col.row(align=True)
-		subrow.prop(context.scene, "mcprep_texturepack_path", text="")
-		subrow.operator(
-			"mcprep.reset_texture_path", icon=LOAD_FACTORY, text="")
-		b_row = box.row()
-		b_col = b_row.column(align=True)
-		b_col.operator("mcprep.reload_models")
+    if not scn_props.show_settings_spawner:
+        col.prop(scn_props, "show_settings_spawner", text="Advanced", icon="TRIA_RIGHT")
+    else:
+        col.prop(scn_props, "show_settings_spawner", text="Advanced", icon="TRIA_DOWN")
+        box = col.box()
+        b_row = box.row()
+        b_col = b_row.column(align=False)
+        b_col.label(text="Resource pack")
+        subrow = b_col.row(align=True)
+        subrow.prop(context.scene, "mcprep_texturepack_path", text="")
+        subrow.operator("mcprep.reset_texture_path", icon=LOAD_FACTORY, text="")
+        b_row = box.row()
+        b_col = b_row.column(align=True)
+        b_col.operator("mcprep.reload_models")
 
 
 def effects_spawner(self, context):
-	"""Code for drawing the effects spawner"""
-	scn_props = context.scene.mcprep_props
+    """Code for drawing the effects spawner"""
+    scn_props = context.scene.mcprep_props
 
-	layout = self.layout
-	col = layout.column(align=True)
-	col.label(text="Load/generate effects")
+    layout = self.layout
+    col = layout.column(align=True)
+    col.label(text="Load/generate effects")
 
-	# Alternate draw approach, using UI list.
-	if scn_props.effects_list:
-		col.template_list(
-			"MCPREP_UL_effects", "",
-			scn_props, "effects_list",
-			scn_props, "effects_list_index",
-			rows=4)
-		col = layout.column(align=True)
-		row = col.row(align=True)
-		row.scale_y = 1.5
-		effect = scn_props.effects_list[scn_props.effects_list_index]
-		if effect.effect_type in (effects.GEO_AREA, effects.PARTICLE_AREA):
-			ops = row.operator(
-				"mcprep.spawn_global_effect", text="Add: " + effect.name)
-			ops.effect_id = str(effect.index)
-		elif effect.effect_type in (effects.COLLECTION, effects.IMG_SEQ):
-			ops = row.operator(
-				"mcprep.spawn_instant_effect", text="Add: " + effect.name)
-			ops.effect_id = str(effect.index)
-			ops.location = util.get_cuser_location(context)
-			ops.frame = context.scene.frame_current
-	else:
-		box = col.box()
-		b_row = box.row()
-		b_row.label(text="No effects loaded")
-		b_row = box.row()
-		b_row.scale_y = 2
-		b_row.operator(
-			"mcprep.reload_spawners",
-			text="Reload assets", icon="ERROR")
+    # Alternate draw approach, using UI list.
+    if scn_props.effects_list:
+        col.template_list(
+            "MCPREP_UL_effects",
+            "",
+            scn_props,
+            "effects_list",
+            scn_props,
+            "effects_list_index",
+            rows=4,
+        )
+        col = layout.column(align=True)
+        row = col.row(align=True)
+        row.scale_y = 1.5
+        effect = scn_props.effects_list[scn_props.effects_list_index]
+        if effect.effect_type in (effects.GEO_AREA, effects.PARTICLE_AREA):
+            ops = row.operator("mcprep.spawn_global_effect", text="Add: " + effect.name)
+            ops.effect_id = str(effect.index)
+        elif effect.effect_type in (effects.COLLECTION, effects.IMG_SEQ):
+            ops = row.operator(
+                "mcprep.spawn_instant_effect", text="Add: " + effect.name
+            )
+            ops.effect_id = str(effect.index)
+            ops.location = util.get_cuser_location(context)
+            ops.frame = context.scene.frame_current
+    else:
+        box = col.box()
+        b_row = box.row()
+        b_row.label(text="No effects loaded")
+        b_row = box.row()
+        b_row.scale_y = 2
+        b_row.operator("mcprep.reload_spawners", text="Reload assets", icon="ERROR")
 
-		col = layout.column(align=True)
-		row = col.row(align=True)
-		row.scale_y = 1.5
-		row.enabled = False
-		row.operator("mcprep.spawn_item", text="Add effect")
-	row = col.row(align=True)
-	ops = row.operator("mcprep.spawn_particle_planes")
-	ops.location = util.get_cuser_location(context)
-	ops.frame = context.scene.frame_current
+        col = layout.column(align=True)
+        row = col.row(align=True)
+        row.scale_y = 1.5
+        row.enabled = False
+        row.operator("mcprep.spawn_item", text="Add effect")
+    row = col.row(align=True)
+    ops = row.operator("mcprep.spawn_particle_planes")
+    ops.location = util.get_cuser_location(context)
+    ops.frame = context.scene.frame_current
 
-	# If particle planes has not been changed yet this session,
-	# use the texture pack location in
-	if not context.scene.mcprep_particle_plane_file:
-		initial_sel = os.path.join(
-			context.scene.mcprep_texturepack_path,
-			"assets", "minecraft", "textures", "block", "dirt.png")
-		alt_sel = os.path.join(
-			context.scene.mcprep_texturepack_path,
-			"assets", "minecraft", "textures", "block")
-		if os.path.isfile(initial_sel):
-			ops.filepath = initial_sel
-		elif os.path.isdir(alt_sel):
-			ops.filepath = alt_sel
-		else:
-			ops.filepath = context.scene.mcprep_texturepack_path
-	else:
-		ops.filepath = context.scene.mcprep_particle_plane_file
+    # If particle planes has not been changed yet this session,
+    # use the texture pack location in
+    if not context.scene.mcprep_particle_plane_file:
+        initial_sel = os.path.join(
+            context.scene.mcprep_texturepack_path,
+            "assets",
+            "minecraft",
+            "textures",
+            "block",
+            "dirt.png",
+        )
+        alt_sel = os.path.join(
+            context.scene.mcprep_texturepack_path,
+            "assets",
+            "minecraft",
+            "textures",
+            "block",
+        )
+        if os.path.isfile(initial_sel):
+            ops.filepath = initial_sel
+        elif os.path.isdir(alt_sel):
+            ops.filepath = alt_sel
+        else:
+            ops.filepath = context.scene.mcprep_texturepack_path
+    else:
+        ops.filepath = context.scene.mcprep_particle_plane_file
 
-	col = layout.column()
-	if not scn_props.show_settings_effect:
-		col.prop(
-			scn_props, "show_settings_effect",
-			text="Advanced", icon="TRIA_RIGHT")
-	else:
-		col.prop(
-			scn_props, "show_settings_effect",
-			text="Advanced", icon="TRIA_DOWN")
-		box = col.box()
-		b_row = box.row()
-		b_col = b_row.column(align=False)
-		b_col.label(text="Effects folder")
-		subrow = b_col.row(align=True)
-		subrow.prop(context.scene, "mcprep_effects_path", text="")
-		subrow.operator("mcprep.effects_path_reset", icon=LOAD_FACTORY, text="")
+    col = layout.column()
+    if not scn_props.show_settings_effect:
+        col.prop(scn_props, "show_settings_effect", text="Advanced", icon="TRIA_RIGHT")
+    else:
+        col.prop(scn_props, "show_settings_effect", text="Advanced", icon="TRIA_DOWN")
+        box = col.box()
+        b_row = box.row()
+        b_col = b_row.column(align=False)
+        b_col.label(text="Effects folder")
+        subrow = b_col.row(align=True)
+        subrow.prop(context.scene, "mcprep_effects_path", text="")
+        subrow.operator("mcprep.effects_path_reset", icon=LOAD_FACTORY, text="")
 
-		box.label(text="Texture pack folder")
-		row = box.row(align=True)
-		row.prop(context.scene, "mcprep_texturepack_path", text="")
-		row.operator("mcprep.reset_texture_path", text="", icon=LOAD_FACTORY)
+        box.label(text="Texture pack folder")
+        row = box.row(align=True)
+        row.prop(context.scene, "mcprep_texturepack_path", text="")
+        row.operator("mcprep.reset_texture_path", text="", icon=LOAD_FACTORY)
 
-		base = bpy.path.abspath(context.scene.mcprep_effects_path)
-		if not os.path.isdir(base):
-			b_col.label(text="Effects folder not found", icon="ERROR")
-		elif not os.path.isdir(os.path.join(base, "collection")):
-			b_col.label(text="Effects/collection folder not found", icon="ERROR")
-		elif not os.path.isdir(os.path.join(base, "geonodes")):
-			b_col.label(text="Effects/geonodes folder not found", icon="ERROR")
-		elif not os.path.isdir(os.path.join(base, "particle")):
-			b_col.label(text="Effects/particle folder not found", icon="ERROR")
-		b_row = box.row()
-		b_col = b_row.column(align=True)
-		b_col.operator("mcprep.reload_effects")
+        base = bpy.path.abspath(context.scene.mcprep_effects_path)
+        if not os.path.isdir(base):
+            b_col.label(text="Effects folder not found", icon="ERROR")
+        elif not os.path.isdir(os.path.join(base, "collection")):
+            b_col.label(text="Effects/collection folder not found", icon="ERROR")
+        elif not os.path.isdir(os.path.join(base, "geonodes")):
+            b_col.label(text="Effects/geonodes folder not found", icon="ERROR")
+        elif not os.path.isdir(os.path.join(base, "particle")):
+            b_col.label(text="Effects/particle folder not found", icon="ERROR")
+        b_row = box.row()
+        b_col = b_row.column(align=True)
+        b_col.operator("mcprep.reload_effects")
 
 
 class MCPREP_PT_spawn(bpy.types.Panel):
-	"""MCprep panel for mob spawning"""
-	bl_label = "Spawner"
-	bl_space_type = "VIEW_3D"
-	bl_region_type = 'UI'
-	bl_category = "MCprep"
+    """MCprep panel for mob spawning"""
 
-	def draw(self, context):
-		if addon_just_updated():
-			restart_layout(self.layout)
-			return
-		row = self.layout.row(align=True)
-		row.label(text="Click triangle to open")
-		ops = row.operator(
-			"mcprep.open_help", text="", icon="QUESTION", emboss=False)
-		ops.url = "https://theduckcow.com/dev/blender/mcprep/mcprep-spawner/"
-		addon_updater_ops.check_for_update_background()
+    bl_label = "Spawner"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
+    bl_category = "MCprep"
+
+    def draw(self, context):
+        if addon_just_updated():
+            restart_layout(self.layout)
+            return
+        row = self.layout.row(align=True)
+        row.label(text="Click triangle to open")
+        ops = row.operator("mcprep.open_help", text="", icon="QUESTION", emboss=False)
+        ops.url = "https://theduckcow.com/dev/blender/mcprep/mcprep-spawner/"
+        addon_updater_ops.check_for_update_background()
 
 
 class MCPREP_PT_mob_spawner(bpy.types.Panel):
-	"""MCprep panel for mob spawning"""
-	bl_label = "Mob spawner"
-	bl_parent_id = "MCPREP_PT_spawn"
-	bl_space_type = "VIEW_3D"
-	bl_region_type = 'UI'	
-	bl_category = "MCprep"
-	bl_options = {'DEFAULT_CLOSED'}
+    """MCprep panel for mob spawning"""
 
-	def draw(self, context):
-		if addon_just_updated():
-			restart_layout(self.layout)
-			return
-		is_obj_mode = context.mode == "OBJECT"
-		if not is_obj_mode:
-			draw_mode_warning(self.layout)
-			return
-		mob_spawner(self, context)
+    bl_label = "Mob spawner"
+    bl_parent_id = "MCPREP_PT_spawn"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
+    bl_category = "MCprep"
+    bl_options = {"DEFAULT_CLOSED"}
 
-	def draw_header(self, context):
-		if not env.use_icons or env.preview_collections["main"] == "":
-			return
-		icon = env.preview_collections["main"].get("spawner_icon")
-		if not icon:
-			return
-		self.layout.label(text="", icon_value=icon.icon_id)
+    def draw(self, context):
+        if addon_just_updated():
+            restart_layout(self.layout)
+            return
+        is_obj_mode = context.mode == "OBJECT"
+        if not is_obj_mode:
+            draw_mode_warning(self.layout)
+            return
+        mob_spawner(self, context)
+
+    def draw_header(self, context):
+        if not env.use_icons or env.preview_collections["main"] == "":
+            return
+        icon = env.preview_collections["main"].get("spawner_icon")
+        if not icon:
+            return
+        self.layout.label(text="", icon_value=icon.icon_id)
 
 
 class MCPREP_PT_model_spawner(bpy.types.Panel):
-	"""MCprep panel for model/block spawning"""
-	bl_label = "Block (model) spawner"
-	bl_parent_id = "MCPREP_PT_spawn"
-	bl_space_type = "VIEW_3D"
-	bl_region_type = 'UI'
-	bl_category = "MCprep"
-	bl_options = {'DEFAULT_CLOSED'}
+    """MCprep panel for model/block spawning"""
 
-	def draw(self, context):
-		if addon_just_updated():
-			restart_layout(self.layout)
-			return
-		is_obj_mode = context.mode == "OBJECT"
-		if not is_obj_mode:
-			draw_mode_warning(self.layout)
-			return
-		model_spawner(self, context)
+    bl_label = "Block (model) spawner"
+    bl_parent_id = "MCPREP_PT_spawn"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
+    bl_category = "MCprep"
+    bl_options = {"DEFAULT_CLOSED"}
 
-	def draw_header(self, context):
-		if not env.use_icons or env.preview_collections["main"] == "":
-			return
-		icon = env.preview_collections["main"].get("model_icon")
-		if not icon:
-			return
-		self.layout.label(text="", icon_value=icon.icon_id)
+    def draw(self, context):
+        if addon_just_updated():
+            restart_layout(self.layout)
+            return
+        is_obj_mode = context.mode == "OBJECT"
+        if not is_obj_mode:
+            draw_mode_warning(self.layout)
+            return
+        model_spawner(self, context)
+
+    def draw_header(self, context):
+        if not env.use_icons or env.preview_collections["main"] == "":
+            return
+        icon = env.preview_collections["main"].get("model_icon")
+        if not icon:
+            return
+        self.layout.label(text="", icon_value=icon.icon_id)
 
 
 class MCPREP_PT_item_spawner(bpy.types.Panel):
-	"""MCprep panel for item spawning"""
-	bl_label = "Item spawner"
-	bl_parent_id = "MCPREP_PT_spawn"
-	bl_space_type = "VIEW_3D"
-	bl_region_type = 'UI'
-	bl_category = "MCprep"
-	bl_options = {'DEFAULT_CLOSED'}
+    """MCprep panel for item spawning"""
 
-	def draw(self, context):
-		if addon_just_updated():
-			restart_layout(self.layout)
-			return
-		is_obj_mode = context.mode == "OBJECT"
-		is_pose_mode = context.mode == "POSE"
-		if not is_obj_mode and not is_pose_mode:
-			draw_mode_warning(self.layout)
-			return
-		item_spawner(self, context)
+    bl_label = "Item spawner"
+    bl_parent_id = "MCPREP_PT_spawn"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
+    bl_category = "MCprep"
+    bl_options = {"DEFAULT_CLOSED"}
 
-	def draw_header(self, context):
-		if not env.use_icons or env.preview_collections["main"] == "":
-			return
-		icon = env.preview_collections["main"].get("sword_icon")
-		if not icon:
-			return
-		self.layout.label(text="", icon_value=icon.icon_id)
+    def draw(self, context):
+        if addon_just_updated():
+            restart_layout(self.layout)
+            return
+        is_obj_mode = context.mode == "OBJECT"
+        is_pose_mode = context.mode == "POSE"
+        if not is_obj_mode and not is_pose_mode:
+            draw_mode_warning(self.layout)
+            return
+        item_spawner(self, context)
+
+    def draw_header(self, context):
+        if not env.use_icons or env.preview_collections["main"] == "":
+            return
+        icon = env.preview_collections["main"].get("sword_icon")
+        if not icon:
+            return
+        self.layout.label(text="", icon_value=icon.icon_id)
 
 
 class MCPREP_PT_effects_spawner(bpy.types.Panel):
-	"""MCprep panel for effects spawning"""
-	bl_label = "Effects + weather"
-	bl_parent_id = "MCPREP_PT_spawn"
-	bl_space_type = "VIEW_3D"
-	bl_region_type = 'UI'
-	bl_category = "MCprep"
-	bl_options = {'DEFAULT_CLOSED'}
+    """MCprep panel for effects spawning"""
 
-	def draw(self, context):
-		if addon_just_updated():
-			restart_layout(self.layout)
-			return
-		is_obj_mode = context.mode == "OBJECT"
-		if not is_obj_mode:
-			draw_mode_warning(self.layout)
-			return
-		effects_spawner(self, context)
+    bl_label = "Effects + weather"
+    bl_parent_id = "MCPREP_PT_spawn"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
+    bl_category = "MCprep"
+    bl_options = {"DEFAULT_CLOSED"}
 
-	def draw_header(self, context):
-		if not env.use_icons or env.preview_collections["main"] == "":
-			return
-		icon = env.preview_collections["main"].get("effects_icon")
-		if not icon:
-			return
-		self.layout.label(text="", icon_value=icon.icon_id)
+    def draw(self, context):
+        if addon_just_updated():
+            restart_layout(self.layout)
+            return
+        is_obj_mode = context.mode == "OBJECT"
+        if not is_obj_mode:
+            draw_mode_warning(self.layout)
+            return
+        effects_spawner(self, context)
+
+    def draw_header(self, context):
+        if not env.use_icons or env.preview_collections["main"] == "":
+            return
+        icon = env.preview_collections["main"].get("effects_icon")
+        if not icon:
+            return
+        self.layout.label(text="", icon_value=icon.icon_id)
 
 
 class MCPREP_PT_entity_spawner(bpy.types.Panel):
-	"""MCprep panel for entity spawning"""
-	bl_label = "Entity spawner"
-	bl_parent_id = "MCPREP_PT_spawn"
-	bl_space_type = "VIEW_3D"
-	bl_region_type = 'UI'
-	bl_category = "MCprep"
-	bl_options = {'DEFAULT_CLOSED'}
+    """MCprep panel for entity spawning"""
 
-	def draw(self, context):
-		if addon_just_updated():
-			restart_layout(self.layout)
-			return
-		is_obj_mode = context.mode == "OBJECT"
-		if not is_obj_mode:
-			draw_mode_warning(self.layout)
-			return
-		entity_spawner(self, context)
+    bl_label = "Entity spawner"
+    bl_parent_id = "MCPREP_PT_spawn"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
+    bl_category = "MCprep"
+    bl_options = {"DEFAULT_CLOSED"}
 
-	def draw_header(self, context):
-		if not env.use_icons or env.preview_collections["main"] == "":
-			return
-		icon = env.preview_collections["main"].get("entity_icon")
-		if not icon:
-			return
-		self.layout.label(text="", icon_value=icon.icon_id)
+    def draw(self, context):
+        if addon_just_updated():
+            restart_layout(self.layout)
+            return
+        is_obj_mode = context.mode == "OBJECT"
+        if not is_obj_mode:
+            draw_mode_warning(self.layout)
+            return
+        entity_spawner(self, context)
+
+    def draw_header(self, context):
+        if not env.use_icons or env.preview_collections["main"] == "":
+            return
+        icon = env.preview_collections["main"].get("entity_icon")
+        if not icon:
+            return
+        self.layout.label(text="", icon_value=icon.icon_id)
 
 
 class MCPREP_PT_meshswap_spawner(bpy.types.Panel):
-	"""MCprep panel for meshswap spawning"""
-	bl_label = "Meshswap spawner"
-	bl_parent_id = "MCPREP_PT_spawn"
-	bl_space_type = "VIEW_3D"
-	bl_region_type = 'UI'
-	bl_category = "MCprep"
-	bl_options = {'DEFAULT_CLOSED'}
+    """MCprep panel for meshswap spawning"""
 
-	def draw(self, context):
-		if addon_just_updated():
-			restart_layout(self.layout)
-			return
-		is_obj_mode = context.mode == "OBJECT"
-		if not is_obj_mode:
-			draw_mode_warning(self.layout)
-			return
-		meshswap_spawner(self, context)
+    bl_label = "Meshswap spawner"
+    bl_parent_id = "MCPREP_PT_spawn"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "UI"
+    bl_category = "MCprep"
+    bl_options = {"DEFAULT_CLOSED"}
 
-	def draw_header(self, context):
-		if not env.use_icons or env.preview_collections["main"] == "":
-			return
-		icon = env.preview_collections["main"].get("meshswap_icon")
-		if not icon:
-			return
-		self.layout.label(text="", icon_value=icon.icon_id)
+    def draw(self, context):
+        if addon_just_updated():
+            restart_layout(self.layout)
+            return
+        is_obj_mode = context.mode == "OBJECT"
+        if not is_obj_mode:
+            draw_mode_warning(self.layout)
+            return
+        meshswap_spawner(self, context)
+
+    def draw_header(self, context):
+        if not env.use_icons or env.preview_collections["main"] == "":
+            return
+        icon = env.preview_collections["main"].get("meshswap_icon")
+        if not icon:
+            return
+        self.layout.label(text="", icon_value=icon.icon_id)
 
 
 # -----------------------------------------------------------------------------
@@ -1859,52 +1901,52 @@ class MCPREP_PT_meshswap_spawner(bpy.types.Panel):
 
 
 def draw_mcprepadd(self, context):
-	"""Append to Shift+A, icon for top-level MCprep section."""
-	layout = self.layout
-	pcoll = env.preview_collections["main"]
-	if pcoll != "":
-		my_icon = pcoll["crafting_icon"]
-		layout.menu(MCPREP_MT_3dview_add.bl_idname, icon_value=my_icon.icon_id)
-	else:
-		layout.menu(MCPREP_MT_3dview_add.bl_idname)
+    """Append to Shift+A, icon for top-level MCprep section."""
+    layout = self.layout
+    pcoll = env.preview_collections["main"]
+    if pcoll != "":
+        my_icon = pcoll["crafting_icon"]
+        layout.menu(MCPREP_MT_3dview_add.bl_idname, icon_value=my_icon.icon_id)
+    else:
+        layout.menu(MCPREP_MT_3dview_add.bl_idname)
 
 
 def mcprep_uv_tools(self, context):
-	"""Appended to UV tools in UV image editor tab, in object edit mode."""
-	layout = self.layout
-	layout.separator()
-	layout.label(text="MCprep tools")
-	col = layout.column(align=True)
-	col.operator("mcprep.scale_uv")
-	col.operator("mcprep.select_alpha_faces")
+    """Appended to UV tools in UV image editor tab, in object edit mode."""
+    layout = self.layout
+    layout.separator()
+    layout.label(text="MCprep tools")
+    col = layout.column(align=True)
+    col.operator("mcprep.scale_uv")
+    col.operator("mcprep.select_alpha_faces")
 
 
 def mcprep_image_tools(self, context):
-	"""Tools that will display in object mode in the UV image editor."""
-	row = self.layout.row()
-	img = context.space_data.image
-	if img:
-		path = context.space_data.image.filepath
-	else:
-		path = ""
-	if not path:
-		txt = "(Save image first)"
-		row.enabled = False
-	else:
-		txt = "Spawn as item"
-	if not img:
-		row.enabled = False
-	if env.preview_collections["main"] != "":
-		sword_icon = env.preview_collections["main"]["sword_icon"]
-	else:
-		sword_icon = None
+    """Tools that will display in object mode in the UV image editor."""
+    row = self.layout.row()
+    img = context.space_data.image
+    if img:
+        path = context.space_data.image.filepath
+    else:
+        path = ""
+    if not path:
+        txt = "(Save image first)"
+        row.enabled = False
+    else:
+        txt = "Spawn as item"
+    if not img:
+        row.enabled = False
+    if env.preview_collections["main"] != "":
+        sword_icon = env.preview_collections["main"]["sword_icon"]
+    else:
+        sword_icon = None
 
-	if sword_icon:
-		row.operator(
-			"mcprep.spawn_item", text=txt,
-			icon_value=sword_icon.icon_id).filepath = path
-	else:
-		row.operator("mcprep.spawn_item", text=txt).filepath = path
+    if sword_icon:
+        row.operator(
+            "mcprep.spawn_item", text=txt, icon_value=sword_icon.icon_id
+        ).filepath = path
+    else:
+        row.operator("mcprep.spawn_item", text=txt).filepath = path
 
 
 # -----------------------------------------------
@@ -1913,74 +1955,77 @@ def mcprep_image_tools(self, context):
 
 
 class McprepProps(bpy.types.PropertyGroup):
-	"""Properties saved to an individual scene"""
+    """Properties saved to an individual scene"""
 
-	# not available here
-	# addon_prefs = util.get_user_preferences()
+    # not available here
+    # addon_prefs = util.get_user_preferences()
 
-	# depreciated, keeping to prevent re-registration errors
-	show_settings_material: bpy.props.BoolProperty(
-		name="show material settings",
-		description="Show extra MCprep panel settings",
-		default=False)
-	show_settings_skin: bpy.props.BoolProperty(
-		name="show skin settings",
-		description="Show extra MCprep panel settings",
-		default=False)
-	show_settings_optimizer: bpy.props.BoolProperty(
-		name="show optimizer settings",
-		description="Show extra MCprep panel settings",
-		default=False)
-	show_settings_spawner: bpy.props.BoolProperty(
-		name="show spawner settings",
-		description="Show extra MCprep panel settings",
-		default=False)
-	show_settings_effect: bpy.props.BoolProperty(
-		name="show effect settings",
-		description="Show extra MCprep panel settings",
-		default=False)
+    # depreciated, keeping to prevent re-registration errors
+    show_settings_material: bpy.props.BoolProperty(
+        name="show material settings",
+        description="Show extra MCprep panel settings",
+        default=False,
+    )
+    show_settings_skin: bpy.props.BoolProperty(
+        name="show skin settings",
+        description="Show extra MCprep panel settings",
+        default=False,
+    )
+    show_settings_optimizer: bpy.props.BoolProperty(
+        name="show optimizer settings",
+        description="Show extra MCprep panel settings",
+        default=False,
+    )
+    show_settings_spawner: bpy.props.BoolProperty(
+        name="show spawner settings",
+        description="Show extra MCprep panel settings",
+        default=False,
+    )
+    show_settings_effect: bpy.props.BoolProperty(
+        name="show effect settings",
+        description="Show extra MCprep panel settings",
+        default=False,
+    )
 
-	# Rig settings
-	spawn_rig_category: bpy.props.EnumProperty(
-		name="Mob category",
-		description="Category of mobs & character rigs to spawn",
-		update=mobs.spawn_rigs_category_load,
-		items=mobs.spawn_rigs_categories
-	)
-	spawn_mode: bpy.props.EnumProperty(
-		name="Spawn Mode",
-		description="Set mode for rig/object spawner",
-		items=[
-			('mob', 'Mob', 'Show mob spawner'),
-			('model', 'Block', 'Show model (block) spawner'),
-			('item', 'Item', 'Show item spawner'),
-			('entity', 'Entity', 'Show entity spawner'),
-			('meshswap', 'MeshSwap', 'Show MeshSwap spawner')]
-	)
+    # Rig settings
+    spawn_rig_category: bpy.props.EnumProperty(
+        name="Mob category",
+        description="Category of mobs & character rigs to spawn",
+        update=mobs.spawn_rigs_category_load,
+        items=mobs.spawn_rigs_categories,
+    )
+    spawn_mode: bpy.props.EnumProperty(
+        name="Spawn Mode",
+        description="Set mode for rig/object spawner",
+        items=[
+            ("mob", "Mob", "Show mob spawner"),
+            ("model", "Block", "Show model (block) spawner"),
+            ("item", "Item", "Show item spawner"),
+            ("entity", "Entity", "Show entity spawner"),
+            ("meshswap", "MeshSwap", "Show MeshSwap spawner"),
+        ],
+    )
 
-	# spawn lists
-	mob_list: bpy.props.CollectionProperty(type=spawn_util.ListMobAssets)
-	mob_list_index: bpy.props.IntProperty(default=0)
-	mob_list_all: bpy.props.CollectionProperty(
-		type=spawn_util.ListMobAssetsAll)
-	meshswap_list: bpy.props.CollectionProperty(
-		type=spawn_util.ListMeshswapAssets)
-	meshswap_list_index: bpy.props.IntProperty(default=0)
-	item_list: bpy.props.CollectionProperty(type=spawn_util.ListItemAssets)
-	item_list_index: bpy.props.IntProperty(default=0)
-	material_list: bpy.props.CollectionProperty(
-		type=material_manager.ListMaterials)
-	material_list_index: bpy.props.IntProperty(default=0)
-	entity_list: bpy.props.CollectionProperty(type=spawn_util.ListEntityAssets)
-	entity_list_index: bpy.props.IntProperty(default=0)
-	model_list: bpy.props.CollectionProperty(type=spawn_util.ListModelAssets)
-	model_list_index: bpy.props.IntProperty(default=0)
+    # spawn lists
+    mob_list: bpy.props.CollectionProperty(type=spawn_util.ListMobAssets)
+    mob_list_index: bpy.props.IntProperty(default=0)
+    mob_list_all: bpy.props.CollectionProperty(type=spawn_util.ListMobAssetsAll)
+    meshswap_list: bpy.props.CollectionProperty(type=spawn_util.ListMeshswapAssets)
+    meshswap_list_index: bpy.props.IntProperty(default=0)
+    item_list: bpy.props.CollectionProperty(type=spawn_util.ListItemAssets)
+    item_list_index: bpy.props.IntProperty(default=0)
+    material_list: bpy.props.CollectionProperty(type=material_manager.ListMaterials)
+    material_list_index: bpy.props.IntProperty(default=0)
+    entity_list: bpy.props.CollectionProperty(type=spawn_util.ListEntityAssets)
+    entity_list_index: bpy.props.IntProperty(default=0)
+    model_list: bpy.props.CollectionProperty(type=spawn_util.ListModelAssets)
+    model_list_index: bpy.props.IntProperty(default=0)
 
-	# Effects are uniqune in that they are loaded into a list structure,
-	# but the UI list itself is not directly displayed. Rather, dropdowns
-	# will iterate over this to populate based on type.
-	effects_list: bpy.props.CollectionProperty(type=spawn_util.ListEffectsAssets)
-	effects_list_index: bpy.props.IntProperty(default=0)
+    # Effects are uniqune in that they are loaded into a list structure,
+    # but the UI list itself is not directly displayed. Rather, dropdowns
+    # will iterate over this to populate based on type.
+    effects_list: bpy.props.CollectionProperty(type=spawn_util.ListEffectsAssets)
+    effects_list_index: bpy.props.IntProperty(default=0)
 
 
 # -----------------------------------------------------------------------------
@@ -1989,109 +2034,117 @@ class McprepProps(bpy.types.PropertyGroup):
 
 
 classes = (
-	McprepPreference,
-	McprepProps,
-	MCPREP_MT_mob_spawner,
-	MCPREP_MT_meshswap_place,
-	MCPREP_MT_item_spawn,
-	MCPREP_MT_effect_spawn,
-	MCPREP_MT_entity_spawn,
-	MCPREP_MT_model_spawn,
-	MCPREP_MT_3dview_add,
-	MCPREP_PT_world_imports,
-	# MCPREP_PT_bridge,
-	MCPREP_PT_world_tools,
-	MCPREP_PT_skins,
-	MCPREP_PT_spawn,
-	MCPREP_PT_mob_spawner,
-	MCPREP_PT_model_spawner,
-	MCPREP_PT_item_spawner,
-	MCPREP_PT_effects_spawner,
-	MCPREP_PT_entity_spawner,
-	MCPREP_PT_meshswap_spawner,
-	MCPREP_PT_materials,
-	MCPREP_PT_materials_subsettings,
+    McprepPreference,
+    McprepProps,
+    MCPREP_MT_mob_spawner,
+    MCPREP_MT_meshswap_place,
+    MCPREP_MT_item_spawn,
+    MCPREP_MT_effect_spawn,
+    MCPREP_MT_entity_spawn,
+    MCPREP_MT_model_spawn,
+    MCPREP_MT_3dview_add,
+    MCPREP_PT_world_imports,
+    # MCPREP_PT_bridge,
+    MCPREP_PT_world_tools,
+    MCPREP_PT_skins,
+    MCPREP_PT_spawn,
+    MCPREP_PT_mob_spawner,
+    MCPREP_PT_model_spawner,
+    MCPREP_PT_item_spawner,
+    MCPREP_PT_effects_spawner,
+    MCPREP_PT_entity_spawner,
+    MCPREP_PT_meshswap_spawner,
+    MCPREP_PT_materials,
+    MCPREP_PT_materials_subsettings,
 )
 
 
 def register():
-	for cls in classes:
-		bpy.utils.register_class(cls)
+    for cls in classes:
+        bpy.utils.register_class(cls)
 
-	bpy.types.Scene.mcprep_props = bpy.props.PointerProperty(type=McprepProps)
+    bpy.types.Scene.mcprep_props = bpy.props.PointerProperty(type=McprepProps)
 
-	# scene settings (later re-attempt to put into props group)
-	addon_prefs = util.get_user_preferences()
+    # scene settings (later re-attempt to put into props group)
+    addon_prefs = util.get_user_preferences()
 
-	bpy.types.Scene.mcprep_mob_path = bpy.props.StringProperty(
-		name="Mob folder",
-		description="Folder for rigs to spawn in, saved with this blend file data",
-		subtype='DIR_PATH',
-		update=mobs.update_rig_path,
-		default=addon_prefs.mob_path)
-	bpy.types.Scene.mcprep_skin_path = bpy.props.StringProperty(
-		name="Skin folder",
-		description="Folder for skin textures, used in skin swapping",
-		subtype='DIR_PATH',
-		update=update_skin_path,
-		default=addon_prefs.skin_path)
-	bpy.types.Scene.meshswap_path = bpy.props.StringProperty(
-		name="Meshswap file",
-		description="File for meshswap library",
-		subtype='FILE_PATH',
-		update=meshswap.update_meshswap_path,
-		default=addon_prefs.meshswap_path)
-	bpy.types.Scene.mcprep_effects_path = bpy.props.StringProperty(
-		name="Effects folder",
-		description="Folder for handcrafted effects like particles and geonodes",
-		subtype='DIR_PATH',
-		update=effects.update_effects_path,
-		default=addon_prefs.effects_path)
-	bpy.types.Scene.mcprep_particle_plane_file = bpy.props.StringProperty(
-		name="Particle planes file set",
-		description="Has the particle planes file been changed",
-		subtype='FILE_PATH',
-		default='')
-	bpy.types.Scene.entity_path = bpy.props.StringProperty(
-		name="Entity file",
-		description="File for entity library",
-		subtype='FILE_PATH',
-		update=entities.update_entity_path,
-		default=addon_prefs.entity_path)
-	bpy.types.Scene.mcprep_texturepack_path = bpy.props.StringProperty(
-		name="Path to texture pack",
-		subtype='DIR_PATH',
-		description=(
-			"Path to a folder containing resources and textures to use "
-			"with material prepping"),
-		update=update_mcprep_texturepack_path,
-		default=addon_prefs.custom_texturepack_path)
+    bpy.types.Scene.mcprep_mob_path = bpy.props.StringProperty(
+        name="Mob folder",
+        description="Folder for rigs to spawn in, saved with this blend file data",
+        subtype="DIR_PATH",
+        update=mobs.update_rig_path,
+        default=addon_prefs.mob_path,
+    )
+    bpy.types.Scene.mcprep_skin_path = bpy.props.StringProperty(
+        name="Skin folder",
+        description="Folder for skin textures, used in skin swapping",
+        subtype="DIR_PATH",
+        update=update_skin_path,
+        default=addon_prefs.skin_path,
+    )
+    bpy.types.Scene.meshswap_path = bpy.props.StringProperty(
+        name="Meshswap file",
+        description="File for meshswap library",
+        subtype="FILE_PATH",
+        update=meshswap.update_meshswap_path,
+        default=addon_prefs.meshswap_path,
+    )
+    bpy.types.Scene.mcprep_effects_path = bpy.props.StringProperty(
+        name="Effects folder",
+        description="Folder for handcrafted effects like particles and geonodes",
+        subtype="DIR_PATH",
+        update=effects.update_effects_path,
+        default=addon_prefs.effects_path,
+    )
+    bpy.types.Scene.mcprep_particle_plane_file = bpy.props.StringProperty(
+        name="Particle planes file set",
+        description="Has the particle planes file been changed",
+        subtype="FILE_PATH",
+        default="",
+    )
+    bpy.types.Scene.entity_path = bpy.props.StringProperty(
+        name="Entity file",
+        description="File for entity library",
+        subtype="FILE_PATH",
+        update=entities.update_entity_path,
+        default=addon_prefs.entity_path,
+    )
+    bpy.types.Scene.mcprep_texturepack_path = bpy.props.StringProperty(
+        name="Path to texture pack",
+        subtype="DIR_PATH",
+        description=(
+            "Path to a folder containing resources and textures to use "
+            "with material prepping"
+        ),
+        update=update_mcprep_texturepack_path,
+        default=addon_prefs.custom_texturepack_path,
+    )
 
-	env.verbose = addon_prefs.verbose
-	if hasattr(bpy.types, "VIEW3D_MT_add"):  # 2.8
-		bpy.types.VIEW3D_MT_add.append(draw_mcprepadd)
+    env.verbose = addon_prefs.verbose
+    if hasattr(bpy.types, "VIEW3D_MT_add"):  # 2.8
+        bpy.types.VIEW3D_MT_add.append(draw_mcprepadd)
 
-	if hasattr(bpy.types, "IMAGE_MT_uvs"):  # 2.8 *and* 2.7
-		# this is a dropdown menu for UVs, not a panel
-		env.log("IMAGE_MT_uvs registration!")
-		bpy.types.IMAGE_MT_uvs.append(mcprep_uv_tools)
-	# bpy.types.IMAGE_MT_image.append(mcprep_image_tools) # crashes, re-do ops
+    if hasattr(bpy.types, "IMAGE_MT_uvs"):  # 2.8 *and* 2.7
+        # this is a dropdown menu for UVs, not a panel
+        env.log("IMAGE_MT_uvs registration!")
+        bpy.types.IMAGE_MT_uvs.append(mcprep_uv_tools)
+    # bpy.types.IMAGE_MT_image.append(mcprep_image_tools) # crashes, re-do ops
 
 
 def unregister():
-	for cls in reversed(classes):
-		bpy.utils.unregister_class(cls)
+    for cls in reversed(classes):
+        bpy.utils.unregister_class(cls)
 
-	elif hasattr(bpy.types, "VIEW3D_MT_add"):  # 2.8
-		bpy.types.VIEW3D_MT_add.remove(draw_mcprepadd)
+    if hasattr(bpy.types, "VIEW3D_MT_add"):  # 2.8
+        bpy.types.VIEW3D_MT_add.remove(draw_mcprepadd)
 
-	if hasattr(bpy.types, "IMAGE_MT_uvs"):  # 2.8 *and* 2.7
-		bpy.types.IMAGE_MT_uvs.remove(mcprep_uv_tools)
-	# bpy.types.IMAGE_MT_image.remove(mcprep_image_tools)
+    if hasattr(bpy.types, "IMAGE_MT_uvs"):  # 2.8 *and* 2.7
+        bpy.types.IMAGE_MT_uvs.remove(mcprep_uv_tools)
+    # bpy.types.IMAGE_MT_image.remove(mcprep_image_tools)
 
-	del bpy.types.Scene.mcprep_props
-	del bpy.types.Scene.mcprep_mob_path
-	del bpy.types.Scene.meshswap_path
-	del bpy.types.Scene.entity_path
-	del bpy.types.Scene.mcprep_skin_path
-	del bpy.types.Scene.mcprep_texturepack_path
+    del bpy.types.Scene.mcprep_props
+    del bpy.types.Scene.mcprep_mob_path
+    del bpy.types.Scene.meshswap_path
+    del bpy.types.Scene.entity_path
+    del bpy.types.Scene.mcprep_skin_path
+    del bpy.types.Scene.mcprep_texturepack_path

--- a/MCprep_addon/optimize_scene.py
+++ b/MCprep_addon/optimize_scene.py
@@ -23,15 +23,23 @@ from . import util
 from .materials import generate
 
 
-MAX_BOUNCES = 8 # 8 is generally the standard for light bounces
-MIN_BOUNCES = 2 # 2 is the lowest as it avoids issues regarding glossy
-CMP_BOUNCES = MIN_BOUNCES * 2 # To avoid bounces from going bellow 2
-MAX_FILTER_glossy = 1.0 # Standard in Blender
-MAX_STEPS = 200 # 200 is fine for most scenes
-MIN_SCRAMBLING_MULTIPLIER = 0.35 # 0.35 seems to help performance a lot, but we'll do edits to this value depending on materials
-SCRAMBLING_MULTIPLIER_ADD = 0.05 # This is how much we'll add to the srambling distance multiplier 
-CMP_SCRAMBLING_MULTIPLIER = MIN_SCRAMBLING_MULTIPLIER * 3 # The max since beyond this performance doesn't improve as much
-VOLUMETRIC_NODES = ["ShaderNodeVolumeScatter", "ShaderNodeVolumeAbsorption", "ShaderNodeVolumePrincipled"]
+MAX_BOUNCES = 8  # 8 is generally the standard for light bounces
+MIN_BOUNCES = 2  # 2 is the lowest as it avoids issues regarding glossy
+CMP_BOUNCES = MIN_BOUNCES * 2  # To avoid bounces from going bellow 2
+MAX_FILTER_glossy = 1.0  # Standard in Blender
+MAX_STEPS = 200  # 200 is fine for most scenes
+MIN_SCRAMBLING_MULTIPLIER = 0.35  # 0.35 seems to help performance a lot, but we'll do edits to this value depending on materials
+SCRAMBLING_MULTIPLIER_ADD = (
+    0.05  # This is how much we'll add to the srambling distance multiplier
+)
+CMP_SCRAMBLING_MULTIPLIER = (
+    MIN_SCRAMBLING_MULTIPLIER * 3
+)  # The max since beyond this performance doesn't improve as much
+VOLUMETRIC_NODES = [
+    "ShaderNodeVolumeScatter",
+    "ShaderNodeVolumeAbsorption",
+    "ShaderNodeVolumePrincipled",
+]
 
 # MCprep Node Settings
 MCPREP_HOMOGENOUS_volume = "MCPREP_HOMOGENOUS_VOLUME"
@@ -39,301 +47,331 @@ MCPREP_NOT_HOMOGENOUS_volume = "MCPREP_NOT_HOMOGENOUS_VOLUME"
 
 
 class MCprepOptimizerProperties(bpy.types.PropertyGroup):
-	def scene_brightness(self, context):
-		itms = [
-			("BRIGHT", "Scene is bright", "Use this setting if your scene is mostly bright\nEx. outside during the day"), 
-			("DARK", "Scene is dark", "Use this setting if your scene is mostly dark\nEx. caves, interiors, and outside at night")
-		]
-		return itms
+    def scene_brightness(self, context):
+        itms = [
+            (
+                "BRIGHT",
+                "Scene is bright",
+                "Use this setting if your scene is mostly bright\nEx. outside during the day",
+            ),
+            (
+                "DARK",
+                "Scene is dark",
+                "Use this setting if your scene is mostly dark\nEx. caves, interiors, and outside at night",
+            ),
+        ]
+        return itms
 
-	caustics_bool: bpy.props.BoolProperty(
-		name="Caustics (slower)",
-		default=False,
-		description="If checked allows cautics to be enabled"
-	)
-	motion_blur_bool: bpy.props.BoolProperty(
-		name="Motion Blur (slower)",
-		default=False,
-		description="If checked allows motion blur to be enabled"
-	)
-	scene_brightness: bpy.props.EnumProperty(
-		name="",
-		description="Brightness of the scene: Affects how the optimizer adjusts sampling",
-		items=scene_brightness
-	)
-	quality_vs_speed: bpy.props.BoolProperty(
-		name="Optimize scene for quality: Makes the optimizer adjust settings in a less \"destructive\" way",
-		default=True
-	)
-	simplify: bpy.props.BoolProperty(
-		name="Simplify the viewport: Reduces subdivisions to 0. Only disable if any assets will break when using this",
-		default=True
-	)
-	scrambling_unsafe: bpy.props.BoolProperty(
-		name="Automatic Scrambling Distance: Can cause artifacts when rendering",
-		default=False
-	)
-	preview_scrambling: bpy.props.BoolProperty(
-		name="Preview Scrambling in the viewport",
-		default=True
-	)
+    caustics_bool: bpy.props.BoolProperty(
+        name="Caustics (slower)",
+        default=False,
+        description="If checked allows cautics to be enabled",
+    )
+    motion_blur_bool: bpy.props.BoolProperty(
+        name="Motion Blur (slower)",
+        default=False,
+        description="If checked allows motion blur to be enabled",
+    )
+    scene_brightness: bpy.props.EnumProperty(
+        name="",
+        description="Brightness of the scene: Affects how the optimizer adjusts sampling",
+        items=scene_brightness,
+    )
+    quality_vs_speed: bpy.props.BoolProperty(
+        name='Optimize scene for quality: Makes the optimizer adjust settings in a less "destructive" way',
+        default=True,
+    )
+    simplify: bpy.props.BoolProperty(
+        name="Simplify the viewport: Reduces subdivisions to 0. Only disable if any assets will break when using this",
+        default=True,
+    )
+    scrambling_unsafe: bpy.props.BoolProperty(
+        name="Automatic Scrambling Distance: Can cause artifacts when rendering",
+        default=False,
+    )
+    preview_scrambling: bpy.props.BoolProperty(
+        name="Preview Scrambling in the viewport", default=True
+    )
 
 
 def panel_draw(context, element):
-	box = element.box()
-	col = box.column()
-	engine = context.scene.render.engine
-	scn_props = context.scene.optimizer_props
-	if engine == 'CYCLES':
-		col.label(text="Options")
-		quality_icon = "INDIRECT_ONLY_ON" if scn_props.quality_vs_speed else "INDIRECT_ONLY_OFF"
-		col.prop(scn_props, "quality_vs_speed", icon=quality_icon)
-		col.prop(scn_props, "simplify", icon=quality_icon)
+    box = element.box()
+    col = box.column()
+    engine = context.scene.render.engine
+    scn_props = context.scene.optimizer_props
+    if engine == "CYCLES":
+        col.label(text="Options")
+        quality_icon = (
+            "INDIRECT_ONLY_ON" if scn_props.quality_vs_speed else "INDIRECT_ONLY_OFF"
+        )
+        col.prop(scn_props, "quality_vs_speed", icon=quality_icon)
+        col.prop(scn_props, "simplify", icon=quality_icon)
 
-		col.label(text="Time of Day")
-		col.prop(scn_props, "scene_brightness")
-		col.prop(scn_props, "caustics_bool", icon="TRIA_UP")
-		col.prop(scn_props, "motion_blur_bool", icon="TRIA_UP")
-		col.row()
-		col.label(text="Unsafe Options! Use at your own risk!")
-		if util.bv30():
-			scrambling_unsafe_icon = "TRIA_DOWN" if scn_props.scrambling_unsafe else "TRIA_RIGHT"
-			col.prop(scn_props, "scrambling_unsafe", icon=scrambling_unsafe_icon)
-			if scn_props.scrambling_unsafe:
-				col.prop(scn_props, "preview_scrambling")
-		col.row()
-		col.label(text="")
-		subrow = col.row()
-		subrow.scale_y = 1.5
-		subrow.operator("mcprep.optimize_scene", text="Optimize Scene")
-	else:
-		col.label(text="Cycles Only :C")
+        col.label(text="Time of Day")
+        col.prop(scn_props, "scene_brightness")
+        col.prop(scn_props, "caustics_bool", icon="TRIA_UP")
+        col.prop(scn_props, "motion_blur_bool", icon="TRIA_UP")
+        col.row()
+        col.label(text="Unsafe Options! Use at your own risk!")
+        if util.bv30():
+            scrambling_unsafe_icon = (
+                "TRIA_DOWN" if scn_props.scrambling_unsafe else "TRIA_RIGHT"
+            )
+            col.prop(scn_props, "scrambling_unsafe", icon=scrambling_unsafe_icon)
+            if scn_props.scrambling_unsafe:
+                col.prop(scn_props, "preview_scrambling")
+        col.row()
+        col.label(text="")
+        subrow = col.row()
+        subrow.scale_y = 1.5
+        subrow.operator("mcprep.optimize_scene", text="Optimize Scene")
+    else:
+        col.label(text="Cycles Only :C")
 
 
 class MCPrep_OT_optimize_scene(bpy.types.Operator):
-	bl_idname = "mcprep.optimize_scene"
-	bl_label = "Optimize Scene"
-	bl_options = {'REGISTER', 'UNDO'}
+    bl_idname = "mcprep.optimize_scene"
+    bl_label = "Optimize Scene"
+    bl_options = {"REGISTER", "UNDO"}
 
-	def __init__(self):
-		# Sampling Settings.
-		self.samples = bpy.context.scene.cycles.samples # We will be doing some minor adjustments to the sample count
-		self.minimum_samples = None
-		self.noise_threshold = 0.2
+    def __init__(self):
+        # Sampling Settings.
+        self.samples = (
+            bpy.context.scene.cycles.samples
+        )  # We will be doing some minor adjustments to the sample count
+        self.minimum_samples = None
+        self.noise_threshold = 0.2
 
-		# Light Bounces.
-		self.diffuse = 2  # This is default because diffuse bounces don't need to be high
-		self.glossy = 1
-		self.transmissive = 1
-		self.volume = 2
+        # Light Bounces.
+        self.diffuse = (
+            2  # This is default because diffuse bounces don't need to be high
+        )
+        self.glossy = 1
+        self.transmissive = 1
+        self.volume = 2
 
-		# volumetric Settings.
-		self.max_steps = 100
-		self.stepping_rate = 5
-		self.homogenous_volumes = 0
-		self.not_homogenous_volumes = 0
+        # volumetric Settings.
+        self.max_steps = 100
+        self.stepping_rate = 5
+        self.homogenous_volumes = 0
+        self.not_homogenous_volumes = 0
 
-		# Filter glossy and clamping settings.
-		self.filter_glossy = 1
-		self.clamping_indirect = 1
+        # Filter glossy and clamping settings.
+        self.filter_glossy = 1
+        self.clamping_indirect = 1
 
-		# Motion blur, caustics, etc.
-		self.motion_blur = None
-		self.reflective_caustics = None
-		self.refractive_caustics = None
+        # Motion blur, caustics, etc.
+        self.motion_blur = None
+        self.reflective_caustics = None
+        self.refractive_caustics = None
 
-		# Optimizer Settings.
-		self.quality = None
-		self.uses_scrambling = None
-		self.preview_scrambling = None
-		self.scrambling_multiplier = MIN_SCRAMBLING_MULTIPLIER
-	
-	def is_vol(self, context, node):
-		density_socket = node.inputs["Density"] # Grab the density
-		node_name = util.nameGeneralize(node.name).rstrip()  # Get the name (who knew this could be used on nodes?)
-		# Sometimes there may be something linked to the density but it's fine to treat it as a homogeneous volume
-		# This allows the user to control the addon at the node level
-		if not density_socket.is_linked:
-			if node_name == MCPREP_NOT_HOMOGENOUS_volume:
-				self.not_homogenous_volumes -= 1
-			else:
-				self.homogenous_volumes += 1
-		else:
-			if node_name == MCPREP_HOMOGENOUS_volume:
-				self.homogenous_volumes += 1
-			else:
-				self.not_homogenous_volumes += 1
+        # Optimizer Settings.
+        self.quality = None
+        self.uses_scrambling = None
+        self.preview_scrambling = None
+        self.scrambling_multiplier = MIN_SCRAMBLING_MULTIPLIER
 
-		self.scrambling_multiplier += SCRAMBLING_MULTIPLIER_ADD
-		if self.scrambling_multiplier >= CMP_SCRAMBLING_MULTIPLIER: # at this point, it's worthless to keep it enabled 
-			self.uses_scrambling = False
-			self.preview_scrambling = False
-			self.scrambling_multiplier = 1.0
+    def is_vol(self, context, node):
+        density_socket = node.inputs["Density"]  # Grab the density
+        node_name = util.nameGeneralize(
+            node.name
+        ).rstrip()  # Get the name (who knew this could be used on nodes?)
+        # Sometimes there may be something linked to the density but it's fine to treat it as a homogeneous volume
+        # This allows the user to control the addon at the node level
+        if not density_socket.is_linked:
+            if node_name == MCPREP_NOT_HOMOGENOUS_volume:
+                self.not_homogenous_volumes -= 1
+            else:
+                self.homogenous_volumes += 1
+        else:
+            if node_name == MCPREP_HOMOGENOUS_volume:
+                self.homogenous_volumes += 1
+            else:
+                self.not_homogenous_volumes += 1
 
-		print(self.homogenous_volumes, " ", self.not_homogenous_volumes)
+        self.scrambling_multiplier += SCRAMBLING_MULTIPLIER_ADD
+        if (
+            self.scrambling_multiplier >= CMP_SCRAMBLING_MULTIPLIER
+        ):  # at this point, it's worthless to keep it enabled
+            self.uses_scrambling = False
+            self.preview_scrambling = False
+            self.scrambling_multiplier = 1.0
 
-	def is_pricipled(self, context, mat_type, node):
-		if mat_type == "reflective":
-			roughness_socket = node.inputs["Roughness"]
-			if not roughness_socket.is_linked and roughness_socket.default_value >= 0.2:
-				self.glossy = self.glossy - 1 if self.glossy > 2 else 2
-		elif mat_type == "glass":
-			transmission_socket = node.inputs["Transmission"]
-			if not transmission_socket.is_linked and transmission_socket.default_value >= 0:
-				self.transmissive = self.transmissive - 2 if self.transmissive > 1 else 2
+        print(self.homogenous_volumes, " ", self.not_homogenous_volumes)
 
-	def execute(self, context):
-		# ! Calling this twice seems to remove all unused materials
-		# TODO: find a better way of doing this
-		try:
-			bpy.ops.outliner.orphans_purge()
-			bpy.ops.outliner.orphans_purge()
-		except Exception as e:
-			print("Failed to purge orphans:")
-			print(e)
-		prefs = util.get_preferences(context)
-		cprefs = prefs.addons.get("cycles")
-		scn_props = context.scene.optimizer_props
+    def is_pricipled(self, context, mat_type, node):
+        if mat_type == "reflective":
+            roughness_socket = node.inputs["Roughness"]
+            if not roughness_socket.is_linked and roughness_socket.default_value >= 0.2:
+                self.glossy = self.glossy - 1 if self.glossy > 2 else 2
+        elif mat_type == "glass":
+            transmission_socket = node.inputs["Transmission"]
+            if (
+                not transmission_socket.is_linked
+                and transmission_socket.default_value >= 0
+            ):
+                self.transmissive = (
+                    self.transmissive - 2 if self.transmissive > 1 else 2
+                )
 
-		# Get the compute device type.
-		cycles_compute_device_type = None
-		has_active_device = cprefs.preferences.has_active_device()
-		if cprefs is not None and has_active_device:
-			cycles_compute_device_type = cprefs.preferences.compute_device_type
+    def execute(self, context):
+        # ! Calling this twice seems to remove all unused materials
+        # TODO: find a better way of doing this
+        try:
+            bpy.ops.outliner.orphans_purge()
+            bpy.ops.outliner.orphans_purge()
+        except Exception as e:
+            print("Failed to purge orphans:")
+            print(e)
+        prefs = util.get_preferences(context)
+        cprefs = prefs.addons.get("cycles")
+        scn_props = context.scene.optimizer_props
 
-		# Sampling Settings.
-		self.samples = bpy.context.scene.cycles.samples # We will be doing some minor adjustments to the sample count
-		self.minimum_samples = None
-		self.noise_threshold = 0.2
+        # Get the compute device type.
+        cycles_compute_device_type = None
+        has_active_device = cprefs.preferences.has_active_device()
+        if cprefs is not None and has_active_device:
+            cycles_compute_device_type = cprefs.preferences.compute_device_type
 
+        # Sampling Settings.
+        self.samples = (
+            bpy.context.scene.cycles.samples
+        )  # We will be doing some minor adjustments to the sample count
+        self.minimum_samples = None
+        self.noise_threshold = 0.2
 
-		# Light Bounces.
-		self.diffuse = 2  # This is default because diffuse bounces don't need to be high
-		self.glossy = 1
-		self.transmissive = 1
-		self.volume = 2
+        # Light Bounces.
+        self.diffuse = (
+            2  # This is default because diffuse bounces don't need to be high
+        )
+        self.glossy = 1
+        self.transmissive = 1
+        self.volume = 2
 
-		# volumetric Settings.
-		self.max_steps = 100
-		self.stepping_rate = 5
-		self.homogenous_volumes = 0
-		self.not_homogenous_volumes = 0
+        # volumetric Settings.
+        self.max_steps = 100
+        self.stepping_rate = 5
+        self.homogenous_volumes = 0
+        self.not_homogenous_volumes = 0
 
-		# Filter glossy and clamping settings.
-		self.filter_glossy = 1
-		self.clamping_indirect = 1
+        # Filter glossy and clamping settings.
+        self.filter_glossy = 1
+        self.clamping_indirect = 1
 
-		# Motion blur, caustics, etc.
-		self.motion_blur = scn_props.motion_blur_bool
-		self.reflective_caustics = scn_props.caustics_bool
-		self.refractive_caustics = scn_props.caustics_bool
+        # Motion blur, caustics, etc.
+        self.motion_blur = scn_props.motion_blur_bool
+        self.reflective_caustics = scn_props.caustics_bool
+        self.refractive_caustics = scn_props.caustics_bool
 
-		# Optimizer Settings.
-		self.quality = scn_props.quality_vs_speed
-		self.uses_scrambling = scn_props.scrambling_unsafe
-		self.preview_scrambling = scn_props.preview_scrambling
-		self.scrambling_multiplier = MIN_SCRAMBLING_MULTIPLIER
+        # Optimizer Settings.
+        self.quality = scn_props.quality_vs_speed
+        self.uses_scrambling = scn_props.scrambling_unsafe
+        self.preview_scrambling = scn_props.preview_scrambling
+        self.scrambling_multiplier = MIN_SCRAMBLING_MULTIPLIER
 
-		# Time of day.
-		if scn_props.scene_brightness == "BRIGHT":
-			self.noise_threshold = 0.2
-		else:
-			self.samples += 20
-			self.noise_threshold = 0.05
-		
-		if self.quality:
-			self.minimum_samples = self.samples // 4
-			self.filter_glossy = MAX_FILTER_glossy // 2
-			self.max_steps = MAX_STEPS # TODO: Add better volumetric optimizations
+        # Time of day.
+        if scn_props.scene_brightness == "BRIGHT":
+            self.noise_threshold = 0.2
+        else:
+            self.samples += 20
+            self.noise_threshold = 0.05
 
-		else:
-			self.minimum_samples = self.samples // 8
-			self.filter_glossy = MAX_FILTER_glossy
-			self.max_steps = MAX_STEPS // 2 # TODO: Add better volumetric optimizations
+        if self.quality:
+            self.minimum_samples = self.samples // 4
+            self.filter_glossy = MAX_FILTER_glossy // 2
+            self.max_steps = MAX_STEPS  # TODO: Add better volumetric optimizations
 
-		# Compute device.
-		if cycles_compute_device_type == "NONE":
-			if util.bv30() is False:
-				try:
-					addon_utils.enable("render_auto_tile_size", default_set=True)
-					val_1, val_2 = addon_utils.check("render_auto_tile_size")
-					if val_1 is not True:
-						bpy.context.scene.render.tile_x = 32
-						bpy.context.scene.render.tile_y = 32
-				except Exception:
-					bpy.context.scene.render.tile_x = 32
-					bpy.context.scene.render.tile_y = 32
+        else:
+            self.minimum_samples = self.samples // 8
+            self.filter_glossy = MAX_FILTER_glossy
+            self.max_steps = MAX_STEPS // 2  # TODO: Add better volumetric optimizations
 
-		elif cycles_compute_device_type in ("CUDA", "HIP"):
-			if util.bv30() is False:
-				try:
-					addon_utils.enable("render_auto_tile_size", default_set=True)
-					val_1, val_2 = addon_utils.check("render_auto_tile_size")
-					if val_1 is not True:
-						bpy.context.scene.render.tile_x = 256
-						bpy.context.scene.render.tile_y = 256
-				except Exception:
-					bpy.context.scene.render.tile_x = 256
-					bpy.context.scene.render.tile_y = 256
-	
-		elif cycles_compute_device_type == "OPTIX":
-			if util.bv30() is False:
-				try:
-					addon_utils.enable("render_auto_tile_size", default_set=True)
-					val_1, val_2 = addon_utils.check("render_auto_tile_size")
-					if val_1 is not True:
-						bpy.context.scene.render.tile_x = 512
-						bpy.context.scene.render.tile_y = 512
-				except Exception:
-					bpy.context.scene.render.tile_x = 512
-					bpy.context.scene.render.tile_y = 512
+        # Compute device.
+        if cycles_compute_device_type == "NONE":
+            if util.bv30() is False:
+                try:
+                    addon_utils.enable("render_auto_tile_size", default_set=True)
+                    val_1, val_2 = addon_utils.check("render_auto_tile_size")
+                    if val_1 is not True:
+                        bpy.context.scene.render.tile_x = 32
+                        bpy.context.scene.render.tile_y = 32
+                except Exception:
+                    bpy.context.scene.render.tile_x = 32
+                    bpy.context.scene.render.tile_y = 32
 
-		elif cycles_compute_device_type == "OPENCL": # Always in any version of Blender pre-3.0
-			try:
-				addon_utils.enable("render_auto_tile_size", default_set=True)
-				val_1, val_2 = addon_utils.check("render_auto_tile_size")
-				if val_1 is not True:
-					bpy.context.scene.render.tile_x = 256
-					bpy.context.scene.render.tile_y = 256
-			except Exception:
-				bpy.context.scene.render.tile_x = 256
-				bpy.context.scene.render.tile_y = 256
-    
-		# Cycles Render Settings Optimizations.
-		for mat in bpy.data.materials:
-			matGen = util.nameGeneralize(mat.name)
-			canon, form = generate.get_mc_canonical_name(matGen)
-			mat_type = None
-			if generate.checklist(canon, "reflective"):
-				self.glossy += 1
-				mat_type = "reflective"
-			if generate.checklist(canon, "glass"):
-				self.transmissive += 1
-				mat_type = "glass"
+        elif cycles_compute_device_type in ("CUDA", "HIP"):
+            if util.bv30() is False:
+                try:
+                    addon_utils.enable("render_auto_tile_size", default_set=True)
+                    val_1, val_2 = addon_utils.check("render_auto_tile_size")
+                    if val_1 is not True:
+                        bpy.context.scene.render.tile_x = 256
+                        bpy.context.scene.render.tile_y = 256
+                except Exception:
+                    bpy.context.scene.render.tile_x = 256
+                    bpy.context.scene.render.tile_y = 256
 
-			if mat.use_nodes:
-				nodes = mat.node_tree.nodes
-				for node in nodes:
-					print(node.bl_idname)
-					if node.bl_idname in VOLUMETRIC_NODES:
-						self.is_vol(context, node)
+        elif cycles_compute_device_type == "OPTIX":
+            if util.bv30() is False:
+                try:
+                    addon_utils.enable("render_auto_tile_size", default_set=True)
+                    val_1, val_2 = addon_utils.check("render_auto_tile_size")
+                    if val_1 is not True:
+                        bpy.context.scene.render.tile_x = 512
+                        bpy.context.scene.render.tile_y = 512
+                except Exception:
+                    bpy.context.scene.render.tile_x = 512
+                    bpy.context.scene.render.tile_y = 512
 
-					# Not the best check, but better then nothing
-					if node.bl_idname == "ShaderNodeBsdfPrincipled":
-						self.is_pricipled(context, mat_type, node)
-				
-				if self.homogenous_volumes > 0 or self.not_homogenous_volumes > 0:
-					volumes_rate = self.homogenous_volumes - self.not_homogenous_volumes
-					if volumes_rate > 0:
-						self.stepping_rate += 2 * volumes_rate
-						mat.cycles.homogenous_volume = True
-					elif volumes_rate < 0:
-						self.stepping_rate -= 2 * abs(volumes_rate) # get the absolute value of volumes_rate since it's negative
-						if self.stepping_rate < 2:
-							self.stepping_rate = 2 # 2 is the lowest stepping rate
+        elif (
+            cycles_compute_device_type == "OPENCL"
+        ):  # Always in any version of Blender pre-3.0
+            try:
+                addon_utils.enable("render_auto_tile_size", default_set=True)
+                val_1, val_2 = addon_utils.check("render_auto_tile_size")
+                if val_1 is not True:
+                    bpy.context.scene.render.tile_x = 256
+                    bpy.context.scene.render.tile_y = 256
+            except Exception:
+                bpy.context.scene.render.tile_x = 256
+                bpy.context.scene.render.tile_y = 256
 
+        # Cycles Render Settings Optimizations.
+        for mat in bpy.data.materials:
+            matGen = util.nameGeneralize(mat.name)
+            canon, form = generate.get_mc_canonical_name(matGen)
+            mat_type = None
+            if generate.checklist(canon, "reflective"):
+                self.glossy += 1
+                mat_type = "reflective"
+            if generate.checklist(canon, "glass"):
+                self.transmissive += 1
+                mat_type = "glass"
 
-		"""
+            if mat.use_nodes:
+                nodes = mat.node_tree.nodes
+                for node in nodes:
+                    print(node.bl_idname)
+                    if node.bl_idname in VOLUMETRIC_NODES:
+                        self.is_vol(context, node)
+
+                    # Not the best check, but better then nothing
+                    if node.bl_idname == "ShaderNodeBsdfPrincipled":
+                        self.is_pricipled(context, mat_type, node)
+
+                if self.homogenous_volumes > 0 or self.not_homogenous_volumes > 0:
+                    volumes_rate = self.homogenous_volumes - self.not_homogenous_volumes
+                    if volumes_rate > 0:
+                        self.stepping_rate += 2 * volumes_rate
+                        mat.cycles.homogenous_volume = True
+                    elif volumes_rate < 0:
+                        self.stepping_rate -= 2 * abs(
+                            volumes_rate
+                        )  # get the absolute value of volumes_rate since it's negative
+                        if self.stepping_rate < 2:
+                            self.stepping_rate = 2  # 2 is the lowest stepping rate
+
+        """
 		The reason we divide by 2 only if the bounces are greater then or equal to CMP_BOUNCES (MIN_BOUNCES * 2) is to 
 		prevent the division operation from setting the bounces below MIN_BOUNCES.
 
@@ -342,75 +380,75 @@ class MCPrep_OT_optimize_scene(bpy.types.Operator):
 
 		However, this is not an issue in this case since 3 is less then CMP_BOUNCES (by default anyway)
 		"""
-		if self.glossy >= CMP_BOUNCES:
-			self.glossy = self.glossy // 2
-		if self.transmissive >= CMP_BOUNCES:
-			self.transmissive = self.transmissive // 2
+        if self.glossy >= CMP_BOUNCES:
+            self.glossy = self.glossy // 2
+        if self.transmissive >= CMP_BOUNCES:
+            self.transmissive = self.transmissive // 2
 
-		local_max_bounce = MAX_BOUNCES
-		if self.glossy > local_max_bounce:
-			local_max_bounce = self.glossy
+        local_max_bounce = MAX_BOUNCES
+        if self.glossy > local_max_bounce:
+            local_max_bounce = self.glossy
 
-		if self.transmissive > local_max_bounce:
-			local_max_bounce = self.transmissive
+        if self.transmissive > local_max_bounce:
+            local_max_bounce = self.transmissive
 
-		# Sampling settings
-		# Adaptive sampling is something from Blender 2.9+
-		if util.min_bv((2, 90)):
-			bpy.context.scene.cycles.adaptive_threshold = self.noise_threshold
-			bpy.context.scene.cycles.adaptive_min_samples = self.minimum_samples
-		# Scrambling distance is a 3.0 feature
-		if util.bv30() and self.uses_scrambling:
-			bpy.context.scene.cycles.auto_scrambling_distance = self.uses_scrambling
-			bpy.context.scene.cycles.preview_scrambling_distance = self.preview_scrambling
-			bpy.context.scene.cycles.scrambling_distance = self.scrambling_multiplier
+        # Sampling settings
+        # Adaptive sampling is something from Blender 2.9+
+        if util.min_bv((2, 90)):
+            bpy.context.scene.cycles.adaptive_threshold = self.noise_threshold
+            bpy.context.scene.cycles.adaptive_min_samples = self.minimum_samples
+        # Scrambling distance is a 3.0 feature
+        if util.bv30() and self.uses_scrambling:
+            bpy.context.scene.cycles.auto_scrambling_distance = self.uses_scrambling
+            bpy.context.scene.cycles.preview_scrambling_distance = (
+                self.preview_scrambling
+            )
+            bpy.context.scene.cycles.scrambling_distance = self.scrambling_multiplier
 
-			if self.uses_scrambling is not False:
-				bpy.context.scene.cycles.min_light_bounces = 1
-				bpy.context.scene.cycles.min_transparent_bounces = 2
+            if self.uses_scrambling is not False:
+                bpy.context.scene.cycles.min_light_bounces = 1
+                bpy.context.scene.cycles.min_transparent_bounces = 2
 
-		bpy.context.scene.cycles.samples = self.samples
+        bpy.context.scene.cycles.samples = self.samples
 
-		# volumetric settings 
-		bpy.context.scene.cycles.volume_max_steps = self.max_steps
-		bpy.context.scene.cycles.volume_step_rate = self.stepping_rate
-		bpy.context.scene.cycles.volume_preview_step_rate = self.stepping_rate
+        # volumetric settings
+        bpy.context.scene.cycles.volume_max_steps = self.max_steps
+        bpy.context.scene.cycles.volume_step_rate = self.stepping_rate
+        bpy.context.scene.cycles.volume_preview_step_rate = self.stepping_rate
 
-		# Bounce settings
-		bpy.context.scene.cycles.max_bounces = local_max_bounce
-		bpy.context.scene.cycles.diffuse_bounces = self.diffuse
-		bpy.context.scene.cycles.volume_bounces = self.volume
-		bpy.context.scene.cycles.glossy_bounces = self.glossy
-		bpy.context.scene.cycles.transmission_bounces = self.transmissive
+        # Bounce settings
+        bpy.context.scene.cycles.max_bounces = local_max_bounce
+        bpy.context.scene.cycles.diffuse_bounces = self.diffuse
+        bpy.context.scene.cycles.volume_bounces = self.volume
+        bpy.context.scene.cycles.glossy_bounces = self.glossy
+        bpy.context.scene.cycles.transmission_bounces = self.transmissive
 
-		# Settings related to glossy and transmissive materials
-		bpy.context.scene.cycles.blur_glossy = self.filter_glossy
-		bpy.context.scene.cycles.caustics_reflective = self.reflective_caustics
-		bpy.context.scene.cycles.caustics_refractive = self.refractive_caustics
-		bpy.context.scene.cycles.sample_clamp_indirect = self.clamping_indirect
+        # Settings related to glossy and transmissive materials
+        bpy.context.scene.cycles.blur_glossy = self.filter_glossy
+        bpy.context.scene.cycles.caustics_reflective = self.reflective_caustics
+        bpy.context.scene.cycles.caustics_refractive = self.refractive_caustics
+        bpy.context.scene.cycles.sample_clamp_indirect = self.clamping_indirect
 
-		# Sometimes people don't want to use simplify because it messes with rigs
-		bpy.context.scene.render.use_simplify = scn_props.simplify
-		bpy.context.scene.render.simplify_subdivision = 0
-		bpy.context.scene.render.use_motion_blur = self.motion_blur
-		return {'FINISHED'}
+        # Sometimes people don't want to use simplify because it messes with rigs
+        bpy.context.scene.render.use_simplify = scn_props.simplify
+        bpy.context.scene.render.simplify_subdivision = 0
+        bpy.context.scene.render.use_motion_blur = self.motion_blur
+        return {"FINISHED"}
 
 
-classes = (
-	MCprepOptimizerProperties,
-	MCPrep_OT_optimize_scene
-)
+classes = (MCprepOptimizerProperties, MCPrep_OT_optimize_scene)
 
 
 def register():
-	for cls in classes:
-		bpy.utils.register_class(cls)
+    for cls in classes:
+        bpy.utils.register_class(cls)
 
-	bpy.types.Scene.optimizer_props = bpy.props.PointerProperty(
-		type=MCprepOptimizerProperties)
+    bpy.types.Scene.optimizer_props = bpy.props.PointerProperty(
+        type=MCprepOptimizerProperties
+    )
 
 
 def unregister():
-	for cls in reversed(classes):
-		bpy.utils.unregister_class(cls)
-	del bpy.types.Scene.optimizer_props
+    for cls in reversed(classes):
+        bpy.utils.unregister_class(cls)
+    del bpy.types.Scene.optimizer_props

--- a/MCprep_addon/spawner/effects.py
+++ b/MCprep_addon/spawner/effects.py
@@ -55,698 +55,704 @@ EXTENSIONS = [".png", ".jpg", ".jpeg", ".tiff"]
 
 
 def add_geonode_area_effect(context, effect):
-	"""Create a persistent effect which is meant to emulate a wide-area effect.
+    """Create a persistent effect which is meant to emulate a wide-area effect.
 
-	Effect is of type: ListEffectsAssets.
+    Effect is of type: ListEffectsAssets.
 
-	Import a geonode collection from the effects_geonodes.blend file, and then
-	parent it to the camera. These geonodes should function such that the
-	particles are dynamically loaded based on position to camera, and don't
-	require any pre-simulation time as they are deterministically placed (so
-	the camera can be zooming through an area and not need to give time for a
-	particle system to let some particles fall first).
-	"""
-	existing_geonodes = [
-		ndg for ndg in bpy.data.node_groups
-		if ndg.type == "GEOMETRY" and ndg.name == effect.subpath]
+    Import a geonode collection from the effects_geonodes.blend file, and then
+    parent it to the camera. These geonodes should function such that the
+    particles are dynamically loaded based on position to camera, and don't
+    require any pre-simulation time as they are deterministically placed (so
+    the camera can be zooming through an area and not need to give time for a
+    particle system to let some particles fall first).
+    """
+    existing_geonodes = [
+        ndg
+        for ndg in bpy.data.node_groups
+        if ndg.type == "GEOMETRY" and ndg.name == effect.subpath
+    ]
 
-	# Load this geo node if it doesn't already exist.
-	if not existing_geonodes:
-		with bpy.data.libraries.load(effect.filepath) as (data_from, data_to):
+    # Load this geo node if it doesn't already exist.
+    if not existing_geonodes:
+        with bpy.data.libraries.load(effect.filepath) as (data_from, data_to):
+            for this_group in data_from.node_groups:
+                if this_group != effect.subpath:
+                    continue
+                data_to.node_groups.append(this_group)
+                break
+        # Post
+        post_geonodes = [
+            ndg
+            for ndg in bpy.data.node_groups
+            if ndg.type == "GEOMETRY" and ndg.name == effect.subpath
+        ]
+        diff = list(set(post_geonodes) - set(existing_geonodes))
+        this_nodegroup = diff[0]
+    else:
+        this_nodegroup = existing_geonodes[0]
 
-			for this_group in data_from.node_groups:
-				if this_group != effect.subpath:
-					continue
-				data_to.node_groups.append(this_group)
-				break
-		# Post
-		post_geonodes = [
-			ndg for ndg in bpy.data.node_groups
-			if ndg.type == "GEOMETRY" and ndg.name == effect.subpath]
-		diff = list(set(post_geonodes) - set(existing_geonodes))
-		this_nodegroup = diff[0]
-	else:
-		this_nodegroup = existing_geonodes[0]
+    mesh = bpy.data.meshes.new(effect.name + " empty mesh")
+    new_obj = bpy.data.objects.new(effect.name, mesh)
 
-	mesh = bpy.data.meshes.new(effect.name + " empty mesh")
-	new_obj = bpy.data.objects.new(effect.name, mesh)
+    # TODO: consider trying to pick up the current collection setting,
+    # or placing into an explicit effects collection.
+    util.obj_link_scene(new_obj)
 
-	# TODO: consider trying to pick up the current collection setting,
-	# or placing into an explicit effects collection.
-	util.obj_link_scene(new_obj)
+    geo_mod = new_obj.modifiers.new(effect.name, "NODES")
+    geo_mod.node_group = this_nodegroup
 
-	geo_mod = new_obj.modifiers.new(effect.name, "NODES")
-	geo_mod.node_group = this_nodegroup
+    geo_update_params(context, effect, geo_mod)
 
-	geo_update_params(context, effect, geo_mod)
+    # Deselect everything and set newly added geonodes as active.
+    for ob in context.scene.objects:
+        if util.select_get(ob):
+            util.select_set(ob, False)
+    util.set_active_object(context, new_obj)
+    util.select_set(new_obj, True)
 
-	# Deselect everything and set newly added geonodes as active.
-	for ob in context.scene.objects:
-		if util.select_get(ob):
-			util.select_set(ob, False)
-	util.set_active_object(context, new_obj)
-	util.select_set(new_obj, True)
-
-	return new_obj
+    return new_obj
 
 
 def add_area_particle_effect(context, effect, location):
-	"""Create a persistent effect over wide area using traditional particles.
+    """Create a persistent effect over wide area using traditional particles.
 
-	Effect is of type: ListEffectsAssets.
+    Effect is of type: ListEffectsAssets.
 
-	Where geo nodes are not available (older blender versions) or if the user
-	prefers to have more control of the particle system being created after.
-	When created, it adds a plane over the area of the camera, with a
-	determined density setting such over the given radius it emits a consistent
-	amount per unit area. Ideally, the system could auto update the emission
-	count even as this object is scaled.
-	"""
+    Where geo nodes are not available (older blender versions) or if the user
+    prefers to have more control of the particle system being created after.
+    When created, it adds a plane over the area of the camera, with a
+    determined density setting such over the given radius it emits a consistent
+    amount per unit area. Ideally, the system could auto update the emission
+    count even as this object is scaled.
+    """
 
-	# Create the plane.
-	mesh = get_or_create_plane_mesh("particle_plane")
-	obj = bpy.data.objects.new(effect.name, mesh)
-	util.obj_link_scene(obj, context)
-	obj.location = location
-	obj.scale = (40, 40, 40)
+    # Create the plane.
+    mesh = get_or_create_plane_mesh("particle_plane")
+    obj = bpy.data.objects.new(effect.name, mesh)
+    util.obj_link_scene(obj, context)
+    obj.location = location
+    obj.scale = (40, 40, 40)
 
-	# Load the indicated particle system.
-	pre_systems = list(bpy.data.particles)
-	with bpy.data.libraries.load(effect.filepath) as (data_from, data_to):
-		for itm in data_from.particles:
-			if itm == effect.name:
-				data_to.particles.append(itm)
-	post_systems = list(bpy.data.particles)
-	imported_particles = list(set(post_systems) - set(pre_systems))[0]
+    # Load the indicated particle system.
+    pre_systems = list(bpy.data.particles)
+    with bpy.data.libraries.load(effect.filepath) as (data_from, data_to):
+        for itm in data_from.particles:
+            if itm == effect.name:
+                data_to.particles.append(itm)
+    post_systems = list(bpy.data.particles)
+    imported_particles = list(set(post_systems) - set(pre_systems))[0]
 
-	# Assign particles as fake, to avoid being purged after file reload.
-	if hasattr(imported_particles, "instance_object"):
-		# 2.8+
-		if imported_particles.instance_object:
-			imported_particles.instance_object.use_fake_user = True
-	elif imported_particles.dupli_object:
-		# the 2.7x way.
-		imported_particles.dupli_object.use_fake_user = True
+    # Assign particles as fake, to avoid being purged after file reload.
+    if hasattr(imported_particles, "instance_object"):
+        # 2.8+
+        if imported_particles.instance_object:
+            imported_particles.instance_object.use_fake_user = True
+    elif imported_particles.dupli_object:
+        # the 2.7x way.
+        imported_particles.dupli_object.use_fake_user = True
 
-	# Assign the active object and selection state.
-	for sel_obj in bpy.context.selected_objects:
-		util.select_set(sel_obj, False)
-	util.set_active_object(context, obj)
-	util.select_set(obj, True)
+    # Assign the active object and selection state.
+    for sel_obj in bpy.context.selected_objects:
+        util.select_set(sel_obj, False)
+    util.set_active_object(context, obj)
+    util.select_set(obj, True)
 
-	# Assign the newly imported system, assign generalied settings.
-	bpy.ops.object.particle_system_add()
-	psystem = obj.particle_systems[-1]
-	psystem.settings = imported_particles
-	if util.bv28():
-		obj.show_instancer_for_render = False
-	else:
-		psystem.settings.use_render_emitter = False
+    # Assign the newly imported system, assign generalied settings.
+    bpy.ops.object.particle_system_add()
+    psystem = obj.particle_systems[-1]
+    psystem.settings = imported_particles
+    if util.bv28():
+        obj.show_instancer_for_render = False
+    else:
+        psystem.settings.use_render_emitter = False
 
-	# Update particle density to match the current timeline.
-	frames = psystem.settings.frame_end - psystem.settings.frame_start
-	density = psystem.settings.count / frames
+    # Update particle density to match the current timeline.
+    frames = psystem.settings.frame_end - psystem.settings.frame_start
+    density = psystem.settings.count / frames
 
-	early_offset = 30  # Start partciles before scene start.
-	if "snow" in effect.name.lower():
-		early_offset = 150  # Much slower partciles need more time.
-	psystem.settings.frame_start = context.scene.frame_start - early_offset
-	psystem.settings.frame_end = context.scene.frame_end
-	scene_frames = psystem.settings.frame_end - psystem.settings.frame_start
-	psystem.settings.count = int(density * scene_frames)
+    early_offset = 30  # Start partciles before scene start.
+    if "snow" in effect.name.lower():
+        early_offset = 150  # Much slower partciles need more time.
+    psystem.settings.frame_start = context.scene.frame_start - early_offset
+    psystem.settings.frame_end = context.scene.frame_end
+    scene_frames = psystem.settings.frame_end - psystem.settings.frame_start
+    psystem.settings.count = int(density * scene_frames)
 
-	return obj
+    return obj
 
 
 def add_collection_effect(context, effect, location, frame):
-	"""Spawn a pre-animated collection effect at a specific point and time.
+    """Spawn a pre-animated collection effect at a specific point and time.
 
-	Import a new copy of a collection from the effects_collections.blend file.
-	Each collection hsa some pre-animated settings. When the collection is
-	imported, all animation, particle, or other time-dependent features are
-	shifted by the indicated number of frames over. It is then placed as an
-	expanded collection. No instancing because there's no savings.
+    Import a new copy of a collection from the effects_collections.blend file.
+    Each collection hsa some pre-animated settings. When the collection is
+    imported, all animation, particle, or other time-dependent features are
+    shifted by the indicated number of frames over. It is then placed as an
+    expanded collection. No instancing because there's no savings.
 
-	Effect is of type: ListEffectsAssets.
+    Effect is of type: ListEffectsAssets.
 
-	Could potentially offer to 'prebake' so that once its loaded, it auto bakes
-	any particles the collection may be using.
-	"""
+    Could potentially offer to 'prebake' so that once its loaded, it auto bakes
+    any particles the collection may be using.
+    """
 
-	keyname = "{}_frame_{}".format(effect.name, frame)
-	if keyname in util.collections():
-		coll = util.collections()[keyname]
-	else:
-		coll = import_animated_coll(context, effect, keyname)
-		coll.name = effect.name + "_" + str(frame)
+    keyname = "{}_frame_{}".format(effect.name, frame)
+    if keyname in util.collections():
+        coll = util.collections()[keyname]
+    else:
+        coll = import_animated_coll(context, effect, keyname)
+        coll.name = effect.name + "_" + str(frame)
 
-		# Update the animation per intended frame.
-		offset_animation_to_frame(coll, frame)
+        # Update the animation per intended frame.
+        offset_animation_to_frame(coll, frame)
 
-	# Create the object instance.
-	obj = util.addGroupInstance(coll.name, location)
-	obj.location = location
-	obj.name = keyname
-	if util.bv28():
-		util.move_to_collection(obj, context.collection)
+    # Create the object instance.
+    obj = util.addGroupInstance(coll.name, location)
+    obj.location = location
+    obj.name = keyname
+    if util.bv28():
+        util.move_to_collection(obj, context.collection)
 
-	# Deselect everything and set newly added empty as active.
-	for ob in context.scene.objects:
-		if util.select_get(ob):
-			util.select_set(ob, False)
-	util.set_active_object(context, obj)
-	util.select_set(obj, True)
+    # Deselect everything and set newly added empty as active.
+    for ob in context.scene.objects:
+        if util.select_get(ob):
+            util.select_set(ob, False)
+    util.set_active_object(context, obj)
+    util.select_set(obj, True)
 
 
 def add_image_sequence_effect(context, effect, location, frame, speed):
-	"""Spawn a short-term sequence of individual images at a point in time.
+    """Spawn a short-term sequence of individual images at a point in time.
 
-	Effect is of type: ListEffectsAssets.
-	"""
+    Effect is of type: ListEffectsAssets.
+    """
 
-	# Get the list of explicit files.
-	basepath = os.path.dirname(effect.filepath)
-	root = os.path.basename(effect.filepath)
-	images = [
-		img for img in os.listdir(basepath)
-		if img.startswith(root) and os.path.isfile(os.path.join(basepath, img))
-		and os.path.splitext(img)[-1].lower() in EXTENSIONS
-	]
+    # Get the list of explicit files.
+    basepath = os.path.dirname(effect.filepath)
+    root = os.path.basename(effect.filepath)
+    images = [
+        img
+        for img in os.listdir(basepath)
+        if img.startswith(root)
+        and os.path.isfile(os.path.join(basepath, img))
+        and os.path.splitext(img)[-1].lower() in EXTENSIONS
+    ]
 
-	if not images:
-		raise Exception("Failed to load images in question: " + root)
+    if not images:
+        raise Exception("Failed to load images in question: " + root)
 
-	# Implement human sorting, such that img_2.png is before img_11.png
-	human_sorted = util.natural_sort(images)
+    # Implement human sorting, such that img_2.png is before img_11.png
+    human_sorted = util.natural_sort(images)
 
-	# Create the collection to add objects into.
-	keyname = "{}_frame_{}@{:.2f}".format(effect.name, frame, speed)
+    # Create the collection to add objects into.
+    keyname = "{}_frame_{}@{:.2f}".format(effect.name, frame, speed)
 
-	if util.bv28():
-		# Move the source collection (world center) into excluded coll
-		effects_vl = util.get_or_create_viewlayer(context, EFFECT_EXCLUDE)
-		effects_vl.exclude = True
+    if util.bv28():
+        # Move the source collection (world center) into excluded coll
+        effects_vl = util.get_or_create_viewlayer(context, EFFECT_EXCLUDE)
+        effects_vl.exclude = True
 
-		seq_coll = bpy.data.collections.get(keyname)
-		if not seq_coll:
-			seq_coll = bpy.data.collections.new(name=keyname)
-			effects_vl.collection.children.link(seq_coll)
-	else:
-		seq_coll = bpy.data.groups.new(keyname)
+        seq_coll = bpy.data.collections.get(keyname)
+        if not seq_coll:
+            seq_coll = bpy.data.collections.new(name=keyname)
+            effects_vl.collection.children.link(seq_coll)
+    else:
+        seq_coll = bpy.data.groups.new(keyname)
 
-	if len(seq_coll.objects) != len(human_sorted):
-		# Generate the items before instancing collection/group.
-		framerate = 1 / speed
-		frames_added = []
+    if len(seq_coll.objects) != len(human_sorted):
+        # Generate the items before instancing collection/group.
+        framerate = 1 / speed
+        frames_added = []
 
-		for i, img in enumerate(human_sorted):
-			target_frame = int(frame + i * framerate)
-			end_frame = int(frame + (i + 1) * framerate)
-			if target_frame in frames_added:
-				continue
-			else:
-				frames_added.append(target_frame)
+        for i, img in enumerate(human_sorted):
+            target_frame = int(frame + i * framerate)
+            end_frame = int(frame + (i + 1) * framerate)
+            if target_frame in frames_added:
+                continue
+            else:
+                frames_added.append(target_frame)
 
-			if end_frame == target_frame:
-				end_frame += 1
+            if end_frame == target_frame:
+                end_frame += 1
 
-			this_file = os.path.join(basepath, img)
-			pre_objs = list(bpy.data.objects)
-			bpy.ops.mcprep.spawn_item_file(
-				filepath=this_file, thickness=0, skipUsage=True)
-			post_objs = list(bpy.data.objects)
-			new = list(set(post_objs) - set(pre_objs))
+            this_file = os.path.join(basepath, img)
+            pre_objs = list(bpy.data.objects)
+            bpy.ops.mcprep.spawn_item_file(
+                filepath=this_file, thickness=0, skipUsage=True
+            )
+            post_objs = list(bpy.data.objects)
+            new = list(set(post_objs) - set(pre_objs))
 
-			if not new or len(new) != 1:
-				print("Error fetching new object for frame ", target_frame)
-				continue
-			obj = new[0]
-			obj.location = Vector([0, 0, 0])
+            if not new or len(new) != 1:
+                print("Error fetching new object for frame ", target_frame)
+                continue
+            obj = new[0]
+            obj.location = Vector([0, 0, 0])
 
-			# Set the animation for visibility for the range of frames.
-			def keyframe_current_visibility(context, obj, state):
-				frame = context.scene.frame_current
+            # Set the animation for visibility for the range of frames.
+            def keyframe_current_visibility(context, obj, state):
+                frame = context.scene.frame_current
 
-				obj.hide_render = state
-				if util.bv28():
-					obj.hide_viewport = state
-					obj.keyframe_insert(data_path="hide_viewport", frame=frame)
-				else:
-					obj.hide = state
-					obj.keyframe_insert(data_path="hide", frame=frame)
-				obj.keyframe_insert(data_path="hide_render", frame=frame)
+                obj.hide_render = state
+                if util.bv28():
+                    obj.hide_viewport = state
+                    obj.keyframe_insert(data_path="hide_viewport", frame=frame)
+                else:
+                    obj.hide = state
+                    obj.keyframe_insert(data_path="hide", frame=frame)
+                obj.keyframe_insert(data_path="hide_render", frame=frame)
 
-			context.scene.frame_current = target_frame - 1
-			keyframe_current_visibility(context, obj, True)
+            context.scene.frame_current = target_frame - 1
+            keyframe_current_visibility(context, obj, True)
 
-			context.scene.frame_current = target_frame
-			keyframe_current_visibility(context, obj, False)
+            context.scene.frame_current = target_frame
+            keyframe_current_visibility(context, obj, False)
 
-			context.scene.frame_current = end_frame
-			keyframe_current_visibility(context, obj, True)
+            context.scene.frame_current = end_frame
+            keyframe_current_visibility(context, obj, True)
 
-			if util.bv28():
-				util.move_to_collection(obj, seq_coll)
-			else:
-				seq_coll.objects.link(obj)
+            if util.bv28():
+                util.move_to_collection(obj, seq_coll)
+            else:
+                seq_coll.objects.link(obj)
 
-	context.scene.frame_current = frame
+    context.scene.frame_current = frame
 
-	# Finalize creation of the instances.
-	instance = util.addGroupInstance(seq_coll.name, location)
-	if hasattr(instance, "empty_draw_size"):  # Older blender versions.
-		instance.empty_draw_size = 0.25
-	else:
-		instance.empty_display_size = 1.0
-		instance.empty_display_type = 'IMAGE'
-		instance.use_empty_image_alpha = True
-		instance.color[3] = 0.1
+    # Finalize creation of the instances.
+    instance = util.addGroupInstance(seq_coll.name, location)
+    if hasattr(instance, "empty_draw_size"):  # Older blender versions.
+        instance.empty_draw_size = 0.25
+    else:
+        instance.empty_display_size = 1.0
+        instance.empty_display_type = "IMAGE"
+        instance.use_empty_image_alpha = True
+        instance.color[3] = 0.1
 
-		# Load in the image to display in place of the empty.
-		img_index = int(len(human_sorted) / 2)
-		img_index = min(img_index, len(human_sorted) - 1)
-		img = os.path.join(basepath, human_sorted[img_index])
-		img_block = bpy.data.images.load(img, check_existing=True)
-		instance.data = img_block
+        # Load in the image to display in place of the empty.
+        img_index = int(len(human_sorted) / 2)
+        img_index = min(img_index, len(human_sorted) - 1)
+        img = os.path.join(basepath, human_sorted[img_index])
+        img_block = bpy.data.images.load(img, check_existing=True)
+        instance.data = img_block
 
-	if util.bv28():
-		# Move the new object into the active layer.
-		util.move_to_collection(instance, context.collection)
-	# TODO: if not bv28, unlink the src group objects from the scene.
+    if util.bv28():
+        # Move the new object into the active layer.
+        util.move_to_collection(instance, context.collection)
+    # TODO: if not bv28, unlink the src group objects from the scene.
 
-	return instance
+    return instance
 
 
 def add_particle_planes_effect(context, image_path, location, frame):
-	"""Spawn a short-term particle system at a specific point and time.
+    """Spawn a short-term particle system at a specific point and time.
 
-	This is the only effect type that does not get pre-loaded into a list. The
-	user is prompted for an image, and this is then imported, chopped into a
-	few smaller square pieces, and then this collection is used as a source for
-	a particle system that emits some number of particles over a 1 frame
-	period of time. Ideal for footfalls, impacts, etc.
-	"""
+    This is the only effect type that does not get pre-loaded into a list. The
+    user is prompted for an image, and this is then imported, chopped into a
+    few smaller square pieces, and then this collection is used as a source for
+    a particle system that emits some number of particles over a 1 frame
+    period of time. Ideal for footfalls, impacts, etc.
+    """
 
-	# Add object, use lower level functions to make it run faster.
-	f_name = os.path.splitext(os.path.basename(image_path))[0]
-	base_name = "{}_frame_{}".format(f_name, frame)
+    # Add object, use lower level functions to make it run faster.
+    f_name = os.path.splitext(os.path.basename(image_path))[0]
+    base_name = "{}_frame_{}".format(f_name, frame)
 
-	mesh = get_or_create_plane_mesh("particle_plane")
-	obj = bpy.data.objects.new(base_name, mesh)
-	util.obj_link_scene(obj, context)
-	# TODO: link to currently active collection.
-	obj.location = location
+    mesh = get_or_create_plane_mesh("particle_plane")
+    obj = bpy.data.objects.new(base_name, mesh)
+    util.obj_link_scene(obj, context)
+    # TODO: link to currently active collection.
+    obj.location = location
 
-	# Select and make active.
-	# Setting active here ensures the emitter also gets the texture, making it
-	# easier to tell which particles it emits.
-	for sel_obj in bpy.context.selected_objects:
-		util.select_set(sel_obj, False)
-	util.set_active_object(context, obj)
-	util.select_set(obj, True)
+    # Select and make active.
+    # Setting active here ensures the emitter also gets the texture, making it
+    # easier to tell which particles it emits.
+    for sel_obj in bpy.context.selected_objects:
+        util.select_set(sel_obj, False)
+    util.set_active_object(context, obj)
+    util.select_set(obj, True)
 
-	# Generate the collection/group of objects to be spawned.
-	img = bpy.data.images.get(f_name)
-	img_abs_path = bpy.path.abspath(image_path)
-	if not img or not bpy.path.abspath(img.filepath) == img_abs_path:
-		# Check if any others loaded, otherwise just load new.
-		for this_img in bpy.data.images:
-			if bpy.path.abspath(this_img.filepath) == img_abs_path:
-				img = this_img
-				break
-		if not img:
-			img = bpy.data.images.load(image_path)
+    # Generate the collection/group of objects to be spawned.
+    img = bpy.data.images.get(f_name)
+    img_abs_path = bpy.path.abspath(image_path)
+    if not img or not bpy.path.abspath(img.filepath) == img_abs_path:
+        # Check if any others loaded, otherwise just load new.
+        for this_img in bpy.data.images:
+            if bpy.path.abspath(this_img.filepath) == img_abs_path:
+                img = this_img
+                break
+        if not img:
+            img = bpy.data.images.load(image_path)
 
-	pcoll = get_or_create_particle_meshes_coll(
-		context, f_name, img)
+    pcoll = get_or_create_particle_meshes_coll(context, f_name, img)
 
-	# Set the material for the emitter object. Though not actually rendered,
-	# this helps clarify which particle is being emitted from this object.
-	mat = None
-	for ob in pcoll.objects:
-		if ob.material_slots and ob.material_slots[0].material:
-			mat = ob.material_slots[0].material
-			break
-	if mat:
-		if not obj.material_slots:
-			obj.data.materials.append(mat)
-		# Must use 'OBEJCT' instead of mesh data, otherwise all particle
-		# emitters will have the same material (how it was initially working)
-		obj.material_slots[0].link = 'OBJECT'
-		obj.material_slots[0].material = mat
-		print("Linked {} with {}".format(obj.name, mat.name))
+    # Set the material for the emitter object. Though not actually rendered,
+    # this helps clarify which particle is being emitted from this object.
+    mat = None
+    for ob in pcoll.objects:
+        if ob.material_slots and ob.material_slots[0].material:
+            mat = ob.material_slots[0].material
+            break
+    if mat:
+        if not obj.material_slots:
+            obj.data.materials.append(mat)
+        # Must use 'OBEJCT' instead of mesh data, otherwise all particle
+        # emitters will have the same material (how it was initially working)
+        obj.material_slots[0].link = "OBJECT"
+        obj.material_slots[0].material = mat
+        print("Linked {} with {}".format(obj.name, mat.name))
 
-	apply_particle_settings(obj, frame, base_name, pcoll)
+    apply_particle_settings(obj, frame, base_name, pcoll)
 
 
 # -----------------------------------------------------------------------------
 # Core effects supportive functions
 # -----------------------------------------------------------------------------
 
+
 def geo_update_params(context, effect, geo_mod):
-	"""Update the paramters of the applied geonode effect.
+    """Update the paramters of the applied geonode effect.
 
-	Loads fields to apply based on json file where necessary.
-	"""
+    Loads fields to apply based on json file where necessary.
+    """
 
-	base_file = os.path.splitext(os.path.basename(effect.filepath))[0]
-	base_dir = os.path.dirname(effect.filepath)
-	jpath = os.path.join(base_dir, base_file + ".json")
-	geo_fields = {}
-	if os.path.isfile(jpath):
-		geo_fields = geo_fields_from_json(effect, jpath)
-	else:
-		env.log("No json params path for geonode effects", vv_only=True)
-		return
+    base_file = os.path.splitext(os.path.basename(effect.filepath))[0]
+    base_dir = os.path.dirname(effect.filepath)
+    jpath = os.path.join(base_dir, base_file + ".json")
+    geo_fields = {}
+    if os.path.isfile(jpath):
+        geo_fields = geo_fields_from_json(effect, jpath)
+    else:
+        env.log("No json params path for geonode effects", vv_only=True)
+        return
 
-	# Determine if these special keywords exist.
-	has_followkey = False
-	for input_name in geo_fields.keys():
-		if geo_fields[input_name] == "FOLLOW_OBJ":
-			has_followkey = True
-	env.log("geonode has_followkey field? " + str(has_followkey), vv_only=True)
+    # Determine if these special keywords exist.
+    has_followkey = False
+    for input_name in geo_fields.keys():
+        if geo_fields[input_name] == "FOLLOW_OBJ":
+            has_followkey = True
+    env.log("geonode has_followkey field? " + str(has_followkey), vv_only=True)
 
-	# Create follow empty if required by the group.
-	camera = context.scene.camera
-	center_empty = None
-	if has_followkey:
-		center_empty = bpy.data.objects.new(
-			name="{} origin".format(effect.name),
-			object_data=None)
-		util.obj_link_scene(center_empty)
-		if camera:
-			center_empty.parent = camera
-			center_empty.location = (0, 0, -10)
-		else:
-			center_empty.location = util.get_cuser_location()
+    # Create follow empty if required by the group.
+    camera = context.scene.camera
+    center_empty = None
+    if has_followkey:
+        center_empty = bpy.data.objects.new(
+            name="{} origin".format(effect.name), object_data=None
+        )
+        util.obj_link_scene(center_empty)
+        if camera:
+            center_empty.parent = camera
+            center_empty.location = (0, 0, -10)
+        else:
+            center_empty.location = util.get_cuser_location()
 
-	# Cache mapping of names like "Weather Type" to "Input_1" internals.
-	geo_inp_id = {}
-	for inp in geo_mod.node_group.inputs:
-		if inp.name in list(geo_fields):
-			geo_inp_id[inp.name] = inp.identifier
+    # Cache mapping of names like "Weather Type" to "Input_1" internals.
+    geo_inp_id = {}
+    for inp in geo_mod.node_group.inputs:
+        if inp.name in list(geo_fields):
+            geo_inp_id[inp.name] = inp.identifier
 
-	# Now update the final geo node inputs based gathered settings.
-	for inp in geo_mod.node_group.inputs:
-		if inp.name in list(geo_fields):
-			value = geo_fields[inp.name]
-			if value == "CAMERA_OBJ":
-				env.log("Set cam for geonode input", vv_only=True)
-				geo_mod[geo_inp_id[inp.name]] = camera
-			elif value == "FOLLOW_OBJ":
-				if not center_empty:
-					print(">> Center empty missing, not in preset!")
-				else:
-					env.log("Set follow for geonode input", vv_only=True)
-					geo_mod[geo_inp_id[inp.name]] = center_empty
-			else:
-				env.log("Set {} for geonode input".format(inp.name), vv_only=True)
-				geo_mod[geo_inp_id[inp.name]] = value
-		# TODO: check if any socket name in json specified not found in node.
+    # Now update the final geo node inputs based gathered settings.
+    for inp in geo_mod.node_group.inputs:
+        if inp.name in list(geo_fields):
+            value = geo_fields[inp.name]
+            if value == "CAMERA_OBJ":
+                env.log("Set cam for geonode input", vv_only=True)
+                geo_mod[geo_inp_id[inp.name]] = camera
+            elif value == "FOLLOW_OBJ":
+                if not center_empty:
+                    print(">> Center empty missing, not in preset!")
+                else:
+                    env.log("Set follow for geonode input", vv_only=True)
+                    geo_mod[geo_inp_id[inp.name]] = center_empty
+            else:
+                env.log("Set {} for geonode input".format(inp.name), vv_only=True)
+                geo_mod[geo_inp_id[inp.name]] = value
+        # TODO: check if any socket name in json specified not found in node.
 
 
 def geo_fields_from_json(effect, jpath):
-	"""Extract json values from a file for a given effect.
+    """Extract json values from a file for a given effect.
 
-	Parse for a json structure with a hierarhcy of:
+    Parse for a json structure with a hierarhcy of:
 
-	geo node group name:
-		sub effect name e.g. "rain":
-			input setting name: value
+    geo node group name:
+            sub effect name e.g. "rain":
+                    input setting name: value
 
-	Special values for given keys (where key is the geonode UI name):
-		CAMERA_OBJ: Tells MCprep to assign the active camera object to slot.
-		FOLLOW_OBJ: Tells MCprep to assign a generated empty to this slot.
-	"""
-	env.log("Loading geo fields form json: " + jpath)
-	with open(jpath) as fopen:
-		jdata = json.load(fopen)
+    Special values for given keys (where key is the geonode UI name):
+            CAMERA_OBJ: Tells MCprep to assign the active camera object to slot.
+            FOLLOW_OBJ: Tells MCprep to assign a generated empty to this slot.
+    """
+    env.log("Loading geo fields form json: " + jpath)
+    with open(jpath) as fopen:
+        jdata = json.load(fopen)
 
-	# Find the matching
-	geo_fields = {}
-	for geonode_name in list(jdata):
-		if geonode_name != effect.subpath:
-			continue
-		for effect_preset in list(jdata[geonode_name]):
-			if effect_preset == effect.name:
-				geo_fields = jdata[geonode_name][effect_preset]
-				break
-	if not geo_fields:
-		print("Failed to load presets for this effect from json")
-	return geo_fields
+    # Find the matching
+    geo_fields = {}
+    for geonode_name in list(jdata):
+        if geonode_name != effect.subpath:
+            continue
+        for effect_preset in list(jdata[geonode_name]):
+            if effect_preset == effect.name:
+                geo_fields = jdata[geonode_name][effect_preset]
+                break
+    if not geo_fields:
+        print("Failed to load presets for this effect from json")
+    return geo_fields
 
 
 def get_or_create_plane_mesh(mesh_name, uvs=[]):
-	"""Generate a 1x1 plane with UVs stretched out to ends, cache if exists.
+    """Generate a 1x1 plane with UVs stretched out to ends, cache if exists.
 
-	Arg `uvs` represents the 4 coordinate values clockwise from top left of the
-	mesh, with values of 0-1.
-	"""
+    Arg `uvs` represents the 4 coordinate values clockwise from top left of the
+    mesh, with values of 0-1.
+    """
 
-	# Create or fetch mesh, returned existing cache if it exists.
-	mesh = bpy.data.meshes.get(mesh_name)
-	if mesh is None:
-		mesh = bpy.data.meshes.new(mesh_name)
-	else:
-		return mesh
+    # Create or fetch mesh, returned existing cache if it exists.
+    mesh = bpy.data.meshes.get(mesh_name)
+    if mesh is None:
+        mesh = bpy.data.meshes.new(mesh_name)
+    else:
+        return mesh
 
-	bm = bmesh.new()
-	uv_layer = bm.loops.layers.uv.verify()
+    bm = bmesh.new()
+    uv_layer = bm.loops.layers.uv.verify()
 
-	verts = [
-		[-0.5, 0.5, 0],  # Top left, clockwise down.
-		[0.5, 0.5, 0],
-		[0.5, -0.5, 0],
-		[-0.5, -0.5, 0]
-	]
-	for v in reversed(verts):
-		bm.verts.new(v)
+    verts = [
+        [-0.5, 0.5, 0],  # Top left, clockwise down.
+        [0.5, 0.5, 0],
+        [0.5, -0.5, 0],
+        [-0.5, -0.5, 0],
+    ]
+    for v in reversed(verts):
+        bm.verts.new(v)
 
-	if not uvs:
-		uvs = [[0, 0], [1, 0], [1, 1], [0, 1]]
-	if len(uvs) != 4:
-		raise Exception("Wrong number of coords for UVs: " + str(len(uvs)))
+    if not uvs:
+        uvs = [[0, 0], [1, 0], [1, 1], [0, 1]]
+    if len(uvs) != 4:
+        raise Exception("Wrong number of coords for UVs: " + str(len(uvs)))
 
-	face = bm.faces.new(bm.verts)
-	face.normal_update()
+    face = bm.faces.new(bm.verts)
+    face.normal_update()
 
-	for i, loop in enumerate(reversed(face.loops)):
-		loop[uv_layer].uv = uvs[i]
+    for i, loop in enumerate(reversed(face.loops)):
+        loop[uv_layer].uv = uvs[i]
 
-	bm.to_mesh(mesh)
-	bm.free()
+    bm.to_mesh(mesh)
+    bm.free()
 
-	return mesh
+    return mesh
 
 
 def get_or_create_particle_meshes_coll(context, particle_name, img):
-	"""Generate a selection of subsets of a given image for use in partucles.
+    """Generate a selection of subsets of a given image for use in partucles.
 
-	The goal is that instead of spawning entire, complete UVs of the texture,
-	we spawn little subsets of the particles.
+    The goal is that instead of spawning entire, complete UVs of the texture,
+    we spawn little subsets of the particles.
 
-	Returns a collection or group depending on bpy version.
-	"""
-	# Check if it exists already, and if it has at least one object,
-	# assume we'll just use those.
-	particle_key = particle_name + "_particles"
-	particle_coll = util.collections().get(particle_key)
-	if particle_coll:
-		# Check if any objects.
-		if util.bv28() and len(particle_coll.objects) > 0:
-			return particle_coll
+    Returns a collection or group depending on bpy version.
+    """
+    # Check if it exists already, and if it has at least one object,
+    # assume we'll just use those.
+    particle_key = particle_name + "_particles"
+    particle_coll = util.collections().get(particle_key)
+    if particle_coll:
+        # Check if any objects.
+        if util.bv28() and len(particle_coll.objects) > 0:
+            return particle_coll
 
-	# Create the collection/group.
-	if util.bv28():
-		particle_view = util.get_or_create_viewlayer(context, particle_key)
-		particle_view.exclude = True
-	else:
-		particle_group = bpy.data.groups.new(name=particle_key)
+    # Create the collection/group.
+    if util.bv28():
+        particle_view = util.get_or_create_viewlayer(context, particle_key)
+        particle_view.exclude = True
+    else:
+        particle_group = bpy.data.groups.new(name=particle_key)
 
-	# Get or create the material.
-	if particle_name in bpy.data.materials:
-		mat = bpy.data.materials.get(particle_name)
-	else:
-		bpy.ops.mcprep.load_material(filepath=img.filepath, skipUsage=True)
-		mat = bpy.data.materials.get(particle_name)
+    # Get or create the material.
+    if particle_name in bpy.data.materials:
+        mat = bpy.data.materials.get(particle_name)
+    else:
+        bpy.ops.mcprep.load_material(filepath=img.filepath, skipUsage=True)
+        mat = bpy.data.materials.get(particle_name)
 
-	# The different variations of UV slices to create, clockwise from top left.
-	num = 4.0  # Number created is this squared.
-	uv_variants = {}
+    # The different variations of UV slices to create, clockwise from top left.
+    num = 4.0  # Number created is this squared.
+    uv_variants = {}
 
-	for x in range(int(num)):
-		for y in range(int(num)):
-			this_key = "{}-{}".format(x, y)
-			# Reference: [0, 0], [1, 0], [1, 1], [0, 1]
-			uv_variants[this_key] = [
-				[x / num, y / num],
-				[(x + 1) / num, y / num],
-				[(x + 1) / num, (y + 1) / num],
-				[x / num, (y + 1) / num]
-			]
+    for x in range(int(num)):
+        for y in range(int(num)):
+            this_key = "{}-{}".format(x, y)
+            # Reference: [0, 0], [1, 0], [1, 1], [0, 1]
+            uv_variants[this_key] = [
+                [x / num, y / num],
+                [(x + 1) / num, y / num],
+                [(x + 1) / num, (y + 1) / num],
+                [x / num, (y + 1) / num],
+            ]
 
-	# Decide randomly which ones to create (making all would be excessive).
-	while len(uv_variants) > 6:
-		keys = list(uv_variants)
-		del_index = random.randrange(len(keys))
-		del uv_variants[keys[del_index]]
+    # Decide randomly which ones to create (making all would be excessive).
+    while len(uv_variants) > 6:
+        keys = list(uv_variants)
+        del_index = random.randrange(len(keys))
+        del uv_variants[keys[del_index]]
 
-	for key in uv_variants:
-		name = particle_name + "_particle_" + key
-		mesh = get_or_create_plane_mesh(name, uvs=uv_variants[key])
-		obj = bpy.data.objects.new(name, mesh)
-		obj.data.materials.append(mat)
+    for key in uv_variants:
+        name = particle_name + "_particle_" + key
+        mesh = get_or_create_plane_mesh(name, uvs=uv_variants[key])
+        obj = bpy.data.objects.new(name, mesh)
+        obj.data.materials.append(mat)
 
-		if util.bv28():
-			util.move_to_collection(obj, particle_view.collection)
-		else:
-			particle_group.objects.link(obj)
+        if util.bv28():
+            util.move_to_collection(obj, particle_view.collection)
+        else:
+            particle_group.objects.link(obj)
 
-	if util.bv28():
-		return particle_view.collection
-	else:
-		return particle_group
+    if util.bv28():
+        return particle_view.collection
+    else:
+        return particle_group
 
 
 def apply_particle_settings(obj, frame, base_name, pcoll):
-	"""Update the particle settings for particle planes."""
-	obj.scale = (0.5, 0.5, 0.5)  # Tighen up the area it spawns over.
+    """Update the particle settings for particle planes."""
+    obj.scale = (0.5, 0.5, 0.5)  # Tighen up the area it spawns over.
 
-	bpy.ops.object.particle_system_add()  # Must be active object.
-	psystem = obj.particle_systems[-1]  # = ... # How to gen new system?
+    bpy.ops.object.particle_system_add()  # Must be active object.
+    psystem = obj.particle_systems[-1]  # = ... # How to gen new system?
 
-	psystem.name = base_name
-	psystem.seed = frame
-	psystem.settings.count = 5
-	psystem.settings.frame_start = frame
-	psystem.settings.frame_end = frame + 1
-	psystem.settings.lifetime = 30
-	psystem.settings.lifetime_random = 0.2
-	psystem.settings.emit_from = 'FACE'
-	psystem.settings.distribution = 'RAND'
-	psystem.settings.normal_factor = 1.5
-	psystem.settings.use_rotations = True
-	psystem.settings.rotation_factor_random = 1
-	psystem.settings.particle_size = 0.2
-	psystem.settings.factor_random = 1
+    psystem.name = base_name
+    psystem.seed = frame
+    psystem.settings.count = 5
+    psystem.settings.frame_start = frame
+    psystem.settings.frame_end = frame + 1
+    psystem.settings.lifetime = 30
+    psystem.settings.lifetime_random = 0.2
+    psystem.settings.emit_from = "FACE"
+    psystem.settings.distribution = "RAND"
+    psystem.settings.normal_factor = 1.5
+    psystem.settings.use_rotations = True
+    psystem.settings.rotation_factor_random = 1
+    psystem.settings.particle_size = 0.2
+    psystem.settings.factor_random = 1
 
-	if util.bv28():
-		obj.show_instancer_for_render = False
-		psystem.settings.render_type = 'COLLECTION'
-		psystem.settings.instance_collection = pcoll
-	else:
-		psystem.settings.use_render_emitter = False
-		psystem.settings.render_type = 'GROUP'
-		psystem.settings.dupli_group = pcoll
+    if util.bv28():
+        obj.show_instancer_for_render = False
+        psystem.settings.render_type = "COLLECTION"
+        psystem.settings.instance_collection = pcoll
+    else:
+        psystem.settings.use_render_emitter = False
+        psystem.settings.render_type = "GROUP"
+        psystem.settings.dupli_group = pcoll
 
 
 def import_animated_coll(context, effect, keyname):
-	"""Import and return a new animated collection given a specific key."""
-	init_colls = list(util.collections())
-	any_imported = False
-	with bpy.data.libraries.load(effect.filepath) as (data_from, data_to):
-		collections = spawn_util.filter_collections(data_from)
-		for itm in collections:
-			if itm != effect.name:
-				continue
-			if util.bv28():
-				data_to.collections.append(itm)
-				any_imported = True
-			else:
-				data_to.groups.append(itm)
-				any_imported = True
+    """Import and return a new animated collection given a specific key."""
+    init_colls = list(util.collections())
+    any_imported = False
+    with bpy.data.libraries.load(effect.filepath) as (data_from, data_to):
+        collections = spawn_util.filter_collections(data_from)
+        for itm in collections:
+            if itm != effect.name:
+                continue
+            if util.bv28():
+                data_to.collections.append(itm)
+                any_imported = True
+            else:
+                data_to.groups.append(itm)
+                any_imported = True
 
-	final_colls = list(util.collections())
-	new_colls = list(set(final_colls) - set(init_colls))
-	if not new_colls:
-		if any_imported:
-			env.log("New collection loaded, but not picked up")
-		else:
-			env.log("No colleections imported or recognized")
-		raise Exception("No collections imported")
-	elif len(new_colls) > 1:
-		# Pick the closest fitting one. At worst, will pick a random one.
-		coll = None
-		for this_coll in new_colls:
-			if util.nameGeneralize(this_coll.name) == effect.name:
-				coll = this_coll
-		if not coll:
-			raise Exception("Could not import required collection")
-	else:
-		coll = new_colls[0]
+    final_colls = list(util.collections())
+    new_colls = list(set(final_colls) - set(init_colls))
+    if not new_colls:
+        if any_imported:
+            env.log("New collection loaded, but not picked up")
+        else:
+            env.log("No colleections imported or recognized")
+        raise Exception("No collections imported")
+    elif len(new_colls) > 1:
+        # Pick the closest fitting one. At worst, will pick a random one.
+        coll = None
+        for this_coll in new_colls:
+            if util.nameGeneralize(this_coll.name) == effect.name:
+                coll = this_coll
+        if not coll:
+            raise Exception("Could not import required collection")
+    else:
+        coll = new_colls[0]
 
-	if util.bv28():
-		# Move the source collection (world center) into excluded coll
-		effects_vl = util.get_or_create_viewlayer(context, EFFECT_EXCLUDE)
-		effects_vl.exclude = True
-		effects_vl.collection.children.link(coll)
+    if util.bv28():
+        # Move the source collection (world center) into excluded coll
+        effects_vl = util.get_or_create_viewlayer(context, EFFECT_EXCLUDE)
+        effects_vl.exclude = True
+        effects_vl.collection.children.link(coll)
 
-	return coll
+    return coll
 
 
 def offset_animation_to_frame(collection, frame):
-	"""Offset all animations and particles based on the given frame."""
-	if frame == 1:
-		return
-	frame -= 1
+    """Offset all animations and particles based on the given frame."""
+    if frame == 1:
+        return
+    frame -= 1
 
-	objs = []
-	actions = []
-	mats = []
+    objs = []
+    actions = []
+    mats = []
 
-	if util.bv28():
-		objs = list(collection.all_objects)
-	else:
-		objs = list(collection.objects)
+    if util.bv28():
+        objs = list(collection.all_objects)
+    else:
+        objs = list(collection.objects)
 
-	# Expand the list by checking for any empties instancing other collections.
-	for obj in objs:
-		if util.bv28():
-			if obj.instance_collection:
-				objs.extend(list(obj.instance_collection.all_objects))
-		else:
-			if obj.dupli_group:
-				objs.extend(list(obj.dupli_group.objects))
+    # Expand the list by checking for any empties instancing other collections.
+    for obj in objs:
+        if util.bv28():
+            if obj.instance_collection:
+                objs.extend(list(obj.instance_collection.all_objects))
+        else:
+            if obj.dupli_group:
+                objs.extend(list(obj.dupli_group.objects))
 
-	# Make unique.
-	objs = list(set(objs))
+    # Make unique.
+    objs = list(set(objs))
 
-	for obj in objs:
-		if obj.animation_data and obj.animation_data.action:
-			actions.append(obj.animation_data.action)
-		for sys in obj.particle_systems:
-			# Be sure to change end frame first, otherwise its overridden.
-			sys.settings.frame_end += frame
-			sys.settings.frame_start += frame
-		for slot in obj.material_slots:
-			if slot.material:
-				mats.append(slot.material)
-	mats = list(set(mats))
+    for obj in objs:
+        if obj.animation_data and obj.animation_data.action:
+            actions.append(obj.animation_data.action)
+        for sys in obj.particle_systems:
+            # Be sure to change end frame first, otherwise its overridden.
+            sys.settings.frame_end += frame
+            sys.settings.frame_start += frame
+        for slot in obj.material_slots:
+            if slot.material:
+                mats.append(slot.material)
+    mats = list(set(mats))
 
-	for mat in mats:
-		if mat.animation_data:
-			# Materials with animation data
-			actions.append(mat.animation_data.action)
-		if mat.node_tree.animation_data:
-			actions.append(mat.node_tree.animation_data.action)
-		for node in mat.node_tree.nodes:
-			# Nodegroups that contain animations within.
-			if hasattr(node, "node_tree") and node.node_tree.animation_data:
-				actions.append(node.node_tree.animation_data.action)
+    for mat in mats:
+        if mat.animation_data:
+            # Materials with animation data
+            actions.append(mat.animation_data.action)
+        if mat.node_tree.animation_data:
+            actions.append(mat.node_tree.animation_data.action)
+        for node in mat.node_tree.nodes:
+            # Nodegroups that contain animations within.
+            if hasattr(node, "node_tree") and node.node_tree.animation_data:
+                actions.append(node.node_tree.animation_data.action)
 
-	actions = list(set(actions))
+    actions = list(set(actions))
 
-	# Finally, perform the main operation of shifting keyframes.
-	for action in actions:
-		for fcurve in action.fcurves:
-			# Ensure we move points in reverse order, otherwise adjacent frames
-			# will overwrite each other.
-			points = list(fcurve.keyframe_points)
-			points.sort(key=lambda x: x.co.x)
-			for point in points:
-				point.co.x += frame
-				point.handle_left.x += frame
-				point.handle_right.x += frame
+    # Finally, perform the main operation of shifting keyframes.
+    for action in actions:
+        for fcurve in action.fcurves:
+            # Ensure we move points in reverse order, otherwise adjacent frames
+            # will overwrite each other.
+            points = list(fcurve.keyframe_points)
+            points.sort(key=lambda x: x.co.x)
+            for point in points:
+                point.co.x += frame
+                point.handle_left.x += frame
+                point.handle_right.x += frame
 
 
 # -----------------------------------------------------------------------------
@@ -755,235 +761,237 @@ def offset_animation_to_frame(collection, frame):
 
 
 def update_effects_path(self, context):
-	"""List for UI effects callback ."""
-	env.log("Updating effects path", vv_only=True)
-	update_effects_list(context)
+    """List for UI effects callback ."""
+    env.log("Updating effects path", vv_only=True)
+    update_effects_list(context)
 
 
 def update_effects_list(context):
-	"""Update the effects list."""
-	mcprep_props = context.scene.mcprep_props
-	mcprep_props.effects_list.clear()
+    """Update the effects list."""
+    mcprep_props = context.scene.mcprep_props
+    mcprep_props.effects_list.clear()
 
-	if env.use_icons and env.preview_collections["effects"]:
-		try:
-			bpy.utils.previews.remove(env.preview_collections["effects"])
-		except Exception as e:
-			print(e)
-			env.log("MCPREP: Failed to remove icon set, effects")
+    if env.use_icons and env.preview_collections["effects"]:
+        try:
+            bpy.utils.previews.remove(env.preview_collections["effects"])
+        except Exception as e:
+            print(e)
+            env.log("MCPREP: Failed to remove icon set, effects")
 
-	load_geonode_effect_list(context)
-	load_area_particle_effects(context)
-	load_collection_effects(context)
-	load_image_sequence_effects(context)
+    load_geonode_effect_list(context)
+    load_area_particle_effects(context)
+    load_collection_effects(context)
+    load_image_sequence_effects(context)
 
 
 def load_geonode_effect_list(context):
-	"""Load effects defined by geonodes for wide area effects."""
-	if not util.bv30():
-		print("Not loading geonode effects")
-		return
+    """Load effects defined by geonodes for wide area effects."""
+    if not util.bv30():
+        print("Not loading geonode effects")
+        return
 
-	mcprep_props = context.scene.mcprep_props
-	path = context.scene.mcprep_effects_path
-	path = os.path.join(path, "geonodes")
+    mcprep_props = context.scene.mcprep_props
+    path = context.scene.mcprep_effects_path
+    path = os.path.join(path, "geonodes")
 
-	if not os.path.isdir(path):
-		print("The geonode directory is missing! Reinstall MCprep")
-		print(path)
-		return
+    if not os.path.isdir(path):
+        print("The geonode directory is missing! Reinstall MCprep")
+        print(path)
+        return
 
-	# Find all files with geonodes.
-	blends = [
-		os.path.join(path, blend) for blend in os.listdir(path)
-		if os.path.isfile(os.path.join(path, blend))
-		and blend.lower().endswith(".blend")
-	]
-	json_files = [
-		os.path.join(path, jsf) for jsf in os.listdir(path)
-		if os.path.isfile(os.path.join(path, jsf))
-		and jsf.lower().endswith(".json")
-	]
+    # Find all files with geonodes.
+    blends = [
+        os.path.join(path, blend)
+        for blend in os.listdir(path)
+        if os.path.isfile(os.path.join(path, blend))
+        and blend.lower().endswith(".blend")
+    ]
+    json_files = [
+        os.path.join(path, jsf)
+        for jsf in os.listdir(path)
+        if os.path.isfile(os.path.join(path, jsf)) and jsf.lower().endswith(".json")
+    ]
 
-	env.log("json pairs of blend files", vv_only=True)
-	env.log(json_files, vv_only=True)
+    env.log("json pairs of blend files", vv_only=True)
+    env.log(json_files, vv_only=True)
 
-	for bfile in blends:
-		row_items = []
-		using_json = False
-		js_equiv = os.path.splitext(bfile)[0] + ".json"
-		if js_equiv in json_files:
-			env.log("Loading json preset for geonode for " + bfile)
-			# Read nodegroups to include from json presets file.
-			jpath = os.path.splitext(bfile)[0] + ".json"
-			with open(jpath) as jopen:
-				jdata = json.load(jopen)
-			row_items = jdata.keys()
-			using_json = True
-		else:
-			env.log("Loading nodegroups from blend for geonode effects: " + bfile)
-			# Read nodegroup names from blend file directly.
-			with bpy.data.libraries.load(bfile) as (data_from, _):
-				row_items = list(data_from.node_groups)
+    for bfile in blends:
+        row_items = []
+        using_json = False
+        js_equiv = os.path.splitext(bfile)[0] + ".json"
+        if js_equiv in json_files:
+            env.log("Loading json preset for geonode for " + bfile)
+            # Read nodegroups to include from json presets file.
+            jpath = os.path.splitext(bfile)[0] + ".json"
+            with open(jpath) as jopen:
+                jdata = json.load(jopen)
+            row_items = jdata.keys()
+            using_json = True
+        else:
+            env.log("Loading nodegroups from blend for geonode effects: " + bfile)
+            # Read nodegroup names from blend file directly.
+            with bpy.data.libraries.load(bfile) as (data_from, _):
+                row_items = list(data_from.node_groups)
 
-		for itm in row_items:
-			if spawn_util.SKIP_COLL in itm.lower():  # mcskip
-				continue
+        for itm in row_items:
+            if spawn_util.SKIP_COLL in itm.lower():  # mcskip
+                continue
 
-			if using_json:
-				# First key in index is nodegroup, save to subpath, but then
-				# the present name (list of keys within) are the actual names.
-				for preset in jdata[itm]:
-					env.log("\tgeonode preset: " + preset, vv_only=True)
-					effect = mcprep_props.effects_list.add()
-					effect.name = preset  # This is the assign json preset name.
-					effect.subpath = itm  # This is the node group name.
-					effect.effect_type = GEO_AREA
-					effect.filepath = bfile
-					effect.index = len(mcprep_props.effects_list) - 1  # For icon index.
+            if using_json:
+                # First key in index is nodegroup, save to subpath, but then
+                # the present name (list of keys within) are the actual names.
+                for preset in jdata[itm]:
+                    env.log("\tgeonode preset: " + preset, vv_only=True)
+                    effect = mcprep_props.effects_list.add()
+                    effect.name = preset  # This is the assign json preset name.
+                    effect.subpath = itm  # This is the node group name.
+                    effect.effect_type = GEO_AREA
+                    effect.filepath = bfile
+                    effect.index = len(mcprep_props.effects_list) - 1  # For icon index.
 
-			else:
-				# Using the nodegroup name itself as the key, no subpath.
-				effect = mcprep_props.effects_list.add()
-				effect.name = itm
-				effect.subpath = itm  # Always the nodegroup name.
-				effect.effect_type = GEO_AREA
-				effect.filepath = bfile
-				effect.index = len(mcprep_props.effects_list) - 1  # For icon index.
+            else:
+                # Using the nodegroup name itself as the key, no subpath.
+                effect = mcprep_props.effects_list.add()
+                effect.name = itm
+                effect.subpath = itm  # Always the nodegroup name.
+                effect.effect_type = GEO_AREA
+                effect.filepath = bfile
+                effect.index = len(mcprep_props.effects_list) - 1  # For icon index.
 
 
 def load_area_particle_effects(context):
-	"""Load effects defined by wide area particle effects (non geo nodes).
+    """Load effects defined by wide area particle effects (non geo nodes).
 
-	This is a fallback for older versions of blender which don't have geonodes,
-	or where geonodes aren't working well or someone just wants to use
-	particles.
-	"""
-	mcprep_props = context.scene.mcprep_props
-	path = context.scene.mcprep_effects_path
-	path = os.path.join(path, "particle")
+    This is a fallback for older versions of blender which don't have geonodes,
+    or where geonodes aren't working well or someone just wants to use
+    particles.
+    """
+    mcprep_props = context.scene.mcprep_props
+    path = context.scene.mcprep_effects_path
+    path = os.path.join(path, "particle")
 
-	if not os.path.isdir(path):
-		print("The particle directory is missing! Reinstall MCprep")
-		print(path)
-		return
+    if not os.path.isdir(path):
+        print("The particle directory is missing! Reinstall MCprep")
+        print(path)
+        return
 
-	# Find all files with geonodes.
-	blends = [
-		os.path.join(path, blend) for blend in os.listdir(path)
-		if os.path.isfile(os.path.join(path, blend))
-		and blend.lower().endswith("blend")
-	]
+    # Find all files with geonodes.
+    blends = [
+        os.path.join(path, blend)
+        for blend in os.listdir(path)
+        if os.path.isfile(os.path.join(path, blend)) and blend.lower().endswith("blend")
+    ]
 
-	for bfile in blends:
-		with bpy.data.libraries.load(bfile) as (data_from, _):
-			particles = list(data_from.particles)
+    for bfile in blends:
+        with bpy.data.libraries.load(bfile) as (data_from, _):
+            particles = list(data_from.particles)
 
-		for itm in particles:
-			effect = mcprep_props.effects_list.add()
-			effect.effect_type = PARTICLE_AREA
-			effect.name = itm
-			effect.filepath = bfile
-			effect.index = len(mcprep_props.effects_list) - 1  # For icon index.
+        for itm in particles:
+            effect = mcprep_props.effects_list.add()
+            effect.effect_type = PARTICLE_AREA
+            effect.name = itm
+            effect.filepath = bfile
+            effect.index = len(mcprep_props.effects_list) - 1  # For icon index.
 
 
 def load_collection_effects(context):
-	"""Load effects defined by collections saved to an effects blend file."""
-	if not util.bv28():
-		print("Collection spawning not supported in Blender 2.7x")
-		return
-	mcprep_props = context.scene.mcprep_props
-	path = context.scene.mcprep_effects_path
-	path = os.path.join(path, "collection")
+    """Load effects defined by collections saved to an effects blend file."""
+    if not util.bv28():
+        print("Collection spawning not supported in Blender 2.7x")
+        return
+    mcprep_props = context.scene.mcprep_props
+    path = context.scene.mcprep_effects_path
+    path = os.path.join(path, "collection")
 
-	if not os.path.isdir(path):
-		print("The collection directory is missing! Reinstall MCprep")
-		print(path)
-		return
+    if not os.path.isdir(path):
+        print("The collection directory is missing! Reinstall MCprep")
+        print(path)
+        return
 
-	# Find all files with geonodes.
-	blends = [
-		os.path.join(path, blend) for blend in os.listdir(path)
-		if os.path.isfile(os.path.join(path, blend))
-		and blend.lower().endswith("blend")
-	]
+    # Find all files with geonodes.
+    blends = [
+        os.path.join(path, blend)
+        for blend in os.listdir(path)
+        if os.path.isfile(os.path.join(path, blend)) and blend.lower().endswith("blend")
+    ]
 
-	for bfile in blends:
-		with bpy.data.libraries.load(bfile) as (data_from, _):
-			collections = spawn_util.filter_collections(data_from)
+    for bfile in blends:
+        with bpy.data.libraries.load(bfile) as (data_from, _):
+            collections = spawn_util.filter_collections(data_from)
 
-		for itm in collections:
-			effect = mcprep_props.effects_list.add()
-			effect.effect_type = "collection"
-			effect.name = itm
-			effect.filepath = bfile
-			effect.index = len(mcprep_props.effects_list) - 1  # For icon index.
+        for itm in collections:
+            effect = mcprep_props.effects_list.add()
+            effect.effect_type = "collection"
+            effect.name = itm
+            effect.filepath = bfile
+            effect.index = len(mcprep_props.effects_list) - 1  # For icon index.
 
 
 def load_image_sequence_effects(context):
-	"""Load effects from the particles folder that should be animated."""
-	mcprep_props = context.scene.mcprep_props
+    """Load effects from the particles folder that should be animated."""
+    mcprep_props = context.scene.mcprep_props
 
-	resource_folder = bpy.path.abspath(context.scene.mcprep_texturepack_path)
+    resource_folder = bpy.path.abspath(context.scene.mcprep_texturepack_path)
 
-	# Check levels.
-	lvl_0 = os.path.join(resource_folder, "particle")
-	lvl_1 = os.path.join(resource_folder, "textures", "particle")
-	lvl_2 = os.path.join(resource_folder, "minecraft", "textures", "particle")
-	lvl_3 = os.path.join(resource_folder, "assets", "minecraft", "textures", "particle")
+    # Check levels.
+    lvl_0 = os.path.join(resource_folder, "particle")
+    lvl_1 = os.path.join(resource_folder, "textures", "particle")
+    lvl_2 = os.path.join(resource_folder, "minecraft", "textures", "particle")
+    lvl_3 = os.path.join(resource_folder, "assets", "minecraft", "textures", "particle")
 
-	if not os.path.isdir(resource_folder):
-		env.log(
-			"The particle resource directory is missing! Assign another resource pack")
-		return
-	elif os.path.isdir(lvl_0):
-		resource_folder = lvl_0
-	elif os.path.isdir(lvl_1):
-		resource_folder = lvl_1
-	elif os.path.isdir(lvl_2):
-		resource_folder = lvl_2
-	elif os.path.isdir(lvl_3):
-		resource_folder = lvl_3
+    if not os.path.isdir(resource_folder):
+        env.log(
+            "The particle resource directory is missing! Assign another resource pack"
+        )
+        return
+    elif os.path.isdir(lvl_0):
+        resource_folder = lvl_0
+    elif os.path.isdir(lvl_1):
+        resource_folder = lvl_1
+    elif os.path.isdir(lvl_2):
+        resource_folder = lvl_2
+    elif os.path.isdir(lvl_3):
+        resource_folder = lvl_3
 
-	# List all files and reduce to basename: fname_01.png to fname.
-	rfiles = os.listdir(resource_folder)
-	effect_files = [
-		os.path.splitext(fname)[0].rsplit("_", 1)[0]
-		for fname in rfiles
-		if os.path.isfile(os.path.join(resource_folder, fname))
-		and os.path.splitext(fname)[-1].lower() in EXTENSIONS
-	]
-	effect_files = list(set(effect_files))
+    # List all files and reduce to basename: fname_01.png to fname.
+    rfiles = os.listdir(resource_folder)
+    effect_files = [
+        os.path.splitext(fname)[0].rsplit("_", 1)[0]
+        for fname in rfiles
+        if os.path.isfile(os.path.join(resource_folder, fname))
+        and os.path.splitext(fname)[-1].lower() in EXTENSIONS
+    ]
+    effect_files = list(set(effect_files))
 
-	effect_files = sorted(effect_files)
+    effect_files = sorted(effect_files)
 
-	for itm in effect_files:
-		effect = mcprep_props.effects_list.add()
-		effect.effect_type = "img_seq"
-		effect.name = itm.replace("_", " ").capitalize()
-		effect.description = "Instance the {} particle aniamted sequence".format(
-			itm)
+    for itm in effect_files:
+        effect = mcprep_props.effects_list.add()
+        effect.effect_type = "img_seq"
+        effect.name = itm.replace("_", " ").capitalize()
+        effect.description = "Instance the {} particle aniamted sequence".format(itm)
 
-		# Note: the item being added is NOT a full filepath, but the prefix.
-		effect.filepath = os.path.join(resource_folder, itm)
+        # Note: the item being added is NOT a full filepath, but the prefix.
+        effect.filepath = os.path.join(resource_folder, itm)
 
-		effect.index = len(mcprep_props.effects_list) - 1  # For icon index.
+        effect.index = len(mcprep_props.effects_list) - 1  # For icon index.
 
-		# Try to load a middle frame as the icon.
-		if not env.use_icons or env.preview_collections["effects"] == "":
-			continue
-		effect_files = [
-			os.path.join(resource_folder, fname)
-			for fname in rfiles
-			if os.path.isfile(os.path.join(resource_folder, fname))
-			and fname.startswith(itm)
-			and os.path.splitext(fname)[-1].lower() in EXTENSIONS
-		]
-		if effect_files:
-			# 0 if 1 item, otherwise greater side of median.
-			e_index = int(len(effect_files) / 2)
-			env.preview_collections["effects"].load(
-				"effects-{}".format(effect.index), effect_files[e_index], 'IMAGE')
+        # Try to load a middle frame as the icon.
+        if not env.use_icons or env.preview_collections["effects"] == "":
+            continue
+        effect_files = [
+            os.path.join(resource_folder, fname)
+            for fname in rfiles
+            if os.path.isfile(os.path.join(resource_folder, fname))
+            and fname.startswith(itm)
+            and os.path.splitext(fname)[-1].lower() in EXTENSIONS
+        ]
+        if effect_files:
+            # 0 if 1 item, otherwise greater side of median.
+            e_index = int(len(effect_files) / 2)
+            env.preview_collections["effects"].load(
+                "effects-{}".format(effect.index), effect_files[e_index], "IMAGE"
+            )
 
 
 # -----------------------------------------------------------------------------
@@ -992,222 +1000,228 @@ def load_image_sequence_effects(context):
 
 
 class MCPREP_OT_effects_path_reset(bpy.types.Operator):
-	"""Reset the effects path to the default specified in the addon preferences panel"""
-	bl_idname = "mcprep.effects_path_reset"
-	bl_label = "Reset effects path"
-	bl_options = {'REGISTER', 'UNDO'}
+    """Reset the effects path to the default specified in the addon preferences panel"""
 
-	@tracking.report_error
-	def execute(self, context):
-		addon_prefs = util.get_user_preferences(context)
-		context.scene.mcprep_effects_path = addon_prefs.effects_path
-		update_effects_list(context)
-		return {'FINISHED'}
+    bl_idname = "mcprep.effects_path_reset"
+    bl_label = "Reset effects path"
+    bl_options = {"REGISTER", "UNDO"}
+
+    @tracking.report_error
+    def execute(self, context):
+        addon_prefs = util.get_user_preferences(context)
+        context.scene.mcprep_effects_path = addon_prefs.effects_path
+        update_effects_list(context)
+        return {"FINISHED"}
 
 
 class MCPREP_OT_reload_effects(bpy.types.Operator):
-	"""Reload effects spawner, use after changes to/new effects files"""
-	bl_idname = "mcprep.reload_effects"
-	bl_label = "Reload effects"
+    """Reload effects spawner, use after changes to/new effects files"""
 
-	@tracking.report_error
-	def execute(self, context):
-		update_effects_list(context)
-		return {'FINISHED'}
+    bl_idname = "mcprep.reload_effects"
+    bl_label = "Reload effects"
+
+    @tracking.report_error
+    def execute(self, context):
+        update_effects_list(context)
+        return {"FINISHED"}
 
 
 class MCPREP_OT_global_effect(bpy.types.Operator):
-	"""Spawn a global effect such as weather particles"""
-	bl_idname = "mcprep.spawn_global_effect"
-	bl_label = "Global effect"
-	bl_options = {'REGISTER', 'UNDO'}
+    """Spawn a global effect such as weather particles"""
 
-	def effects_enum(self, context):
-		"""Identifies eligible global effects to include in the dropdown."""
-		mcprep_props = context.scene.mcprep_props
-		elist = []
-		for effect in mcprep_props.effects_list:
-			if effect.effect_type not in (GEO_AREA, PARTICLE_AREA):
-				continue
-			if effect.effect_type == GEO_AREA:
-				display_type = "geometry node effect"
-				short_type = " (Geo nodes)"
-			else:
-				display_type = "particle system effect"
-				short_type = " (Particles)"
-			elist.append((
-				str(effect.index),
-				effect.name + short_type,
-				"Add {} {} from {}".format(
-					effect.name,
-					display_type,
-					os.path.basename(effect.filepath))
-			))
-		return elist
+    bl_idname = "mcprep.spawn_global_effect"
+    bl_label = "Global effect"
+    bl_options = {"REGISTER", "UNDO"}
 
-	effect_id: bpy.props.EnumProperty(items=effects_enum, name="Effect")
-	skipUsage: bpy.props.BoolProperty(default=False, options={'HIDDEN'})
+    def effects_enum(self, context):
+        """Identifies eligible global effects to include in the dropdown."""
+        mcprep_props = context.scene.mcprep_props
+        elist = []
+        for effect in mcprep_props.effects_list:
+            if effect.effect_type not in (GEO_AREA, PARTICLE_AREA):
+                continue
+            if effect.effect_type == GEO_AREA:
+                display_type = "geometry node effect"
+                short_type = " (Geo nodes)"
+            else:
+                display_type = "particle system effect"
+                short_type = " (Particles)"
+            elist.append(
+                (
+                    str(effect.index),
+                    effect.name + short_type,
+                    "Add {} {} from {}".format(
+                        effect.name, display_type, os.path.basename(effect.filepath)
+                    ),
+                )
+            )
+        return elist
 
-	@classmethod
-	def poll(cls, context):
-		return context.mode == 'OBJECT'
+    effect_id: bpy.props.EnumProperty(items=effects_enum, name="Effect")
+    skipUsage: bpy.props.BoolProperty(default=False, options={"HIDDEN"})
 
-	track_function = "effect_global"
-	@tracking.report_error
-	def execute(self, context):
-		mcprep_props = context.scene.mcprep_props
-		effect = mcprep_props.effects_list[int(self.effect_id)]
+    @classmethod
+    def poll(cls, context):
+        return context.mode == "OBJECT"
 
-		if not os.path.isfile(bpy.path.abspath(effect.filepath)):
-			self.report({'WARNING'}, "Target effects file not found")
-			bpy.ops.mcprep.prompt_reset_spawners('INVOKE_DEFAULT')
-			return {'CANCELLED'}
+    track_function = "effect_global"
 
-		if effect.effect_type == GEO_AREA:
-			add_geonode_area_effect(context, effect)
-			self.report(
-				{"INFO"},
-				"Added geo nodes, edit modifier for further control")
-		elif effect.effect_type == PARTICLE_AREA:
-			cam = context.scene.camera
-			use_camera = False
-			vartical_offset = Vector([0, 0, 15])
-			if cam:
-				location = context.scene.camera.location + vartical_offset
-				use_camera = True
-			else:
-				location = util.get_cuser_location(context)
+    @tracking.report_error
+    def execute(self, context):
+        mcprep_props = context.scene.mcprep_props
+        effect = mcprep_props.effects_list[int(self.effect_id)]
 
-			obj = add_area_particle_effect(context, effect, location)
-			if use_camera:
-				const = obj.constraints.new('COPY_LOCATION')
-				const.target = cam
-				const.use_z = False
-				obj.location = location
+        if not os.path.isfile(bpy.path.abspath(effect.filepath)):
+            self.report({"WARNING"}, "Target effects file not found")
+            bpy.ops.mcprep.prompt_reset_spawners("INVOKE_DEFAULT")
+            return {"CANCELLED"}
 
-		self.track_param = effect.name
-		return {'FINISHED'}
+        if effect.effect_type == GEO_AREA:
+            add_geonode_area_effect(context, effect)
+            self.report({"INFO"}, "Added geo nodes, edit modifier for further control")
+        elif effect.effect_type == PARTICLE_AREA:
+            cam = context.scene.camera
+            use_camera = False
+            vartical_offset = Vector([0, 0, 15])
+            if cam:
+                location = context.scene.camera.location + vartical_offset
+                use_camera = True
+            else:
+                location = util.get_cuser_location(context)
+
+            obj = add_area_particle_effect(context, effect, location)
+            if use_camera:
+                const = obj.constraints.new("COPY_LOCATION")
+                const.target = cam
+                const.use_z = False
+                obj.location = location
+
+        self.track_param = effect.name
+        return {"FINISHED"}
 
 
 class MCPREP_OT_instant_effect(bpy.types.Operator):
-	"""Spawn an effect that takes place at specific time and position"""
-	bl_idname = "mcprep.spawn_instant_effect"
-	bl_label = "Instant effect"
-	bl_options = {'REGISTER', 'UNDO'}
+    """Spawn an effect that takes place at specific time and position"""
 
-	def effects_enum(self, context):
-		"""Identifies eligible instant effects to include in the dropdown."""
-		mcprep_props = context.scene.mcprep_props
-		elist = []
-		for effect in mcprep_props.effects_list:
-			if effect.effect_type == COLLECTION:
-				display_type = "preanimated collection effect"
-			elif effect.effect_type == IMG_SEQ:
-				display_type = "image sequence effect"
-			else:
-				continue
-			elist.append((
-				str(effect.index),
-				effect.name,
-				"Add {} {} from {}".format(
-					effect.name,
-					display_type,
-					os.path.basename(effect.filepath))
-			))
-		return elist
+    bl_idname = "mcprep.spawn_instant_effect"
+    bl_label = "Instant effect"
+    bl_options = {"REGISTER", "UNDO"}
 
-	effect_id: bpy.props.EnumProperty(items=effects_enum, name="Effect")
-	location: bpy.props.FloatVectorProperty(default=(0, 0, 0), name="Location")
-	frame: bpy.props.IntProperty(
-		default=0,
-		name="Frame",
-		description="Start frame for animation")
-	speed: bpy.props.FloatProperty(
-		default=1.0,
-		min=0.1,
-		name="Speed",
-		description="Make the effect run faster (skip frames) or slower (hold frames)")
-	show_image: bpy.props.BoolProperty(
-		default=False,
-		name="Show image preview",
-		description="Show a middle animation frame as a viewport preview")
-	skipUsage: bpy.props.BoolProperty(default=False, options={'HIDDEN'})
+    def effects_enum(self, context):
+        """Identifies eligible instant effects to include in the dropdown."""
+        mcprep_props = context.scene.mcprep_props
+        elist = []
+        for effect in mcprep_props.effects_list:
+            if effect.effect_type == COLLECTION:
+                display_type = "preanimated collection effect"
+            elif effect.effect_type == IMG_SEQ:
+                display_type = "image sequence effect"
+            else:
+                continue
+            elist.append(
+                (
+                    str(effect.index),
+                    effect.name,
+                    "Add {} {} from {}".format(
+                        effect.name, display_type, os.path.basename(effect.filepath)
+                    ),
+                )
+            )
+        return elist
 
-	@classmethod
-	def poll(cls, context):
-		return context.mode == 'OBJECT'
+    effect_id: bpy.props.EnumProperty(items=effects_enum, name="Effect")
+    location: bpy.props.FloatVectorProperty(default=(0, 0, 0), name="Location")
+    frame: bpy.props.IntProperty(
+        default=0, name="Frame", description="Start frame for animation"
+    )
+    speed: bpy.props.FloatProperty(
+        default=1.0,
+        min=0.1,
+        name="Speed",
+        description="Make the effect run faster (skip frames) or slower (hold frames)",
+    )
+    show_image: bpy.props.BoolProperty(
+        default=False,
+        name="Show image preview",
+        description="Show a middle animation frame as a viewport preview",
+    )
+    skipUsage: bpy.props.BoolProperty(default=False, options={"HIDDEN"})
 
-	track_function = "effect_instant"
-	@tracking.report_error
-	def execute(self, context):
-		mcprep_props = context.scene.mcprep_props
-		effect = mcprep_props.effects_list[int(self.effect_id)]
+    @classmethod
+    def poll(cls, context):
+        return context.mode == "OBJECT"
 
-		if effect.effect_type == "collection":
-			if not os.path.isfile(bpy.path.abspath(effect.filepath)):
-				self.report({'WARNING'}, "Target effects file not found")
-				bpy.ops.mcprep.prompt_reset_spawners('INVOKE_DEFAULT')
-				return {'CANCELLED'}
-			add_collection_effect(context, effect, self.location, self.frame)
+    track_function = "effect_instant"
 
-		elif effect.effect_type == "img_seq":
-			base_path = os.path.dirname(effect.filepath)
-			if not os.path.isdir(bpy.path.abspath(base_path)):
-				self.report({'WARNING'}, "Target effects file not found: base_path")
-				print(base_path)
-				bpy.ops.mcprep.prompt_reset_spawners('INVOKE_DEFAULT')
-				return {'CANCELLED'}
+    @tracking.report_error
+    def execute(self, context):
+        mcprep_props = context.scene.mcprep_props
+        effect = mcprep_props.effects_list[int(self.effect_id)]
 
-			inst = add_image_sequence_effect(
-				context, effect, self.location, self.frame, self.speed)
-			if not self.show_image:
-				inst.data = None
+        if effect.effect_type == "collection":
+            if not os.path.isfile(bpy.path.abspath(effect.filepath)):
+                self.report({"WARNING"}, "Target effects file not found")
+                bpy.ops.mcprep.prompt_reset_spawners("INVOKE_DEFAULT")
+                return {"CANCELLED"}
+            add_collection_effect(context, effect, self.location, self.frame)
 
-		self.track_param = effect.name
-		return {'FINISHED'}
+        elif effect.effect_type == "img_seq":
+            base_path = os.path.dirname(effect.filepath)
+            if not os.path.isdir(bpy.path.abspath(base_path)):
+                self.report({"WARNING"}, "Target effects file not found: base_path")
+                print(base_path)
+                bpy.ops.mcprep.prompt_reset_spawners("INVOKE_DEFAULT")
+                return {"CANCELLED"}
+
+            inst = add_image_sequence_effect(
+                context, effect, self.location, self.frame, self.speed
+            )
+            if not self.show_image:
+                inst.data = None
+
+        self.track_param = effect.name
+        return {"FINISHED"}
 
 
 class MCPREP_OT_spawn_particle_planes(bpy.types.Operator, ImportHelper):
-	"""Create a particle system from a selected image input"""
-	bl_idname = "mcprep.spawn_particle_planes"
-	bl_label = "Spawn Particle Planes"
-	bl_options = {'REGISTER', 'UNDO'}
+    """Create a particle system from a selected image input"""
 
-	location: bpy.props.FloatVectorProperty(
-		default=(0, 0, 0), name="Location")
-	frame: bpy.props.IntProperty(default=0, name="Frame")
+    bl_idname = "mcprep.spawn_particle_planes"
+    bl_label = "Spawn Particle Planes"
+    bl_options = {"REGISTER", "UNDO"}
 
-	# Importer helper
-	exts = ";".join(["*" + ext for ext in EXTENSIONS])
-	filter_glob: bpy.props.StringProperty(
-		default=exts,
-		options={'HIDDEN'})
-	fileselectparams = "use_filter_blender"
+    location: bpy.props.FloatVectorProperty(default=(0, 0, 0), name="Location")
+    frame: bpy.props.IntProperty(default=0, name="Frame")
 
-	skipUsage: bpy.props.BoolProperty(
-		default=False,
-		options={'HIDDEN'})
+    # Importer helper
+    exts = ";".join(["*" + ext for ext in EXTENSIONS])
+    filter_glob: bpy.props.StringProperty(default=exts, options={"HIDDEN"})
+    fileselectparams = "use_filter_blender"
 
-	track_function = "particle_planes"
-	@tracking.report_error
-	def execute(self, context):
-		path = bpy.path.abspath(self.filepath)
-		name = os.path.basename(path)
-		name = os.path.splitext(name)[0]
+    skipUsage: bpy.props.BoolProperty(default=False, options={"HIDDEN"})
 
-		try:
-			add_particle_planes_effect(
-				context, self.filepath, self.location, self.frame)
-		except FileNotFoundError as e:
-			print("Particle effect file error:", e)
-			self.report({'WARNING'}, "File not found")
-			bpy.ops.mcprep.prompt_reset_spawners('INVOKE_DEFAULT')
-			return {'CANCELLED'}
+    track_function = "particle_planes"
 
-		context.scene.mcprep_particle_plane_file = self.filepath
+    @tracking.report_error
+    def execute(self, context):
+        path = bpy.path.abspath(self.filepath)
+        name = os.path.basename(path)
+        name = os.path.splitext(name)[0]
 
-		self.track_param = name
-		return {'FINISHED'}
+        try:
+            add_particle_planes_effect(
+                context, self.filepath, self.location, self.frame
+            )
+        except FileNotFoundError as e:
+            print("Particle effect file error:", e)
+            self.report({"WARNING"}, "File not found")
+            bpy.ops.mcprep.prompt_reset_spawners("INVOKE_DEFAULT")
+            return {"CANCELLED"}
+
+        context.scene.mcprep_particle_plane_file = self.filepath
+
+        self.track_param = name
+        return {"FINISHED"}
 
 
 # Potential future features:
@@ -1232,19 +1246,19 @@ class MCPREP_OT_spawn_particle_planes(bpy.types.Operator, ImportHelper):
 
 
 classes = (
-	MCPREP_OT_effects_path_reset,
-	MCPREP_OT_reload_effects,
-	MCPREP_OT_global_effect,
-	MCPREP_OT_instant_effect,
-	MCPREP_OT_spawn_particle_planes,
+    MCPREP_OT_effects_path_reset,
+    MCPREP_OT_reload_effects,
+    MCPREP_OT_global_effect,
+    MCPREP_OT_instant_effect,
+    MCPREP_OT_spawn_particle_planes,
 )
 
 
 def register():
-	for cls in classes:
-		bpy.utils.register_class(cls)
+    for cls in classes:
+        bpy.utils.register_class(cls)
 
 
 def unregister():
-	for cls in reversed(classes):
-		bpy.utils.unregister_class(cls)
+    for cls in reversed(classes):
+        bpy.utils.unregister_class(cls)

--- a/MCprep_addon/spawner/entities.py
+++ b/MCprep_addon/spawner/entities.py
@@ -37,100 +37,103 @@ entity_cache_path = None
 
 
 def get_entity_cache(context, clear=False):
-	"""Load collections from entity spawning lib if not cached, return key vars."""
-	global entity_cache
-	global entity_cache_path  # Used to auto-clear path if bpy prop changed.
+    """Load collections from entity spawning lib if not cached, return key vars."""
+    global entity_cache
+    global entity_cache_path  # Used to auto-clear path if bpy prop changed.
 
-	entity_path = context.scene.entity_path
-	if not entity_cache_path:
-		entity_cache_path = entity_path
-		clear = True
-	if entity_cache_path != entity_path:
-		clear = True
+    entity_path = context.scene.entity_path
+    if not entity_cache_path:
+        entity_cache_path = entity_path
+        clear = True
+    if entity_cache_path != entity_path:
+        clear = True
 
-	if entity_cache and clear is not True:
-		return entity_cache
+    if entity_cache and clear is not True:
+        return entity_cache
 
-	# Note: Only using groups, not objects, for entities.
-	entity_cache = {"groups": [], "objects": []}
-	if not os.path.isfile(entity_path):
-		env.log("Entity path not found")
-		return entity_cache
-	if not entity_path.lower().endswith('.blend'):
-		env.log("Entity path must be a .blend file")
-		return entity_cache
+    # Note: Only using groups, not objects, for entities.
+    entity_cache = {"groups": [], "objects": []}
+    if not os.path.isfile(entity_path):
+        env.log("Entity path not found")
+        return entity_cache
+    if not entity_path.lower().endswith(".blend"):
+        env.log("Entity path must be a .blend file")
+        return entity_cache
 
-	with bpy.data.libraries.load(entity_path) as (data_from, _):
-		grp_list = spawn_util.filter_collections(data_from)
-		entity_cache["groups"] = grp_list
-	return entity_cache
+    with bpy.data.libraries.load(entity_path) as (data_from, _):
+        grp_list = spawn_util.filter_collections(data_from)
+        entity_cache["groups"] = grp_list
+    return entity_cache
 
 
 def getEntityList(context):
-	"""Only used for UI drawing of enum menus, full list."""
+    """Only used for UI drawing of enum menus, full list."""
 
-	# may redraw too many times, perhaps have flag
-	if not context.scene.mcprep_props.entity_list:
-		updateEntityList(context)
-	return [
-		(itm.entity, itm.name.title(), "Place {}".format(itm.name))
-		for itm in context.scene.mcprep_props.entity_list]
+    # may redraw too many times, perhaps have flag
+    if not context.scene.mcprep_props.entity_list:
+        updateEntityList(context)
+    return [
+        (itm.entity, itm.name.title(), "Place {}".format(itm.name))
+        for itm in context.scene.mcprep_props.entity_list
+    ]
 
 
 def update_entity_path(self, context):
-	"""for UI list path callback"""
-	env.log("Updating entity path", vv_only=True)
-	if not context.scene.entity_path.lower().endswith('.blend'):
-		print("Entity file is not a .blend, and should be")
-	if not os.path.isfile(bpy.path.abspath(context.scene.entity_path)):
-		print("Entity blend file does not exist")
-	updateEntityList(context)
+    """for UI list path callback"""
+    env.log("Updating entity path", vv_only=True)
+    if not context.scene.entity_path.lower().endswith(".blend"):
+        print("Entity file is not a .blend, and should be")
+    if not os.path.isfile(bpy.path.abspath(context.scene.entity_path)):
+        print("Entity blend file does not exist")
+    updateEntityList(context)
 
 
 def updateEntityList(context):
-	"""Update the entity list"""
-	entity_file = bpy.path.abspath(context.scene.entity_path)
-	if not os.path.isfile(entity_file):
-		print("Invalid entity blend file path")
-		context.scene.mcprep_props.entity_list.clear()
-		return
+    """Update the entity list"""
+    entity_file = bpy.path.abspath(context.scene.entity_path)
+    if not os.path.isfile(entity_file):
+        print("Invalid entity blend file path")
+        context.scene.mcprep_props.entity_list.clear()
+        return
 
-	temp_entity_list = []  # just to skip duplicates
-	entity_list = []
+    temp_entity_list = []  # just to skip duplicates
+    entity_list = []
 
-	cache = get_entity_cache(context)
-	prefix = "Group/" if hasattr(bpy.data, "groups") else "Collection/"
-	for name in cache.get("groups"):
-		if not name:
-			continue
-		if util.nameGeneralize(name).lower() in temp_entity_list:
-			continue
-		description = "Place {x} entity".format(x=name)
-		entity_list.append((prefix + name, name.title(), description))
-		temp_entity_list.append(util.nameGeneralize(name).lower())
+    cache = get_entity_cache(context)
+    prefix = "Group/" if hasattr(bpy.data, "groups") else "Collection/"
+    for name in cache.get("groups"):
+        if not name:
+            continue
+        if util.nameGeneralize(name).lower() in temp_entity_list:
+            continue
+        description = "Place {x} entity".format(x=name)
+        entity_list.append((prefix + name, name.title(), description))
+        temp_entity_list.append(util.nameGeneralize(name).lower())
 
-	# sort the list alphabetically by name
-	if entity_list:
-		_, sorted_entities = zip(*sorted(zip(
-			[entity[1].lower() for entity in entity_list], entity_list)))
-	else:
-		sorted_entities = []
+    # sort the list alphabetically by name
+    if entity_list:
+        _, sorted_entities = zip(
+            *sorted(zip([entity[1].lower() for entity in entity_list], entity_list))
+        )
+    else:
+        sorted_entities = []
 
-	# now re-populate the UI list
-	context.scene.mcprep_props.entity_list.clear()
-	for itm in sorted_entities:
-		item = context.scene.mcprep_props.entity_list.add()
-		item.entity = itm[0]
-		item.name = itm[1]
-		item.description = itm[2]
+    # now re-populate the UI list
+    context.scene.mcprep_props.entity_list.clear()
+    for itm in sorted_entities:
+        item = context.scene.mcprep_props.entity_list.add()
+        item.entity = itm[0]
+        item.name = itm[1]
+        item.description = itm[2]
 
 
-class face_struct():
-	"""Structure class for preprocessed faces of a mesh"""
-	def __init__(self, normal_coord, global_coord, local_coord):
-		self.n = normal_coord
-		self.g = global_coord
-		self.l = local_coord
+class face_struct:
+    """Structure class for preprocessed faces of a mesh"""
+
+    def __init__(self, normal_coord, global_coord, local_coord):
+        self.n = normal_coord
+        self.g = global_coord
+        self.l = local_coord
 
 
 # -----------------------------------------------------------------------------
@@ -139,108 +142,117 @@ class face_struct():
 
 
 class MCPREP_OT_entity_path_reset(bpy.types.Operator):
-	"""Reset the spawn path to the default specified in the addon preferences panel"""
-	bl_idname = "mcprep.entity_path_reset"
-	bl_label = "Reset entity path"
-	bl_options = {'REGISTER', 'UNDO'}
+    """Reset the spawn path to the default specified in the addon preferences panel"""
 
-	@tracking.report_error
-	def execute(self, context):
+    bl_idname = "mcprep.entity_path_reset"
+    bl_label = "Reset entity path"
+    bl_options = {"REGISTER", "UNDO"}
 
-		addon_prefs = util.get_user_preferences(context)
-		context.scene.entity_path = addon_prefs.entity_path
-		updateEntityList(context)
-		return {'FINISHED'}
+    @tracking.report_error
+    def execute(self, context):
+        addon_prefs = util.get_user_preferences(context)
+        context.scene.entity_path = addon_prefs.entity_path
+        updateEntityList(context)
+        return {"FINISHED"}
 
 
 class MCPREP_OT_entity_spawner(bpy.types.Operator):
-	"""Instantly spawn built-in entities into a scene"""
-	bl_idname = "mcprep.entity_spawner"
-	bl_label = "Entity Spawner"
-	bl_options = {'REGISTER', 'UNDO'}
+    """Instantly spawn built-in entities into a scene"""
 
-	# properties, will appear in redo-last menu
-	def swap_enum(self, context):
-		return getEntityList(context)
+    bl_idname = "mcprep.entity_spawner"
+    bl_label = "Entity Spawner"
+    bl_options = {"REGISTER", "UNDO"}
 
-	entity: bpy.props.EnumProperty(items=swap_enum, name="Entity")
-	append_layer: bpy.props.IntProperty(
-		name="Append layer",
-		default=20,
-		min=0,
-		max=20,
-		description="Set the layer for appending groups, 0 means same as active layers")
-	relocation: bpy.props.EnumProperty(
-		items=[
-			('Cursor', 'Cursor', 'Move the rig to the cursor'),
-			('Clear', 'Origin', 'Move the rig to the origin'),
-			('Offset', 'Offset root', (
-				'Offset the root bone to cursor while leaving the rest pose '
-				'at the origin'))],
-		name="Relocation")
-	clearPose: bpy.props.BoolProperty(
-		name="Clear Pose",
-		description="Clear the pose to rest position",
-		default=True)
-	prep_materials: bpy.props.BoolProperty(
-		name="Prep materials (will reset nodes)",
-		description=(
-			"Prep materials of the added rig, will replace cycles node groups "
-			"with default"),
-		default=True)
+    # properties, will appear in redo-last menu
+    def swap_enum(self, context):
+        return getEntityList(context)
 
-	skipUsage: bpy.props.BoolProperty(
-		default=False,
-		options={'HIDDEN'})
+    entity: bpy.props.EnumProperty(items=swap_enum, name="Entity")
+    append_layer: bpy.props.IntProperty(
+        name="Append layer",
+        default=20,
+        min=0,
+        max=20,
+        description="Set the layer for appending groups, 0 means same as active layers",
+    )
+    relocation: bpy.props.EnumProperty(
+        items=[
+            ("Cursor", "Cursor", "Move the rig to the cursor"),
+            ("Clear", "Origin", "Move the rig to the origin"),
+            (
+                "Offset",
+                "Offset root",
+                (
+                    "Offset the root bone to cursor while leaving the rest pose "
+                    "at the origin"
+                ),
+            ),
+        ],
+        name="Relocation",
+    )
+    clearPose: bpy.props.BoolProperty(
+        name="Clear Pose", description="Clear the pose to rest position", default=True
+    )
+    prep_materials: bpy.props.BoolProperty(
+        name="Prep materials (will reset nodes)",
+        description=(
+            "Prep materials of the added rig, will replace cycles node groups "
+            "with default"
+        ),
+        default=True,
+    )
 
-	@classmethod
-	def poll(self, context):
-		return context.mode == 'OBJECT'
+    skipUsage: bpy.props.BoolProperty(default=False, options={"HIDDEN"})
 
-	track_function = "entitySpawner"
-	track_param = None
-	@tracking.report_error
-	def execute(self, context):
-		entity_path = bpy.path.abspath(context.scene.entity_path)
-		method, name = self.entity.split("/", 1)
+    @classmethod
+    def poll(self, context):
+        return context.mode == "OBJECT"
 
-		try:
-			# must be in object mode, this make similar behavior to other objs
-			bpy.ops.object.mode_set(mode='OBJECT')
-		except:
-			pass  # Can fail to this e.g. if no objects are selected.
+    track_function = "entitySpawner"
+    track_param = None
 
-		# if there is a script with this entity rig, attempt to run it
-		spawn_util.attemptScriptLoad(entity_path)
+    @tracking.report_error
+    def execute(self, context):
+        entity_path = bpy.path.abspath(context.scene.entity_path)
+        method, name = self.entity.split("/", 1)
 
-		if self.prep_materials and context.selected_objects:
-			try:
-				bpy.ops.mcprep.prep_materials(
-					improveUiSettings=False, skipUsage=True)
-			except:
-				self.report({"WARNING"}, "Failed to prep materials on entity load")
+        try:
+            # must be in object mode, this make similar behavior to other objs
+            bpy.ops.object.mode_set(mode="OBJECT")
+        except:
+            pass  # Can fail to this e.g. if no objects are selected.
 
-		spawn_util.load_append(self, context, entity_path, name)
-		self.track_param = self.entity
-		return {'FINISHED'}
+        # if there is a script with this entity rig, attempt to run it
+        spawn_util.attemptScriptLoad(entity_path)
+
+        if self.prep_materials and context.selected_objects:
+            try:
+                bpy.ops.mcprep.prep_materials(improveUiSettings=False, skipUsage=True)
+            except:
+                self.report({"WARNING"}, "Failed to prep materials on entity load")
+
+        spawn_util.load_append(self, context, entity_path, name)
+        self.track_param = self.entity
+        return {"FINISHED"}
 
 
 class MCPREP_OT_reload_entites(bpy.types.Operator):
-	"""Force reload the Entity objects and cache."""
-	bl_idname = "mcprep.reload_entities"
-	bl_label = "Reload Entities"
+    """Force reload the Entity objects and cache."""
 
-	@tracking.report_error
-	def execute(self, context):
-		if not context.scene.entity_path.lower().endswith('.blend'):
-			self.report({'WARNING'}, "Entity file must be a .blend, try resetting")
-		elif not os.path.isfile(bpy.path.abspath(context.scene.entity_path)):
-			self.report({'WARNING'}, "Entity blend file does not exist")
+    bl_idname = "mcprep.reload_entities"
+    bl_label = "Reload Entities"
 
-		# still reload even with above issues, cache/UI should be cleared
-		get_entity_cache(context, clear=True)
-		updateEntityList(context)
-		return {'FINISHED'}
+    @tracking.report_error
+    def execute(self, context):
+        if not context.scene.entity_path.lower().endswith(".blend"):
+            self.report({"WARNING"}, "Entity file must be a .blend, try resetting")
+        elif not os.path.isfile(bpy.path.abspath(context.scene.entity_path)):
+            self.report({"WARNING"}, "Entity blend file does not exist")
+
+        # still reload even with above issues, cache/UI should be cleared
+        get_entity_cache(context, clear=True)
+        updateEntityList(context)
+        return {"FINISHED"}
 
 
 # -----------------------------------------------------------------------------
@@ -249,27 +261,27 @@ class MCPREP_OT_reload_entites(bpy.types.Operator):
 
 
 classes = (
-	MCPREP_OT_entity_path_reset,
-	MCPREP_OT_entity_spawner,
-	MCPREP_OT_reload_entites,
+    MCPREP_OT_entity_path_reset,
+    MCPREP_OT_entity_spawner,
+    MCPREP_OT_reload_entites,
 )
 
 
 def register():
-	for cls in classes:
-		bpy.utils.register_class(cls)
+    for cls in classes:
+        bpy.utils.register_class(cls)
 
-	global entity_cache
-	global entity_cache_path
-	entity_cache = {}
-	entity_cache_path = None
+    global entity_cache
+    global entity_cache_path
+    entity_cache = {}
+    entity_cache_path = None
 
 
 def unregister():
-	for cls in reversed(classes):
-		bpy.utils.unregister_class(cls)
+    for cls in reversed(classes):
+        bpy.utils.unregister_class(cls)
 
-	global entity_cache
-	global entity_cache_path
-	entity_cache = {}
-	entity_cache_path = None
+    global entity_cache
+    global entity_cache_path
+    entity_cache = {}
+    entity_cache_path = None

--- a/MCprep_addon/spawner/item.py
+++ b/MCprep_addon/spawner/item.py
@@ -25,11 +25,12 @@ import mathutils
 from .. import util
 from .. import tracking
 from ..conf import env
-from ..materials import generate 
+from ..materials import generate
+
 try:
-	import bpy.utils.previews
+    import bpy.utils.previews
 except ImportError:
-	pass
+    pass
 
 # -----------------------------------------------------------------------------
 # Support functions
@@ -37,255 +38,275 @@ except ImportError:
 
 
 def reload_items(context):
-	"""Reload the items UI list for spawning"""
+    """Reload the items UI list for spawning"""
 
-	mcprep_props = context.scene.mcprep_props
-	resource_folder = bpy.path.abspath(context.scene.mcprep_texturepack_path)
-	extensions = [".png", ".jpg", ".jpeg"]
+    mcprep_props = context.scene.mcprep_props
+    resource_folder = bpy.path.abspath(context.scene.mcprep_texturepack_path)
+    extensions = [".png", ".jpg", ".jpeg"]
 
-	mcprep_props.item_list.clear()
-	if env.use_icons and env.preview_collections["items"]:
-		try:
-			bpy.utils.previews.remove(env.preview_collections["items"])
-		except Exception as e:
-			print(e)
-			env.log("MCPREP: Failed to remove icon set, items")
+    mcprep_props.item_list.clear()
+    if env.use_icons and env.preview_collections["items"]:
+        try:
+            bpy.utils.previews.remove(env.preview_collections["items"])
+        except Exception as e:
+            print(e)
+            env.log("MCPREP: Failed to remove icon set, items")
 
-	# Check levels
-	lvl_1 = os.path.join(resource_folder, "textures")
-	lvl_2 = os.path.join(resource_folder, "minecraft", "textures")
-	lvl_3 = os.path.join(resource_folder, "assets", "minecraft", "textures")
+    # Check levels
+    lvl_1 = os.path.join(resource_folder, "textures")
+    lvl_2 = os.path.join(resource_folder, "minecraft", "textures")
+    lvl_3 = os.path.join(resource_folder, "assets", "minecraft", "textures")
 
-	if not os.path.isdir(resource_folder):
-		env.log("Error, resource folder does not exist")
-		return
-	elif os.path.isdir(lvl_1):
-		resource_folder = lvl_1
-	elif os.path.isdir(lvl_2):
-		resource_folder = lvl_2
-	elif os.path.isdir(lvl_3):
-		resource_folder = lvl_3
+    if not os.path.isdir(resource_folder):
+        env.log("Error, resource folder does not exist")
+        return
+    elif os.path.isdir(lvl_1):
+        resource_folder = lvl_1
+    elif os.path.isdir(lvl_2):
+        resource_folder = lvl_2
+    elif os.path.isdir(lvl_3):
+        resource_folder = lvl_3
 
-	search_paths = [
-		resource_folder,
-		os.path.join(resource_folder, "items"),
-		os.path.join(resource_folder, "item")]
-	files = []
+    search_paths = [
+        resource_folder,
+        os.path.join(resource_folder, "items"),
+        os.path.join(resource_folder, "item"),
+    ]
+    files = []
 
-	for path in search_paths:
-		if not os.path.isdir(path):
-			continue
-		files += [
-			os.path.join(path, item_file)
-			for item_file in os.listdir(path)
-			if os.path.isfile(os.path.join(path, item_file))
-			and os.path.splitext(item_file.lower())[-1] in extensions]
-	for i, item_file in enumerate(sorted(files)):
-		basename = os.path.splitext(os.path.basename(item_file))[0]
-		asset = mcprep_props.item_list.add()
-		asset.name = basename.replace("_", " ")
-		asset.description = "Spawn one " + basename
-		asset.path = item_file
-		asset.index = i
+    for path in search_paths:
+        if not os.path.isdir(path):
+            continue
+        files += [
+            os.path.join(path, item_file)
+            for item_file in os.listdir(path)
+            if os.path.isfile(os.path.join(path, item_file))
+            and os.path.splitext(item_file.lower())[-1] in extensions
+        ]
+    for i, item_file in enumerate(sorted(files)):
+        basename = os.path.splitext(os.path.basename(item_file))[0]
+        asset = mcprep_props.item_list.add()
+        asset.name = basename.replace("_", " ")
+        asset.description = "Spawn one " + basename
+        asset.path = item_file
+        asset.index = i
 
-		# if available, load the custom icon too
-		if not env.use_icons or env.preview_collections["items"] == "":
-			continue
-		env.preview_collections["items"].load(
-			"item-{}".format(i), item_file, 'IMAGE')
+        # if available, load the custom icon too
+        if not env.use_icons or env.preview_collections["items"] == "":
+            continue
+        env.preview_collections["items"].load("item-{}".format(i), item_file, "IMAGE")
 
-	if mcprep_props.item_list_index >= len(mcprep_props.item_list):
-		mcprep_props.item_list_index = len(mcprep_props.item_list) - 1
+    if mcprep_props.item_list_index >= len(mcprep_props.item_list):
+        mcprep_props.item_list_index = len(mcprep_props.item_list) - 1
 
 
 def spawn_item_from_filepath(
-	context, path, max_pixels, thickness, threshold, transparency):
-	"""Reusable function for generating an item from an image filepath
+    context, path, max_pixels, thickness, threshold, transparency
+):
+    """Reusable function for generating an item from an image filepath
 
-	Arguments
-		context
-		path: Full path to image file
-		max_pixels: int, maximum number of output faces, will scale down
-		thickness: Thickness of the solidfy modifier, minimum 0
-		threshold: float, alpha value below which faces will be removed
-		transparency: bool, remove faces below threshold
-	"""
+    Arguments
+            context
+            path: Full path to image file
+            max_pixels: int, maximum number of output faces, will scale down
+            thickness: Thickness of the solidfy modifier, minimum 0
+            threshold: float, alpha value below which faces will be removed
+            transparency: bool, remove faces below threshold
+    """
 
-	# Load image and initialize objects.
-	image = None  # Image datablock.
-	img_str = os.path.basename(path)
-	name = os.path.splitext(img_str)[0]
-	abspath = bpy.path.abspath(path)
+    # Load image and initialize objects.
+    image = None  # Image datablock.
+    img_str = os.path.basename(path)
+    name = os.path.splitext(img_str)[0]
+    abspath = bpy.path.abspath(path)
 
-	if img_str in bpy.data.images and bpy.path.abspath(
-			bpy.data.images[img_str].filepath) == abspath:
-		image = bpy.data.images[img_str]
-	elif not path or not os.path.isfile(abspath):
-		return None, "File not found"
-	else:
-		image = bpy.data.images.load(abspath)
+    if (
+        img_str in bpy.data.images
+        and bpy.path.abspath(bpy.data.images[img_str].filepath) == abspath
+    ):
+        image = bpy.data.images[img_str]
+    elif not path or not os.path.isfile(abspath):
+        return None, "File not found"
+    else:
+        image = bpy.data.images.load(abspath)
 
-	# Scale image
-	pix = len(image.pixels) / 4
-	if pix > max_pixels:
-		# Find new pixel sizes keeping aspect ratio, equation of:
-		# max_pixels = nwith * nheight
-		# max_pixels = (nheight * aspect) * nheight
-		# nheight = sqrtoot(max_pixels / aspect)
-		aspect = image.size[0] / image.size[1]
-		nheight = (max_pixels / aspect)**0.5
-		image.scale(int(nheight * aspect), int(nheight))
-		pix = len(image.pixels)
+    # Scale image
+    pix = len(image.pixels) / 4
+    if pix > max_pixels:
+        # Find new pixel sizes keeping aspect ratio, equation of:
+        # max_pixels = nwith * nheight
+        # max_pixels = (nheight * aspect) * nheight
+        # nheight = sqrtoot(max_pixels / aspect)
+        aspect = image.size[0] / image.size[1]
+        nheight = (max_pixels / aspect) ** 0.5
+        image.scale(int(nheight * aspect), int(nheight))
+        pix = len(image.pixels)
 
-	width = image.size[0]  # ie columns.
-	height = image.size[1]  # ie rows.
+    width = image.size[0]  # ie columns.
+    height = image.size[1]  # ie rows.
 
-	if width == 0 or height == 0:
-		return None, "Image has invalid 0-size dimension"
+    if width == 0 or height == 0:
+        return None, "Image has invalid 0-size dimension"
 
-	w_even_add = (-0.5 if width % 2 == 0 else 0) + width
-	h_even_add = (-0.5 if height % 2 == 0 else 0) + height
+    w_even_add = (-0.5 if width % 2 == 0 else 0) + width
+    h_even_add = (-0.5 if height % 2 == 0 else 0) + height
 
-	# new method, start with a UV grid and delete faces from there
-	if bpy.app.version >= (2, 93):  # Index changed
-		bpy.ops.mesh.primitive_grid_add(
-			x_subdivisions=height,  # Outter edges count as a subdiv.
-			y_subdivisions=width,  # Outter edges count as a subdiv.
-			size=2,
-			calc_uvs=True,
-			location=(0, 0, 0))
-	elif util.bv28():
-		bpy.ops.mesh.primitive_grid_add(
-			x_subdivisions=height + 1,  # Outter edges count as a subdiv.
-			y_subdivisions=width + 1,  # Outter edges count as a subdiv.
-			size=2,
-			calc_uvs=True,
-			location=(0, 0, 0))
-	elif bpy.app.version < (2, 77):  # Could be 2.76 even.
-		bpy.ops.mesh.primitive_grid_add(
-			x_subdivisions=height + 1,  # Outter edges count as a subdiv.
-			y_subdivisions=width + 1,  # Outter edges count as a subdiv.
-			radius=1,
-			location=(0, 0, 0))
-		bpy.ops.object.mode_set(mode='EDIT')
-		bpy.ops.uv.unwrap()
-		bpy.ops.object.mode_set(mode='OBJECT')
-	else:
-		bpy.ops.mesh.primitive_grid_add(
-			x_subdivisions=height + 1,  # Outter edges count as a subdiv.
-			y_subdivisions=width + 1,  # Outter edges count as a subdiv.
-			radius=1,
-			calc_uvs=True,
-			location=(0, 0, 0))
-	itm_obj = context.object
+    # new method, start with a UV grid and delete faces from there
+    if bpy.app.version >= (2, 93):  # Index changed
+        bpy.ops.mesh.primitive_grid_add(
+            x_subdivisions=height,  # Outter edges count as a subdiv.
+            y_subdivisions=width,  # Outter edges count as a subdiv.
+            size=2,
+            calc_uvs=True,
+            location=(0, 0, 0),
+        )
+    elif util.bv28():
+        bpy.ops.mesh.primitive_grid_add(
+            x_subdivisions=height + 1,  # Outter edges count as a subdiv.
+            y_subdivisions=width + 1,  # Outter edges count as a subdiv.
+            size=2,
+            calc_uvs=True,
+            location=(0, 0, 0),
+        )
+    elif bpy.app.version < (2, 77):  # Could be 2.76 even.
+        bpy.ops.mesh.primitive_grid_add(
+            x_subdivisions=height + 1,  # Outter edges count as a subdiv.
+            y_subdivisions=width + 1,  # Outter edges count as a subdiv.
+            radius=1,
+            location=(0, 0, 0),
+        )
+        bpy.ops.object.mode_set(mode="EDIT")
+        bpy.ops.uv.unwrap()
+        bpy.ops.object.mode_set(mode="OBJECT")
+    else:
+        bpy.ops.mesh.primitive_grid_add(
+            x_subdivisions=height + 1,  # Outter edges count as a subdiv.
+            y_subdivisions=width + 1,  # Outter edges count as a subdiv.
+            radius=1,
+            calc_uvs=True,
+            location=(0, 0, 0),
+        )
+    itm_obj = context.object
 
-	if not itm_obj:
-		print("Error, could not create the item primitive object")
-		return None, "Could not create the item primitive object"
+    if not itm_obj:
+        print("Error, could not create the item primitive object")
+        return None, "Could not create the item primitive object"
 
-	# Scale the object to match ratio, keeping max dimension as set above.
-	if width < height:
-		itm_obj.scale[0] = width / height
-	elif height < width:
-		itm_obj.scale[1] = height / width
+    # Scale the object to match ratio, keeping max dimension as set above.
+    if width < height:
+        itm_obj.scale[0] = width / height
+    elif height < width:
+        itm_obj.scale[1] = height / width
 
-	# Apply scale transform (funcitonally, applies ALL loc, rot, scale).
-	itm_obj.data.transform(itm_obj.matrix_world)
-	itm_obj.matrix_world = mathutils.Matrix()
+    # Apply scale transform (funcitonally, applies ALL loc, rot, scale).
+    itm_obj.data.transform(itm_obj.matrix_world)
+    itm_obj.matrix_world = mathutils.Matrix()
 
-	# Deselect faces now, as setting face.select = False doens't work even
-	# though using face.select = True does work.
-	bpy.ops.object.mode_set(mode='EDIT')
-	bpy.ops.mesh.select_mode(type='FACE')  # Ideally capture initial state.
-	bpy.ops.mesh.select_all(action='DESELECT')
-	bpy.ops.object.mode_set(mode='OBJECT')
+    # Deselect faces now, as setting face.select = False doens't work even
+    # though using face.select = True does work.
+    bpy.ops.object.mode_set(mode="EDIT")
+    bpy.ops.mesh.select_mode(type="FACE")  # Ideally capture initial state.
+    bpy.ops.mesh.select_all(action="DESELECT")
+    bpy.ops.object.mode_set(mode="OBJECT")
 
-	if transparency is True:
-		# Lazy load alpha part of image to memory, hold for whole operator.
-		alpha_faces = list(image.pixels)[3::4]
-		# uv = itm_obj.data.uv_layers.active
-		for face in itm_obj.data.polygons:
-			if len(face.loop_indices) < 3:
-				continue
+    if transparency is True:
+        # Lazy load alpha part of image to memory, hold for whole operator.
+        alpha_faces = list(image.pixels)[3::4]
+        # uv = itm_obj.data.uv_layers.active
+        for face in itm_obj.data.polygons:
+            if len(face.loop_indices) < 3:
+                continue
 
-			# Since we just generated UVs and the mesh, safe to get img
-			# coords from face cetner, offset from obj center.
-			img_x = int((face.center[0] * width + w_even_add) / 2)
-			img_y = int((face.center[1] * height + h_even_add) / 2)
+            # Since we just generated UVs and the mesh, safe to get img
+            # coords from face cetner, offset from obj center.
+            img_x = int((face.center[0] * width + w_even_add) / 2)
+            img_y = int((face.center[1] * height + h_even_add) / 2)
 
-			# Now verify this index of image is below alpha threshold.
-			if len(alpha_faces) > img_y * height + img_x:
-				alpha = alpha_faces[img_y * height + img_x]
-			else:  # This shouldn't occur, but reports were filed.
-				continue
-			if alpha < threshold:
-				face.select = True
+            # Now verify this index of image is below alpha threshold.
+            if len(alpha_faces) > img_y * height + img_x:
+                alpha = alpha_faces[img_y * height + img_x]
+            else:  # This shouldn't occur, but reports were filed.
+                continue
+            if alpha < threshold:
+                face.select = True
 
-		bpy.ops.object.mode_set(mode='EDIT')
-		bpy.ops.mesh.delete(type='FACE')
-		bpy.ops.object.mode_set(mode='OBJECT')
+        bpy.ops.object.mode_set(mode="EDIT")
+        bpy.ops.mesh.delete(type="FACE")
+        bpy.ops.object.mode_set(mode="OBJECT")
 
-	itm_obj.location = util.get_cuser_location(context)
+    itm_obj.location = util.get_cuser_location(context)
 
-	# Material and Textures.
-	# TODO: use the generate functions here instead
-	mat = bpy.data.materials.new(name)
-	mat.name = name
+    # Material and Textures.
+    # TODO: use the generate functions here instead
+    mat = bpy.data.materials.new(name)
+    mat.name = name
 
-	# Replace this with generate materials?
-	engine = bpy.context.scene.render.engine
-	if engine == 'BLENDER_RENDER' or engine == 'BLENDER_GAME':
-		tex = bpy.data.textures.new(name, type='IMAGE')
-		tex.image = image
-		mat.specular_intensity = 0
-		mtex = mat.texture_slots.add()
-		mtex.texture = tex
-		tex.name = name
-		tex.use_interpolation = 0
-		tex.use_mipmap = 0
-		tex.filter_type = 'BOX'
-		tex.filter_size = 0.1
-		if transparency is True:
-			mat.use_transparency = 1
-			mat.alpha = 0
-			mat.texture_slots[0].use_map_alpha = 1
-	elif engine == 'CYCLES' or engine == 'BLENDER_EEVEE':
-		mat.use_nodes = True
-		nodes = mat.node_tree.nodes
-		links = mat.node_tree.links
-		for node in nodes:
-			nodes.remove(node)
+    # Replace this with generate materials?
+    engine = bpy.context.scene.render.engine
+    if engine == "BLENDER_RENDER" or engine == "BLENDER_GAME":
+        tex = bpy.data.textures.new(name, type="IMAGE")
+        tex.image = image
+        mat.specular_intensity = 0
+        mtex = mat.texture_slots.add()
+        mtex.texture = tex
+        tex.name = name
+        tex.use_interpolation = 0
+        tex.use_mipmap = 0
+        tex.filter_type = "BOX"
+        tex.filter_size = 0.1
+        if transparency is True:
+            mat.use_transparency = 1
+            mat.alpha = 0
+            mat.texture_slots[0].use_map_alpha = 1
+    elif engine == "CYCLES" or engine == "BLENDER_EEVEE":
+        mat.use_nodes = True
+        nodes = mat.node_tree.nodes
+        links = mat.node_tree.links
+        for node in nodes:
+            nodes.remove(node)
 
-		tex_node = generate.create_node(nodes, 'ShaderNodeTexImage', image = image, interpolation = 'Closest', location = (-400,0))
-		diffuse_node = generate.create_node(nodes, "ShaderNodeBsdfDiffuse", location = (-200,-100))
-		output_node = generate.create_node(nodes, 'ShaderNodeOutputMaterial', location = (200,0))
+        tex_node = generate.create_node(
+            nodes,
+            "ShaderNodeTexImage",
+            image=image,
+            interpolation="Closest",
+            location=(-400, 0),
+        )
+        diffuse_node = generate.create_node(
+            nodes, "ShaderNodeBsdfDiffuse", location=(-200, -100)
+        )
+        output_node = generate.create_node(
+            nodes, "ShaderNodeOutputMaterial", location=(200, 0)
+        )
 
-		if transparency == 0:
-			links.new(tex_node.outputs[0], diffuse_node.inputs[0])
-			links.new(diffuse_node.outputs[0], output_node.inputs[0])
-		else:
-			transp_node = generate.create_node(nodes, 'ShaderNodeBsdfTransparent', location = (-200,100))
-			mix_node = generate.create_node(nodes, 'ShaderNodeMixShader')
-			links.new(tex_node.outputs[0], diffuse_node.inputs[0])
-			links.new(diffuse_node.outputs[0], mix_node.inputs[2])
-			links.new(transp_node.outputs[0], mix_node.inputs[1])
-			links.new(tex_node.outputs[1], mix_node.inputs[0])
-			links.new(mix_node.outputs[0], output_node.inputs[0])
+        if transparency == 0:
+            links.new(tex_node.outputs[0], diffuse_node.inputs[0])
+            links.new(diffuse_node.outputs[0], output_node.inputs[0])
+        else:
+            transp_node = generate.create_node(
+                nodes, "ShaderNodeBsdfTransparent", location=(-200, 100)
+            )
+            mix_node = generate.create_node(nodes, "ShaderNodeMixShader")
+            links.new(tex_node.outputs[0], diffuse_node.inputs[0])
+            links.new(diffuse_node.outputs[0], mix_node.inputs[2])
+            links.new(transp_node.outputs[0], mix_node.inputs[1])
+            links.new(tex_node.outputs[1], mix_node.inputs[0])
+            links.new(mix_node.outputs[0], output_node.inputs[0])
 
-	# Final object updated
-	if thickness > 0:
-		mod = itm_obj.modifiers.new(type='SOLIDIFY', name='Solidify')
-		mod.thickness = thickness / max([width, height])
-		mod.offset = 0
-	itm_obj.data.name = name
-	bpy.context.object.data.materials.append(mat)
-	itm_obj.name = name
+    # Final object updated
+    if thickness > 0:
+        mod = itm_obj.modifiers.new(type="SOLIDIFY", name="Solidify")
+        mod.thickness = thickness / max([width, height])
+        mod.offset = 0
+    itm_obj.data.name = name
+    bpy.context.object.data.materials.append(mat)
+    itm_obj.name = name
 
-	# set the image, mostly just relevant to blender internal
-	if hasattr(itm_obj.data, "uv_textures"):
-		for uv_face in itm_obj.data.uv_textures.active.data:
-			uv_face.image = image
-	return itm_obj, None
+    # set the image, mostly just relevant to blender internal
+    if hasattr(itm_obj.data, "uv_textures"):
+        for uv_face in itm_obj.data.uv_textures.active.data:
+            uv_face.image = image
+    return itm_obj, None
 
 
 # -----------------------------------------------------------------------------
@@ -293,164 +314,174 @@ def spawn_item_from_filepath(
 # -----------------------------------------------------------------------------
 
 
-class ItemSpawnBase():
-	"""Class to inheret reused MCprep item spawning settings and functions."""
+class ItemSpawnBase:
+    """Class to inheret reused MCprep item spawning settings and functions."""
 
-	# TODO: add options like spawning attached to rig hand or other,
-	size: bpy.props.FloatProperty(
-		name="Size",
-		default=1.0,
-		min=0.001,
-		description="Size in blender units of the item")
-	thickness: bpy.props.FloatProperty(
-		name="Thickness",
-		default=1.0,
-		min=0.0,
-		description=(
-			"The thickness of the item (this can later be changed in "
-			"modifiers)"))
-	transparency: bpy.props.BoolProperty(
-		name="Remove transparent faces",
-		description="Transparent pixels will be transparent once rendered",
-		default=True)
-	threshold: bpy.props.FloatProperty(
-		name="Transparent threshold",
-		description="1.0 = zero tolerance, no transparent pixels will be generated",
-		default=0.5,
-		min=0.0,
-		max=1.0)
-	max_pixels: bpy.props.IntProperty(
-		name="Max pixels",
-		default=50000,
-		min=1,
-		description=(
-			"If needed, scale down image to generate less than this maximum "
-			"pixel count"))
-	scale_uvs: bpy.props.FloatProperty(
-		name="Scale UVs",
-		default=0.75,
-		description="Scale individual UV faces of the generated item")
-	filepath: bpy.props.StringProperty(
-		default="",
-		subtype="FILE_PATH",
-		options={'HIDDEN', 'SKIP_SAVE'})
-	skipUsage: bpy.props.BoolProperty(
-		default=False,
-		options={'HIDDEN'})
+    # TODO: add options like spawning attached to rig hand or other,
+    size: bpy.props.FloatProperty(
+        name="Size",
+        default=1.0,
+        min=0.001,
+        description="Size in blender units of the item",
+    )
+    thickness: bpy.props.FloatProperty(
+        name="Thickness",
+        default=1.0,
+        min=0.0,
+        description=(
+            "The thickness of the item (this can later be changed in " "modifiers)"
+        ),
+    )
+    transparency: bpy.props.BoolProperty(
+        name="Remove transparent faces",
+        description="Transparent pixels will be transparent once rendered",
+        default=True,
+    )
+    threshold: bpy.props.FloatProperty(
+        name="Transparent threshold",
+        description="1.0 = zero tolerance, no transparent pixels will be generated",
+        default=0.5,
+        min=0.0,
+        max=1.0,
+    )
+    max_pixels: bpy.props.IntProperty(
+        name="Max pixels",
+        default=50000,
+        min=1,
+        description=(
+            "If needed, scale down image to generate less than this maximum "
+            "pixel count"
+        ),
+    )
+    scale_uvs: bpy.props.FloatProperty(
+        name="Scale UVs",
+        default=0.75,
+        description="Scale individual UV faces of the generated item",
+    )
+    filepath: bpy.props.StringProperty(
+        default="", subtype="FILE_PATH", options={"HIDDEN", "SKIP_SAVE"}
+    )
+    skipUsage: bpy.props.BoolProperty(default=False, options={"HIDDEN"})
 
-	@classmethod
-	def poll(cls, context):
-		pose_active = context.mode == 'POSE' and context.active_bone
-		return context.mode == 'OBJECT' or pose_active
+    @classmethod
+    def poll(cls, context):
+        pose_active = context.mode == "POSE" and context.active_bone
+        return context.mode == "OBJECT" or pose_active
 
-	def spawn_item_execution(self, context):
-		"""Common execution for both spawn item from filepath and list."""
-		if context.mode == 'POSE' and context.active_bone:
-			spawn_in_pose = True
-			# If in pose mode, assume that we are going to add the item
-			# parented to the active bone, but still switch to object mode.
-			arma_bone = context.active_bone
-			arma_obj = context.object
-			bpy.ops.object.mode_set(mode='OBJECT')
-		else:
-			spawn_in_pose = False
+    def spawn_item_execution(self, context):
+        """Common execution for both spawn item from filepath and list."""
+        if context.mode == "POSE" and context.active_bone:
+            spawn_in_pose = True
+            # If in pose mode, assume that we are going to add the item
+            # parented to the active bone, but still switch to object mode.
+            arma_bone = context.active_bone
+            arma_obj = context.object
+            bpy.ops.object.mode_set(mode="OBJECT")
+        else:
+            spawn_in_pose = False
 
-		obj, status = spawn_item_from_filepath(
-			context, self.filepath, self.max_pixels,
-			self.thickness * self.size, self.threshold, self.transparency)
+        obj, status = spawn_item_from_filepath(
+            context,
+            self.filepath,
+            self.max_pixels,
+            self.thickness * self.size,
+            self.threshold,
+            self.transparency,
+        )
 
-		# apply additional settings
-		# generate materials via prep, without re-loading image datablock
-		if status == "File not found" and not obj:
-			self.report({'WARNING'}, status)
-			bpy.ops.mcprep.prompt_reset_spawners('INVOKE_DEFAULT')
-			return {'CANCELLED'}
-		elif status and not obj:
-			self.report({'ERROR'}, status)
-			return {'CANCELLED'}
-		elif status:
-			self.report({'INFO'}, status)
+        # apply additional settings
+        # generate materials via prep, without re-loading image datablock
+        if status == "File not found" and not obj:
+            self.report({"WARNING"}, status)
+            bpy.ops.mcprep.prompt_reset_spawners("INVOKE_DEFAULT")
+            return {"CANCELLED"}
+        elif status and not obj:
+            self.report({"ERROR"}, status)
+            return {"CANCELLED"}
+        elif status:
+            self.report({"INFO"}, status)
 
-		# Apply other settings such as overall object scale and uv face scale.
-		for i in range(3):
-			obj.scale[i] *= 0.5 * self.size
-		bpy.ops.object.transform_apply(scale=True, location=False)
-		bpy.ops.mcprep.scale_uv(
-			scale=self.scale_uvs, selected_only=False, skipUsage=True)
+        # Apply other settings such as overall object scale and uv face scale.
+        for i in range(3):
+            obj.scale[i] *= 0.5 * self.size
+        bpy.ops.object.transform_apply(scale=True, location=False)
+        bpy.ops.mcprep.scale_uv(
+            scale=self.scale_uvs, selected_only=False, skipUsage=True
+        )
 
-		# If originally in pose mode, do any further movement and parenting.
-		if spawn_in_pose:
-			# bpy.ops.object.parent_set(type='BONE')
-			obj.parent = arma_obj
-			obj.parent_type = 'BONE'
-			obj.parent_bone = arma_bone.name
-			obj.location = (0, 0, 0)
-		return {'FINISHED'}
+        # If originally in pose mode, do any further movement and parenting.
+        if spawn_in_pose:
+            # bpy.ops.object.parent_set(type='BONE')
+            obj.parent = arma_obj
+            obj.parent_type = "BONE"
+            obj.parent_bone = arma_bone.name
+            obj.location = (0, 0, 0)
+        return {"FINISHED"}
 
 
 class MCPREP_OT_spawn_item(bpy.types.Operator, ItemSpawnBase):
-	"""Spawn in an item as a mesh from selected list item"""
-	bl_idname = "mcprep.spawn_item"
-	bl_label = "Spawn selected item"
-	bl_options = {'REGISTER', 'UNDO'}
+    """Spawn in an item as a mesh from selected list item"""
 
-	track_function = "item"
-	track_param = "list"
-	@tracking.report_error
-	def execute(self, context):
-		"""Execute either taking image from UIList or from active UV image"""
-		sima = context.space_data
-		if not self.filepath:
-			scn_props = context.scene.mcprep_props
-			if not scn_props.item_list:
-				self.report(
-					{'ERROR'}, "No filepath input, and no items in list loaded")
-				return {'CANCELLED'}
-			self.filepath = scn_props.item_list[scn_props.item_list_index].path
-			self.track_param = "list"
-		elif sima.type == 'IMAGE_EDITOR' and sima.image:
-			self.track_param = "uvimage"
-		else:
-			self.track_param = "shiftA"
+    bl_idname = "mcprep.spawn_item"
+    bl_label = "Spawn selected item"
+    bl_options = {"REGISTER", "UNDO"}
 
-		return self.spawn_item_execution(context)
+    track_function = "item"
+    track_param = "list"
+
+    @tracking.report_error
+    def execute(self, context):
+        """Execute either taking image from UIList or from active UV image"""
+        sima = context.space_data
+        if not self.filepath:
+            scn_props = context.scene.mcprep_props
+            if not scn_props.item_list:
+                self.report({"ERROR"}, "No filepath input, and no items in list loaded")
+                return {"CANCELLED"}
+            self.filepath = scn_props.item_list[scn_props.item_list_index].path
+            self.track_param = "list"
+        elif sima.type == "IMAGE_EDITOR" and sima.image:
+            self.track_param = "uvimage"
+        else:
+            self.track_param = "shiftA"
+
+        return self.spawn_item_execution(context)
 
 
 class MCPREP_OT_spawn_item_from_file(bpy.types.Operator, ImportHelper, ItemSpawnBase):
-	"""Spawn in an item as a mesh from an image file"""
-	bl_idname = "mcprep.spawn_item_file"
-	bl_label = "Item from file"
+    """Spawn in an item as a mesh from an image file"""
 
-	filter_glob: bpy.props.StringProperty(
-		default="",
-		options={'HIDDEN'})
-	fileselectparams = "use_filter_blender"
-	files: bpy.props.CollectionProperty(
-		type=bpy.types.PropertyGroup,
-		options={'HIDDEN', 'SKIP_SAVE'})
-	filter_image: bpy.props.BoolProperty(
-		default=True,
-		options={'HIDDEN', 'SKIP_SAVE'})
+    bl_idname = "mcprep.spawn_item_file"
+    bl_label = "Item from file"
 
-	track_function = "item"
-	track_param = "from file"
-	@tracking.report_error
-	def execute(self, context):
-		if not self.filepath:
-			self.report({"WARNING"}, "No image selected, cancelling")
-			return {'CANCELLED'}
-		return self.spawn_item_execution(context)
+    filter_glob: bpy.props.StringProperty(default="", options={"HIDDEN"})
+    fileselectparams = "use_filter_blender"
+    files: bpy.props.CollectionProperty(
+        type=bpy.types.PropertyGroup, options={"HIDDEN", "SKIP_SAVE"}
+    )
+    filter_image: bpy.props.BoolProperty(default=True, options={"HIDDEN", "SKIP_SAVE"})
+
+    track_function = "item"
+    track_param = "from file"
+
+    @tracking.report_error
+    def execute(self, context):
+        if not self.filepath:
+            self.report({"WARNING"}, "No image selected, cancelling")
+            return {"CANCELLED"}
+        return self.spawn_item_execution(context)
 
 
 class MCPREP_OT_reload_items(bpy.types.Operator):
-	"""Reload item spawner, use after adding/removing/renaming files in the resource pack folder"""
-	bl_idname = "mcprep.reload_items"
-	bl_label = "Reload items"
+    """Reload item spawner, use after adding/removing/renaming files in the resource pack folder"""
 
-	@tracking.report_error
-	def execute(self, context):
-		reload_items(context)
-		return {'FINISHED'}
+    bl_idname = "mcprep.reload_items"
+    bl_label = "Reload items"
+
+    @tracking.report_error
+    def execute(self, context):
+        reload_items(context)
+        return {"FINISHED"}
 
 
 # -----------------------------------------------------------------------------
@@ -459,17 +490,17 @@ class MCPREP_OT_reload_items(bpy.types.Operator):
 
 
 classes = (
-	MCPREP_OT_spawn_item,
-	MCPREP_OT_spawn_item_from_file,
-	MCPREP_OT_reload_items,
+    MCPREP_OT_spawn_item,
+    MCPREP_OT_spawn_item_from_file,
+    MCPREP_OT_reload_items,
 )
 
 
 def register():
-	for cls in classes:
-		bpy.utils.register_class(cls)
+    for cls in classes:
+        bpy.utils.register_class(cls)
 
 
 def unregister():
-	for cls in reversed(classes):
-		bpy.utils.unregister_class(cls)
+    for cls in reversed(classes):
+        bpy.utils.unregister_class(cls)

--- a/MCprep_addon/spawner/mcmodel.py
+++ b/MCprep_addon/spawner/mcmodel.py
@@ -35,300 +35,313 @@ from ..materials import generate
 # Core MC model functions and implementation
 # -----------------------------------------------------------------------------
 
+
 class ModelException(Exception):
-	"""Custom exception type for model loading."""
+    """Custom exception type for model loading."""
 
 
 def rotate_around(
-	d, pos, origin, axis='z', offset=[8, 0, 8], scale=[0.063, 0.063, 0.063]):
-	r = -radians(d)
-	axis_i = ord(axis) - 120  # 'x'=0, 'y'=1, 'z'=2
-	a = pos[(1 + axis_i) % 3]
-	b = pos[(2 + axis_i) % 3]
-	c = pos[(3 + axis_i) % 3]
-	m = origin[(1 + axis_i) % 3]
-	n = origin[(2 + axis_i) % 3]
-	# this equation rotates the verticies around the origin point
-	new_pos = [0, 0, 0]
-	new_pos[(1 + axis_i) % 3] = cos(r) * (a - m) + (b - n) * sin(r) + m
-	new_pos[(2 + axis_i) % 3] = -sin(r) * (a - m) + cos(r) * (b - n) + n
-	new_pos[(3 + axis_i) % 3] = c
-	# offset and scale are applied to the vertices in the return
-	# the default offset is what makes sure the block/item is centered
-	# the default scale will match the block size of 1m/blender unit.
-	return Vector((
-		-(new_pos[0] - offset[0]) * scale[0],
-		(new_pos[2] - offset[2]) * scale[2],
-		(new_pos[1] - offset[1]) * scale[1]
-	))
+    d, pos, origin, axis="z", offset=[8, 0, 8], scale=[0.063, 0.063, 0.063]
+):
+    r = -radians(d)
+    axis_i = ord(axis) - 120  # 'x'=0, 'y'=1, 'z'=2
+    a = pos[(1 + axis_i) % 3]
+    b = pos[(2 + axis_i) % 3]
+    c = pos[(3 + axis_i) % 3]
+    m = origin[(1 + axis_i) % 3]
+    n = origin[(2 + axis_i) % 3]
+    # this equation rotates the verticies around the origin point
+    new_pos = [0, 0, 0]
+    new_pos[(1 + axis_i) % 3] = cos(r) * (a - m) + (b - n) * sin(r) + m
+    new_pos[(2 + axis_i) % 3] = -sin(r) * (a - m) + cos(r) * (b - n) + n
+    new_pos[(3 + axis_i) % 3] = c
+    # offset and scale are applied to the vertices in the return
+    # the default offset is what makes sure the block/item is centered
+    # the default scale will match the block size of 1m/blender unit.
+    return Vector(
+        (
+            -(new_pos[0] - offset[0]) * scale[0],
+            (new_pos[2] - offset[2]) * scale[2],
+            (new_pos[1] - offset[1]) * scale[1],
+        )
+    )
 
 
 def add_element(
-	elm_from=[0, 0, 0],
-	elm_to=[16, 16, 16],
-	rot_origin=[8, 8, 8],
-	rot_axis='y',
-	rot_angle=0):
-	"""Calculates and defines the verts, edge, and faces that to create."""
-	verts = [
-		rotate_around(
-			rot_angle, [elm_from[0], elm_to[1], elm_from[2]], rot_origin, rot_axis),
-		rotate_around(
-			rot_angle, [elm_to[0], elm_to[1], elm_from[2]], rot_origin, rot_axis),
-		rotate_around(
-			rot_angle, [elm_to[0], elm_from[1], elm_from[2]], rot_origin, rot_axis),
-		rotate_around(
-			rot_angle, [elm_from[0], elm_from[1], elm_from[2]], rot_origin, rot_axis),
-		rotate_around(
-			rot_angle, [elm_from[0], elm_to[1], elm_to[2]], rot_origin, rot_axis),
-		rotate_around(
-			rot_angle, [elm_to[0], elm_to[1], elm_to[2]], rot_origin, rot_axis),
-		rotate_around(
-			rot_angle, [elm_to[0], elm_from[1], elm_to[2]], rot_origin, rot_axis),
-		rotate_around(
-			rot_angle, [elm_from[0], elm_from[1], elm_to[2]], rot_origin, rot_axis),
-	]
+    elm_from=[0, 0, 0],
+    elm_to=[16, 16, 16],
+    rot_origin=[8, 8, 8],
+    rot_axis="y",
+    rot_angle=0,
+):
+    """Calculates and defines the verts, edge, and faces that to create."""
+    verts = [
+        rotate_around(
+            rot_angle, [elm_from[0], elm_to[1], elm_from[2]], rot_origin, rot_axis
+        ),
+        rotate_around(
+            rot_angle, [elm_to[0], elm_to[1], elm_from[2]], rot_origin, rot_axis
+        ),
+        rotate_around(
+            rot_angle, [elm_to[0], elm_from[1], elm_from[2]], rot_origin, rot_axis
+        ),
+        rotate_around(
+            rot_angle, [elm_from[0], elm_from[1], elm_from[2]], rot_origin, rot_axis
+        ),
+        rotate_around(
+            rot_angle, [elm_from[0], elm_to[1], elm_to[2]], rot_origin, rot_axis
+        ),
+        rotate_around(
+            rot_angle, [elm_to[0], elm_to[1], elm_to[2]], rot_origin, rot_axis
+        ),
+        rotate_around(
+            rot_angle, [elm_to[0], elm_from[1], elm_to[2]], rot_origin, rot_axis
+        ),
+        rotate_around(
+            rot_angle, [elm_from[0], elm_from[1], elm_to[2]], rot_origin, rot_axis
+        ),
+    ]
 
-	edges = []
-	faces = [
-		[0, 1, 2, 3],
-		[5, 4, 7, 6],
-		[1, 0, 4, 5],
-		[7, 6, 2, 3],
-		[4, 0, 3, 7],
-		[1, 5, 6, 2]]
+    edges = []
+    faces = [
+        [0, 1, 2, 3],
+        [5, 4, 7, 6],
+        [1, 0, 4, 5],
+        [7, 6, 2, 3],
+        [4, 0, 3, 7],
+        [1, 5, 6, 2],
+    ]
 
-	return [verts, edges, faces]
+    return [verts, edges, faces]
 
 
 def add_material(name="material", path=""):
-	"""Creates a simple material with an image texture from path."""
-	cur_mats = list(bpy.data.materials)
-	res = bpy.ops.mcprep.load_material(filepath=path, skipUsage=True)
-	if res != {'FINISHED'}:
-		env.log("Failed to generate material as specified")
-	post_mats = list(bpy.data.materials)
+    """Creates a simple material with an image texture from path."""
+    cur_mats = list(bpy.data.materials)
+    res = bpy.ops.mcprep.load_material(filepath=path, skipUsage=True)
+    if res != {"FINISHED"}:
+        env.log("Failed to generate material as specified")
+    post_mats = list(bpy.data.materials)
 
-	new_mats = list(set(post_mats) - set(cur_mats))
-	if not new_mats:
-		env.log("Failed to fetch any generated material")
-		return None
+    new_mats = list(set(post_mats) - set(cur_mats))
+    if not new_mats:
+        env.log("Failed to fetch any generated material")
+        return None
 
-	mat = new_mats[0]
-	return mat
+    mat = new_mats[0]
+    return mat
 
 
 def locate_image(context, textures, img, model_filepath):
-	"""Finds and returns the filepath of the image texture."""
-	resource_folder = bpy.path.abspath(context.scene.mcprep_texturepack_path)
+    """Finds and returns the filepath of the image texture."""
+    resource_folder = bpy.path.abspath(context.scene.mcprep_texturepack_path)
 
-	local_path = textures[img]  # Can fail lookup.
-	if local_path[0] == '#':  # reference to another texture
-		return locate_image(context, textures, local_path[1:], model_filepath)
-		# note this will result in multiple materials that use the same texture
-		# considering reworking this function to also create the material so
-		# these can point towards the same material.
-	else:
-		if local_path[0] == '.':  # path is local to the model file
-			directory = os.path.dirname(model_filepath)
-		else:
-			if(len(local_path.split(":")) == 1):
-				namespace = "minecraft"
-			else:
-				namespace = local_path.split(":")[0]
-				local_path = local_path.split(":")[1]
+    local_path = textures[img]  # Can fail lookup.
+    if local_path[0] == "#":  # reference to another texture
+        return locate_image(context, textures, local_path[1:], model_filepath)
+        # note this will result in multiple materials that use the same texture
+        # considering reworking this function to also create the material so
+        # these can point towards the same material.
+    else:
+        if local_path[0] == ".":  # path is local to the model file
+            directory = os.path.dirname(model_filepath)
+        else:
+            if len(local_path.split(":")) == 1:
+                namespace = "minecraft"
+            else:
+                namespace = local_path.split(":")[0]
+                local_path = local_path.split(":")[1]
 
-			directory = os.path.join(
-				resource_folder, "assets", namespace, "textures")
-		return os.path.realpath(os.path.join(directory, local_path) + ".png")
+            directory = os.path.join(resource_folder, "assets", namespace, "textures")
+        return os.path.realpath(os.path.join(directory, local_path) + ".png")
 
 
 def read_model(context, model_filepath):
-	"""Reads json file to get textures and elements needed for model.
+    """Reads json file to get textures and elements needed for model.
 
-	This function is recursively called to also get the elements and textures
-	from the parent models the elements from the child will always overwrite
-	the parent's elements individual textures from the child will overwrite the
-	same texture from the parent.
-	"""
-	try:
-		with open(model_filepath, 'r') as f:
-			obj_data = json.load(f)
-	except PermissionError as e:
-		print(e)
-		raise ModelException("Permission error, try running as admin") from e
-	except UnicodeDecodeError as e:
-		print(e)
-		raise ModelException("Could not read file, select valid json file") from e
+    This function is recursively called to also get the elements and textures
+    from the parent models the elements from the child will always overwrite
+    the parent's elements individual textures from the child will overwrite the
+    same texture from the parent.
+    """
+    try:
+        with open(model_filepath, "r") as f:
+            obj_data = json.load(f)
+    except PermissionError as e:
+        print(e)
+        raise ModelException("Permission error, try running as admin") from e
+    except UnicodeDecodeError as e:
+        print(e)
+        raise ModelException("Could not read file, select valid json file") from e
 
-	addon_prefs = util.get_user_preferences(context)
+    addon_prefs = util.get_user_preferences(context)
 
-	# Go from:      pack/assets/minecraft/models/block/block.json
-	# to 5 dirs up: pack/
-	targets_folder = bpy.path.abspath(
-		os.path.dirname(
-			os.path.dirname(
-				os.path.dirname(
-					os.path.dirname(
-						os.path.dirname(model_filepath))))))
-	# Fallback directories, which should already be resource pack paths.
-	resource_folder = bpy.path.abspath(context.scene.mcprep_texturepack_path)
-	fallback_folder = bpy.path.abspath(addon_prefs.custom_texturepack_path)
+    # Go from:      pack/assets/minecraft/models/block/block.json
+    # to 5 dirs up: pack/
+    targets_folder = bpy.path.abspath(
+        os.path.dirname(
+            os.path.dirname(
+                os.path.dirname(os.path.dirname(os.path.dirname(model_filepath)))
+            )
+        )
+    )
+    # Fallback directories, which should already be resource pack paths.
+    resource_folder = bpy.path.abspath(context.scene.mcprep_texturepack_path)
+    fallback_folder = bpy.path.abspath(addon_prefs.custom_texturepack_path)
 
-	elements = None
-	textures = None
+    elements = None
+    textures = None
 
-	parent = obj_data.get("parent")
-	if parent is not None:
-		if parent == "builtin/generated" or parent == "item/generated":
-			pass  # generates the model from the texture
-		elif parent == "builtin/entity":
-			# model from an entity file, only for chests, ender chests, mob
-			# heads, shields, banners and tridents.
-			pass
-		else:
-			if(len(parent.split(":")) == 1):
-				namespace = "minecraft"
-				parent_filepath = parent
-			else:
-				namespace = parent.split(":")[0]
-				parent_filepath = parent.split(":")[1]
+    parent = obj_data.get("parent")
+    if parent is not None:
+        if parent == "builtin/generated" or parent == "item/generated":
+            pass  # generates the model from the texture
+        elif parent == "builtin/entity":
+            # model from an entity file, only for chests, ender chests, mob
+            # heads, shields, banners and tridents.
+            pass
+        else:
+            if len(parent.split(":")) == 1:
+                namespace = "minecraft"
+                parent_filepath = parent
+            else:
+                namespace = parent.split(":")[0]
+                parent_filepath = parent.split(":")[1]
 
-			# resource_folder
-			models_dir = os.path.join(
-				"assets", namespace, "models", parent_filepath + ".json")
-			target_path = os.path.join(targets_folder, models_dir)
-			active_path = os.path.join(resource_folder, models_dir)
-			base_path = os.path.join(fallback_folder, models_dir)
+            # resource_folder
+            models_dir = os.path.join(
+                "assets", namespace, "models", parent_filepath + ".json"
+            )
+            target_path = os.path.join(targets_folder, models_dir)
+            active_path = os.path.join(resource_folder, models_dir)
+            base_path = os.path.join(fallback_folder, models_dir)
 
-			if os.path.isfile(target_path):
-				elements, textures = read_model(context, target_path)
-			if os.path.isfile(active_path):
-				elements, textures = read_model(context, active_path)
-			elif os.path.isfile(base_path):
-				elements, textures = read_model(context, base_path)
-			else:
-				env.log("Failed to find mcmodel file " + parent_filepath)
+            if os.path.isfile(target_path):
+                elements, textures = read_model(context, target_path)
+            if os.path.isfile(active_path):
+                elements, textures = read_model(context, active_path)
+            elif os.path.isfile(base_path):
+                elements, textures = read_model(context, base_path)
+            else:
+                env.log("Failed to find mcmodel file " + parent_filepath)
 
-	current_elements = obj_data.get("elements")
-	if current_elements is not None:
-		elements = current_elements  # overwrites any elements from parents
+    current_elements = obj_data.get("elements")
+    if current_elements is not None:
+        elements = current_elements  # overwrites any elements from parents
 
-	current_textures = obj_data.get("textures")
-	if current_textures is not None:
-		if textures is None:
-			textures = current_textures
-		else:
-			for img in current_textures:
-				textures[img] = current_textures[img]
+    current_textures = obj_data.get("textures")
+    if current_textures is not None:
+        if textures is None:
+            textures = current_textures
+        else:
+            for img in current_textures:
+                textures[img] = current_textures[img]
 
-	env.log("\nfile:" + str(model_filepath), vv_only=True)
-	# env.log("parent:" + str(parent))
-	# env.log("elements:" + str(elements))
-	# env.log("textures:" + str(textures))
+    env.log("\nfile:" + str(model_filepath), vv_only=True)
+    # env.log("parent:" + str(parent))
+    # env.log("elements:" + str(elements))
+    # env.log("textures:" + str(textures))
 
-	return elements, textures
+    return elements, textures
 
 
 def add_model(model_filepath, obj_name="MinecraftModel"):
-	"""Primary function for generating a model from json file."""
-	mesh = bpy.data.meshes.new(obj_name)  # add a new mesh
-	obj = bpy.data.objects.new(obj_name, mesh)  # add a new object using the mesh
+    """Primary function for generating a model from json file."""
+    mesh = bpy.data.meshes.new(obj_name)  # add a new mesh
+    obj = bpy.data.objects.new(obj_name, mesh)  # add a new object using the mesh
 
-	collection = bpy.context.collection
-	view_layer = bpy.context.view_layer
-	collection.objects.link(obj)  # put the object into the scene (link)
-	view_layer.objects.active = obj  # set as the active object in the scene
-	obj.select_set(True)  # select object
+    collection = bpy.context.collection
+    view_layer = bpy.context.view_layer
+    collection.objects.link(obj)  # put the object into the scene (link)
+    view_layer.objects.active = obj  # set as the active object in the scene
+    obj.select_set(True)  # select object
 
-	bm = bmesh.new()
+    bm = bmesh.new()
 
-	mesh.uv_layers.new()
-	uv_layer = bm.loops.layers.uv.verify()
+    mesh.uv_layers.new()
+    uv_layer = bm.loops.layers.uv.verify()
 
-	# Called recursively!
-	# Can raise ModelException due to permission or corrupted file data.
-	elements, textures = read_model(bpy.context, model_filepath)
+    # Called recursively!
+    # Can raise ModelException due to permission or corrupted file data.
+    elements, textures = read_model(bpy.context, model_filepath)
 
-	materials = []
-	if textures:
-		for img in textures:
-			if img != "particle":
-				tex_pth = locate_image(bpy.context, textures, img, model_filepath)
-				mat = add_material(obj_name + "_" + img, tex_pth)
-				obj.data.materials.append(mat)
-				materials.append("#" + img)
+    materials = []
+    if textures:
+        for img in textures:
+            if img != "particle":
+                tex_pth = locate_image(bpy.context, textures, img, model_filepath)
+                mat = add_material(obj_name + "_" + img, tex_pth)
+                obj.data.materials.append(mat)
+                materials.append("#" + img)
 
-	if elements is None:
-		elements = [
-			{'from': [0, 0, 0], 'to':[0, 0, 0]}]  # temp default elements
+    if elements is None:
+        elements = [{"from": [0, 0, 0], "to": [0, 0, 0]}]  # temp default elements
 
-	for e in elements:
-		rotation = e.get("rotation")
-		if rotation is None:
-			# rotation default
-			rotation = {"angle": 0, "axis": "y", "origin": [8, 8, 8]}
+    for e in elements:
+        rotation = e.get("rotation")
+        if rotation is None:
+            # rotation default
+            rotation = {"angle": 0, "axis": "y", "origin": [8, 8, 8]}
 
-		element = add_element(
-			e['from'], e['to'], rotation['origin'], rotation['axis'], rotation['angle'])
-		verts = [bm.verts.new(v) for v in element[0]]  # add a new vert
-		uvs = [[1, 1], [0, 1], [0, 0], [1, 0]]
-		# face directions defaults
-		face_dir = ["north", "south", "up", "down", "west", "east"]
-		faces = e.get("faces")
-		for i in range(len(element[2])):
-			f = element[2][i]
+        element = add_element(
+            e["from"], e["to"], rotation["origin"], rotation["axis"], rotation["angle"]
+        )
+        verts = [bm.verts.new(v) for v in element[0]]  # add a new vert
+        uvs = [[1, 1], [0, 1], [0, 0], [1, 0]]
+        # face directions defaults
+        face_dir = ["north", "south", "up", "down", "west", "east"]
+        faces = e.get("faces")
+        for i in range(len(element[2])):
+            f = element[2][i]
 
-			if not faces:
-				continue
+            if not faces:
+                continue
 
-			d_face = faces.get(face_dir[i])
-			if not d_face:
-				continue
+            d_face = faces.get(face_dir[i])
+            if not d_face:
+                continue
 
-			face = bm.faces.new(
-				(verts[f[0]], verts[f[1]], verts[f[2]], verts[f[3]])
-			)
-			face.normal_update()
+            face = bm.faces.new((verts[f[0]], verts[f[1]], verts[f[2]], verts[f[3]]))
+            face.normal_update()
 
-			# uv can be rotated 0, 90, 180, or 270 degrees
-			uv_rot = d_face.get("rotation")
-			if uv_rot is None:
-				uv_rot = 0
+            # uv can be rotated 0, 90, 180, or 270 degrees
+            uv_rot = d_face.get("rotation")
+            if uv_rot is None:
+                uv_rot = 0
 
-			# the index of the first uv cord,
-			# the rotation is achieved by shifting the order of the uv coords
-			uv_idx = int(uv_rot / 90)
+            # the index of the first uv cord,
+            # the rotation is achieved by shifting the order of the uv coords
+            uv_idx = int(uv_rot / 90)
 
-			uv_coords = d_face.get("uv")  # in the format [x1, y1, x2, y2]
-			if uv_coords is None:
-				uv_coords = [0, 0, 16, 16]
+            uv_coords = d_face.get("uv")  # in the format [x1, y1, x2, y2]
+            if uv_coords is None:
+                uv_coords = [0, 0, 16, 16]
 
-			# uv in the model is between 0 to 16 regardless of resolution,
-			# in blender its 0 to 1 the y-axis is inverted when compared to
-			# blender uvs, which is why it is subtracted from 1, essentially
-			# this converts the json uv points to the blender equivelent.
-			uvs = [
-				[uv_coords[2] / 16, 1 - (uv_coords[1] / 16)],  # [x2, y1]
-				[uv_coords[0] / 16, 1 - (uv_coords[1] / 16)],  # [x1, y1]
-				[uv_coords[0] / 16, 1 - (uv_coords[3] / 16)],  # [x1, y2]
-				[uv_coords[2] / 16, 1 - (uv_coords[3] / 16)]   # [x2, y2]
-			]
+            # uv in the model is between 0 to 16 regardless of resolution,
+            # in blender its 0 to 1 the y-axis is inverted when compared to
+            # blender uvs, which is why it is subtracted from 1, essentially
+            # this converts the json uv points to the blender equivelent.
+            uvs = [
+                [uv_coords[2] / 16, 1 - (uv_coords[1] / 16)],  # [x2, y1]
+                [uv_coords[0] / 16, 1 - (uv_coords[1] / 16)],  # [x1, y1]
+                [uv_coords[0] / 16, 1 - (uv_coords[3] / 16)],  # [x1, y2]
+                [uv_coords[2] / 16, 1 - (uv_coords[3] / 16)],  # [x2, y2]
+            ]
 
-			for j in range(len(face.loops)):
-				# uv coords order is determened by the rotation of the uv,
-				# e.g. if the uv is rotated by 180 degrees, the first index
-				# will be 2 then 3, 0, 1.
-				face.loops[j][uv_layer].uv = uvs[(j + uv_idx) % len(uvs)]
+            for j in range(len(face.loops)):
+                # uv coords order is determened by the rotation of the uv,
+                # e.g. if the uv is rotated by 180 degrees, the first index
+                # will be 2 then 3, 0, 1.
+                face.loops[j][uv_layer].uv = uvs[(j + uv_idx) % len(uvs)]
 
-			face_mat = d_face.get("texture")
-			if face_mat is not None and face_mat in materials:
-				face.material_index = materials.index(face_mat)
+            face_mat = d_face.get("texture")
+            if face_mat is not None and face_mat in materials:
+                face.material_index = materials.index(face_mat)
 
-	# make the bmesh the object's mesh
-	bm.to_mesh(mesh)
-	bm.free()
-	return obj
+    # make the bmesh the object's mesh
+    bm.to_mesh(mesh)
+    bm.free()
+    return obj
 
 
 # -----------------------------------------------------------------------------
@@ -337,219 +350,223 @@ def add_model(model_filepath, obj_name="MinecraftModel"):
 
 
 def update_model_list(context):
-	"""Update the model list.
+    """Update the model list.
 
-	Prefer loading model names from the active resource pack, but fall back
-	to the default user preferences pack. This ensures that fallback names
-	like "block", which resource packs often don't define themselves, is
-	available.
-	"""
-	scn_props = context.scene.mcprep_props
-	sorted_models = []  # Struc of model, name, description
-	addon_prefs = util.get_user_preferences()
+    Prefer loading model names from the active resource pack, but fall back
+    to the default user preferences pack. This ensures that fallback names
+    like "block", which resource packs often don't define themselves, is
+    available.
+    """
+    scn_props = context.scene.mcprep_props
+    sorted_models = []  # Struc of model, name, description
+    addon_prefs = util.get_user_preferences()
 
-	active_pack = bpy.path.abspath(context.scene.mcprep_texturepack_path)
-	active_pack = os.path.join(
-		active_pack, "assets", "minecraft", "models", "block")
+    active_pack = bpy.path.abspath(context.scene.mcprep_texturepack_path)
+    active_pack = os.path.join(active_pack, "assets", "minecraft", "models", "block")
 
-	base_pack = bpy.path.abspath(addon_prefs.custom_texturepack_path)
-	base_pack = os.path.join(
-		base_pack, "assets", "minecraft", "models", "block")
+    base_pack = bpy.path.abspath(addon_prefs.custom_texturepack_path)
+    base_pack = os.path.join(base_pack, "assets", "minecraft", "models", "block")
 
-	if not os.path.isdir(active_pack):
-		scn_props.model_list.clear()
-		scn_props.model_list_index = 0
-		env.log("No models found for active path " + active_pack)
-		return
-	base_has_models = os.path.isdir(base_pack)
+    if not os.path.isdir(active_pack):
+        scn_props.model_list.clear()
+        scn_props.model_list_index = 0
+        env.log("No models found for active path " + active_pack)
+        return
+    base_has_models = os.path.isdir(base_pack)
 
-	active_models = [
-		model for model in os.listdir(active_pack)
-		if os.path.isfile(os.path.join(active_pack, model))
-		and model.lower().endswith(".json")]
+    active_models = [
+        model
+        for model in os.listdir(active_pack)
+        if os.path.isfile(os.path.join(active_pack, model))
+        and model.lower().endswith(".json")
+    ]
 
-	if base_has_models:
-		base_models = [
-			model for model in os.listdir(active_pack)
-			if os.path.isfile(os.path.join(active_pack, model))
-			and model.lower().endswith(".json")]
-	else:
-		env.log("Base resource pack has no models folder: " + base_pack)
-		base_models = []
+    if base_has_models:
+        base_models = [
+            model
+            for model in os.listdir(active_pack)
+            if os.path.isfile(os.path.join(active_pack, model))
+            and model.lower().endswith(".json")
+        ]
+    else:
+        env.log("Base resource pack has no models folder: " + base_pack)
+        base_models = []
 
-	sorted_models = [
-		os.path.join(active_pack, model) for model in active_models]
-	# Add the fallback models not defined by active pack.
-	sorted_models += [
-		os.path.join(base_pack, model) for model in base_models
-		if model not in active_models]
+    sorted_models = [os.path.join(active_pack, model) for model in active_models]
+    # Add the fallback models not defined by active pack.
+    sorted_models += [
+        os.path.join(base_pack, model)
+        for model in base_models
+        if model not in active_models
+    ]
 
-	sorted_models = sorted(sorted_models)
+    sorted_models = sorted(sorted_models)
 
-	# now re-populate the UI list
-	scn_props.model_list.clear()
-	for model in sorted_models:
-		name = os.path.splitext(os.path.basename(model))[0]
+    # now re-populate the UI list
+    scn_props.model_list.clear()
+    for model in sorted_models:
+        name = os.path.splitext(os.path.basename(model))[0]
 
-		# Filter out models that can't spawn. Typically those that reference
-		# #fire or the likes in the file.
-		if "template" in name:
-			continue
-		item = scn_props.model_list.add()
-		item.filepath = model
-		item.name = name
-		item.description = "Spawn a {} model from active resource pack".format(
-			name)
+        # Filter out models that can't spawn. Typically those that reference
+        # #fire or the likes in the file.
+        if "template" in name:
+            continue
+        item = scn_props.model_list.add()
+        item.filepath = model
+        item.name = name
+        item.description = "Spawn a {} model from active resource pack".format(name)
 
-	if scn_props.model_list_index >= len(scn_props.model_list):
-		scn_props.model_list_index = len(scn_props.model_list) - 1
+    if scn_props.model_list_index >= len(scn_props.model_list):
+        scn_props.model_list_index = len(scn_props.model_list) - 1
 
 
 def draw_import_mcmodel(self, context):
-	"""Import bar layout definition."""
-	layout = self.layout
-	layout.operator("mcprep.import_model_file", text="Minecraft Model (.json)")
+    """Import bar layout definition."""
+    layout = self.layout
+    layout.operator("mcprep.import_model_file", text="Minecraft Model (.json)")
 
 
-class ModelSpawnBase():
-	"""Class to inheret reused MCprep item spawning settings and functions."""
-	location: bpy.props.FloatVectorProperty(
-		default=(0, 0, 0),
-		name="Location")
-	snapping: bpy.props.EnumProperty(
-		name="Snapping",
-		items=[
-			("none", "No snap", "Keep exact location"),
-			("center", "Snap center", "Snap to block center"),
-			("offset", "Snap offset", "Snap to block center with 0.5 offset")],
-		description="Automatically snap to whole block locations")
-	skipUsage: bpy.props.BoolProperty(
-		default=False,
-		options={'HIDDEN'})
+class ModelSpawnBase:
+    """Class to inheret reused MCprep item spawning settings and functions."""
 
-	@classmethod
-	def poll(cls, context):
-		return context.mode == 'OBJECT'
+    location: bpy.props.FloatVectorProperty(default=(0, 0, 0), name="Location")
+    snapping: bpy.props.EnumProperty(
+        name="Snapping",
+        items=[
+            ("none", "No snap", "Keep exact location"),
+            ("center", "Snap center", "Snap to block center"),
+            ("offset", "Snap offset", "Snap to block center with 0.5 offset"),
+        ],
+        description="Automatically snap to whole block locations",
+    )
+    skipUsage: bpy.props.BoolProperty(default=False, options={"HIDDEN"})
 
-	def place_model(self, obj):
-		if self.snapping == "center":
-			offset = 0
-			obj.location = [round(x + offset) - offset for x in self.location]
-			obj.location.z -= 0.5
-		elif self.snapping == "offset":
-			offset = 0.5
-			obj.location = [round(x + offset) - offset for x in self.location]
-			obj.location.z -= 0.5
-		else:
-			obj.location = self.location
+    @classmethod
+    def poll(cls, context):
+        return context.mode == "OBJECT"
 
-	def post_spawn(self, context, new_obj):
-		"""Do final consistent cleanup after model is spawned."""
-		for ob in util.get_objects_conext(context):
-			util.select_set(ob, False)
-		util.select_set(new_obj, True)
+    def place_model(self, obj):
+        if self.snapping == "center":
+            offset = 0
+            obj.location = [round(x + offset) - offset for x in self.location]
+            obj.location.z -= 0.5
+        elif self.snapping == "offset":
+            offset = 0.5
+            obj.location = [round(x + offset) - offset for x in self.location]
+            obj.location.z -= 0.5
+        else:
+            obj.location = self.location
+
+    def post_spawn(self, context, new_obj):
+        """Do final consistent cleanup after model is spawned."""
+        for ob in util.get_objects_conext(context):
+            util.select_set(ob, False)
+        util.select_set(new_obj, True)
 
 
 class MCPREP_OT_spawn_minecraft_model(bpy.types.Operator, ModelSpawnBase):
-	"""Import in an MC model from a json file."""
-	bl_idname = "mcprep.spawn_model"
-	bl_label = "Place model"
-	bl_options = {'REGISTER', 'UNDO'}
+    """Import in an MC model from a json file."""
 
-	filepath: bpy.props.StringProperty(
-		default="",
-		subtype="FILE_PATH",
-		options={'HIDDEN', 'SKIP_SAVE'})
+    bl_idname = "mcprep.spawn_model"
+    bl_label = "Place model"
+    bl_options = {"REGISTER", "UNDO"}
 
-	track_function = "model"
-	track_param = "list"
-	@tracking.report_error
-	def execute(self, context):
-		name = os.path.basename(os.path.splitext(self.filepath)[0])
-		if not self.filepath or not os.path.isfile(self.filepath):
-			self.report({"WARNING"}, "Filepath not found")
-			bpy.ops.mcprep.prompt_reset_spawners('INVOKE_DEFAULT')
-			return {'CANCELLED'}
-		if not self.filepath.lower().endswith(".json"):
-			self.report(
-				{"ERROR"}, "File is not json: " + self.filepath)
-			return {'CANCELLED'}
+    filepath: bpy.props.StringProperty(
+        default="", subtype="FILE_PATH", options={"HIDDEN", "SKIP_SAVE"}
+    )
 
-		try:
-			obj = add_model(os.path.normpath(self.filepath), name)
-		except ModelException as e:
-			self.report({"ERROR"}, "Encountered error: " + str(e))
-			return {'CANCELLED'}
+    track_function = "model"
+    track_param = "list"
 
-		self.place_model(obj)
-		self.post_spawn(context, obj)
-		return {'FINISHED'}
+    @tracking.report_error
+    def execute(self, context):
+        name = os.path.basename(os.path.splitext(self.filepath)[0])
+        if not self.filepath or not os.path.isfile(self.filepath):
+            self.report({"WARNING"}, "Filepath not found")
+            bpy.ops.mcprep.prompt_reset_spawners("INVOKE_DEFAULT")
+            return {"CANCELLED"}
+        if not self.filepath.lower().endswith(".json"):
+            self.report({"ERROR"}, "File is not json: " + self.filepath)
+            return {"CANCELLED"}
+
+        try:
+            obj = add_model(os.path.normpath(self.filepath), name)
+        except ModelException as e:
+            self.report({"ERROR"}, "Encountered error: " + str(e))
+            return {"CANCELLED"}
+
+        self.place_model(obj)
+        self.post_spawn(context, obj)
+        return {"FINISHED"}
 
 
 class MCPREP_OT_import_minecraft_model_file(
-	bpy.types.Operator, ImportHelper, ModelSpawnBase):
-	"""Import an MC model from a json file."""
-	bl_idname = "mcprep.import_model_file"
-	bl_label = "Import model (.json)"
-	bl_options = {'REGISTER', 'UNDO'}
+    bpy.types.Operator, ImportHelper, ModelSpawnBase
+):
+    """Import an MC model from a json file."""
 
-	filename_ext = ".json"
-	filter_glob: bpy.props.StringProperty(
-		default="*.json",
-		options={'HIDDEN'},
-		maxlen=255  # Max internal buffer length, longer would be clamped.
-	)
+    bl_idname = "mcprep.import_model_file"
+    bl_label = "Import model (.json)"
+    bl_options = {"REGISTER", "UNDO"}
 
-	track_function = "model"
-	track_param = "file"
-	@tracking.report_error
-	def execute(self, context):
-		filename = os.path.splitext(os.path.basename(self.filepath))[0]
-		if not self.filepath or not os.path.isfile(self.filepath):
-			self.report({"ERROR"}, "Filepath not found")
-			return {'CANCELLED'}
-		if not self.filepath.lower().endswith(".json"):
-			self.report(
-				{"ERROR"}, "File is not json: " + self.filepath)
-			return {'CANCELLED'}
+    filename_ext = ".json"
+    filter_glob: bpy.props.StringProperty(
+        default="*.json",
+        options={"HIDDEN"},
+        maxlen=255,  # Max internal buffer length, longer would be clamped.
+    )
 
-		try:
-			obj = add_model(os.path.normpath(self.filepath), filename)
-		except ModelException as e:
-			self.report({"ERROR"}, "Encountered error: " + str(e))
-			return {'CANCELLED'}
+    track_function = "model"
+    track_param = "file"
 
-		self.place_model(obj)
-		self.post_spawn(context, obj)
-		return {'FINISHED'}
+    @tracking.report_error
+    def execute(self, context):
+        filename = os.path.splitext(os.path.basename(self.filepath))[0]
+        if not self.filepath or not os.path.isfile(self.filepath):
+            self.report({"ERROR"}, "Filepath not found")
+            return {"CANCELLED"}
+        if not self.filepath.lower().endswith(".json"):
+            self.report({"ERROR"}, "File is not json: " + self.filepath)
+            return {"CANCELLED"}
+
+        try:
+            obj = add_model(os.path.normpath(self.filepath), filename)
+        except ModelException as e:
+            self.report({"ERROR"}, "Encountered error: " + str(e))
+            return {"CANCELLED"}
+
+        self.place_model(obj)
+        self.post_spawn(context, obj)
+        return {"FINISHED"}
 
 
 class MCPREP_OT_reload_models(bpy.types.Operator):
-	"""Reload model spawner, use after adding/removing/renaming files in the resource pack folder"""
-	bl_idname = "mcprep.reload_models"
-	bl_label = "Reload models"
+    """Reload model spawner, use after adding/removing/renaming files in the resource pack folder"""
 
-	@tracking.report_error
-	def execute(self, context):
-		update_model_list(context)
-		return {'FINISHED'}
+    bl_idname = "mcprep.reload_models"
+    bl_label = "Reload models"
+
+    @tracking.report_error
+    def execute(self, context):
+        update_model_list(context)
+        return {"FINISHED"}
 
 
 classes = (
-	MCPREP_OT_spawn_minecraft_model,
-	MCPREP_OT_import_minecraft_model_file,
-	MCPREP_OT_reload_models,
+    MCPREP_OT_spawn_minecraft_model,
+    MCPREP_OT_import_minecraft_model_file,
+    MCPREP_OT_reload_models,
 )
 
 
 def register():
-	for cls in classes:
-		bpy.utils.register_class(cls)
+    for cls in classes:
+        bpy.utils.register_class(cls)
 
-	bpy.types.TOPBAR_MT_file_import.append(draw_import_mcmodel)
+    bpy.types.TOPBAR_MT_file_import.append(draw_import_mcmodel)
 
 
 def unregister():
-	bpy.types.TOPBAR_MT_file_import.remove(draw_import_mcmodel)
-	for cls in reversed(classes):
-		bpy.utils.unregister_class(cls)
+    bpy.types.TOPBAR_MT_file_import.remove(draw_import_mcmodel)
+    for cls in reversed(classes):
+        bpy.utils.unregister_class(cls)

--- a/MCprep_addon/spawner/meshswap.py
+++ b/MCprep_addon/spawner/meshswap.py
@@ -42,127 +42,128 @@ meshswap_cache_path = None
 
 
 def get_meshswap_cache(context, clear=False):
-	"""Load groups/objects from meshswap lib if not cached, return key vars."""
-	global meshswap_cache
-	global meshswap_cache_path  # used to auto-clear path if bpy prop changed
+    """Load groups/objects from meshswap lib if not cached, return key vars."""
+    global meshswap_cache
+    global meshswap_cache_path  # used to auto-clear path if bpy prop changed
 
-	meshswap_path = context.scene.meshswap_path
-	if not meshswap_cache_path:
-		meshswap_cache_path = meshswap_path
-		clear = True
-	if meshswap_cache_path != meshswap_path:
-		clear = True
+    meshswap_path = context.scene.meshswap_path
+    if not meshswap_cache_path:
+        meshswap_cache_path = meshswap_path
+        clear = True
+    if meshswap_cache_path != meshswap_path:
+        clear = True
 
-	if meshswap_cache and clear is not True:
-		return meshswap_cache
+    if meshswap_cache and clear is not True:
+        return meshswap_cache
 
-	meshswap_cache = {"groups": [], "objects": []}
-	if not os.path.isfile(meshswap_path):
-		env.log("Meshswap path not found")
-		return meshswap_cache
-	if not meshswap_path.lower().endswith('.blend'):
-		env.log("Meshswap path must be a .blend file")
-		return meshswap_cache
+    meshswap_cache = {"groups": [], "objects": []}
+    if not os.path.isfile(meshswap_path):
+        env.log("Meshswap path not found")
+        return meshswap_cache
+    if not meshswap_path.lower().endswith(".blend"):
+        env.log("Meshswap path must be a .blend file")
+        return meshswap_cache
 
-	with bpy.data.libraries.load(meshswap_path) as (data_from, _):
-		grp_list = spawn_util.filter_collections(data_from)
+    with bpy.data.libraries.load(meshswap_path) as (data_from, _):
+        grp_list = spawn_util.filter_collections(data_from)
 
-		meshswap_cache["groups"] = grp_list
-		for obj in list(data_from.objects):
-			if obj in meshswap_cache["groups"]:
-				# env.log("Skipping meshwap obj already in cache: "+str(obj))
-				continue
-			# ignore list? e.g. Point.001,
-			meshswap_cache["objects"].append(obj)
-	return meshswap_cache
+        meshswap_cache["groups"] = grp_list
+        for obj in list(data_from.objects):
+            if obj in meshswap_cache["groups"]:
+                # env.log("Skipping meshwap obj already in cache: "+str(obj))
+                continue
+            # ignore list? e.g. Point.001,
+            meshswap_cache["objects"].append(obj)
+    return meshswap_cache
 
 
 def getMeshswapList(context):
-	"""Only used for UI drawing of enum menus, full list."""
+    """Only used for UI drawing of enum menus, full list."""
 
-	# may redraw too many times, perhaps have flag
-	if not context.scene.mcprep_props.meshswap_list:
-		updateMeshswapList(context)
-	return [
-		(itm.block, itm.name.title(), "Place {}".format(itm.name))
-		for itm in context.scene.mcprep_props.meshswap_list]
+    # may redraw too many times, perhaps have flag
+    if not context.scene.mcprep_props.meshswap_list:
+        updateMeshswapList(context)
+    return [
+        (itm.block, itm.name.title(), "Place {}".format(itm.name))
+        for itm in context.scene.mcprep_props.meshswap_list
+    ]
 
 
 def move_assets_to_excluded_layer(context, collections):
-	"""Utility to move source collections to excluded layer to not be rendered"""
-	initial_view_coll = context.view_layer.active_layer_collection
+    """Utility to move source collections to excluded layer to not be rendered"""
+    initial_view_coll = context.view_layer.active_layer_collection
 
-	# Then, setup the exclude view layer
-	meshswap_exclude_vl = util.get_or_create_viewlayer(
-		context, "Meshswap Exclude")
-	meshswap_exclude_vl.collection.hide_viewport = True
-	meshswap_exclude_vl.collection.hide_render = True
+    # Then, setup the exclude view layer
+    meshswap_exclude_vl = util.get_or_create_viewlayer(context, "Meshswap Exclude")
+    meshswap_exclude_vl.collection.hide_viewport = True
+    meshswap_exclude_vl.collection.hide_render = True
 
-	for grp in collections:
-		if grp.name not in initial_view_coll.collection.children:
-			continue  # not linked, likely a sub-group not added to scn
-		initial_view_coll.collection.children.unlink(grp)
-		if grp.name not in meshswap_exclude_vl.collection.children:
-			meshswap_exclude_vl.collection.children.link(grp)
+    for grp in collections:
+        if grp.name not in initial_view_coll.collection.children:
+            continue  # not linked, likely a sub-group not added to scn
+        initial_view_coll.collection.children.unlink(grp)
+        if grp.name not in meshswap_exclude_vl.collection.children:
+            meshswap_exclude_vl.collection.children.link(grp)
 
 
 def update_meshswap_path(self, context):
-	"""for UI list path callback"""
-	env.log("Updating meshswap path", vv_only=True)
-	if not context.scene.meshswap_path.lower().endswith('.blend'):
-		print("Meshswap file is not a .blend, and should be")
-	if not os.path.isfile(bpy.path.abspath(context.scene.meshswap_path)):
-		print("Meshswap blend file does not exist")
-	updateMeshswapList(context)
+    """for UI list path callback"""
+    env.log("Updating meshswap path", vv_only=True)
+    if not context.scene.meshswap_path.lower().endswith(".blend"):
+        print("Meshswap file is not a .blend, and should be")
+    if not os.path.isfile(bpy.path.abspath(context.scene.meshswap_path)):
+        print("Meshswap blend file does not exist")
+    updateMeshswapList(context)
 
 
 def updateMeshswapList(context):
-	"""Update the meshswap list"""
-	meshswap_file = bpy.path.abspath(context.scene.meshswap_path)
-	if not os.path.isfile(meshswap_file):
-		print("Invalid meshswap blend file path")
-		context.scene.mcprep_props.meshswap_list.clear()
-		return
+    """Update the meshswap list"""
+    meshswap_file = bpy.path.abspath(context.scene.meshswap_path)
+    if not os.path.isfile(meshswap_file):
+        print("Invalid meshswap blend file path")
+        context.scene.mcprep_props.meshswap_list.clear()
+        return
 
-	temp_meshswap_list = []  # just to skip duplicates
-	meshswap_list = []
+    temp_meshswap_list = []  # just to skip duplicates
+    meshswap_list = []
 
-	cache = get_meshswap_cache(context)
-	method = "collection"
+    cache = get_meshswap_cache(context)
+    method = "collection"
 
-	for name in cache.get("groups"):
-		if not name:
-			continue
-		if util.nameGeneralize(name).lower() in temp_meshswap_list:
-			continue
-		description = "Place {x} block".format(x=name)
-		meshswap_list.append((method, name, name.title(), description))
-		temp_meshswap_list.append(util.nameGeneralize(name).lower())
+    for name in cache.get("groups"):
+        if not name:
+            continue
+        if util.nameGeneralize(name).lower() in temp_meshswap_list:
+            continue
+        description = "Place {x} block".format(x=name)
+        meshswap_list.append((method, name, name.title(), description))
+        temp_meshswap_list.append(util.nameGeneralize(name).lower())
 
-	# sort the list alphabetically by name
-	if meshswap_list:
-		_, sorted_blocks = zip(*sorted(zip(
-			[block[1].lower() for block in meshswap_list],
-			meshswap_list)))
-	else:
-		sorted_blocks = []
+    # sort the list alphabetically by name
+    if meshswap_list:
+        _, sorted_blocks = zip(
+            *sorted(zip([block[1].lower() for block in meshswap_list], meshswap_list))
+        )
+    else:
+        sorted_blocks = []
 
-	# now re-populate the UI list
-	context.scene.mcprep_props.meshswap_list.clear()
-	for itm in sorted_blocks:
-		item = context.scene.mcprep_props.meshswap_list.add()
-		item.method = itm[0]
-		item.block = itm[1]
-		item.name = itm[2]
-		item.description = itm[3]
+    # now re-populate the UI list
+    context.scene.mcprep_props.meshswap_list.clear()
+    for itm in sorted_blocks:
+        item = context.scene.mcprep_props.meshswap_list.add()
+        item.method = itm[0]
+        item.block = itm[1]
+        item.name = itm[2]
+        item.description = itm[3]
 
 
-class face_struct():
-	"""Structure class for preprocessed faces of a mesh"""
-	def __init__(self, normal_coord, global_coord, local_coord):
-		self.n = normal_coord
-		self.g = global_coord
-		self.l = local_coord
+class face_struct:
+    """Structure class for preprocessed faces of a mesh"""
+
+    def __init__(self, normal_coord, global_coord, local_coord):
+        self.n = normal_coord
+        self.g = global_coord
+        self.l = local_coord
 
 
 # -----------------------------------------------------------------------------
@@ -171,169 +172,175 @@ class face_struct():
 
 
 class MCPREP_OT_meshswap_path_reset(bpy.types.Operator):
-	"""Reset the spawn path to the default specified in the addon preferences panel"""
-	bl_idname = "mcprep.meshswap_path_reset"
-	bl_label = "Reset meshswap path"
-	bl_options = {'REGISTER', 'UNDO'}
+    """Reset the spawn path to the default specified in the addon preferences panel"""
 
-	@tracking.report_error
-	def execute(self, context):
+    bl_idname = "mcprep.meshswap_path_reset"
+    bl_label = "Reset meshswap path"
+    bl_options = {"REGISTER", "UNDO"}
 
-		addon_prefs = util.get_user_preferences(context)
-		context.scene.meshswap_path = addon_prefs.meshswap_path
-		updateMeshswapList(context)
-		return {'FINISHED'}
+    @tracking.report_error
+    def execute(self, context):
+        addon_prefs = util.get_user_preferences(context)
+        context.scene.meshswap_path = addon_prefs.meshswap_path
+        updateMeshswapList(context)
+        return {"FINISHED"}
 
 
 class MCPREP_OT_meshswap_spawner(bpy.types.Operator):
-	"""Instantly spawn built-in meshswap blocks into a scene"""
-	bl_idname = "mcprep.meshswap_spawner"
-	bl_label = "Meshswap Spawner"
-	bl_options = {'REGISTER', 'UNDO'}
+    """Instantly spawn built-in meshswap blocks into a scene"""
 
-	# properties, will appear in redo-last menu
-	def swap_enum(self, context):
-		return getMeshswapList(context)
+    bl_idname = "mcprep.meshswap_spawner"
+    bl_label = "Meshswap Spawner"
+    bl_options = {"REGISTER", "UNDO"}
 
-	block: bpy.props.EnumProperty(items=swap_enum, name="Meshswap block")
-	method: bpy.props.EnumProperty(
-		name="Import method",
-		items=[
-			# Making collection first to be effective default.
-			("collection", "Collection/group asset", "Collection/group asset"),
-			("object", "Object asset", "Object asset"),
-		],
-		options={'HIDDEN'})
-	location: bpy.props.FloatVectorProperty(
-		default=(0, 0, 0),
-		name="Location")
-	append_layer: bpy.props.IntProperty(
-		name="Append layer",
-		default=20,
-		min=0,
-		max=20,
-		description="Set the layer for appending groups, 0 means same as active layers")
-	prep_materials: bpy.props.BoolProperty(
-		name="Prep materials",
-		default=True,
-		description="Run prep materials on objects after appending")
-	snapping: bpy.props.EnumProperty(
-		name="Snapping",
-		items=[
-			("none", "No snap", "Keep exact location"),
-			("center", "Snap center", "Snap to block center"),
-			("offset", "Snap offset", "Snap to block center with 0.5 offset")],
-		description="Automatically snap to whole block locations")
-	make_real: bpy.props.BoolProperty(
-		name="Make real",
-		default=False,  # TODO: make True once able to retain animations like fire
-		description="Automatically make groups real after placement")
+    # properties, will appear in redo-last menu
+    def swap_enum(self, context):
+        return getMeshswapList(context)
 
-	# toLink: bpy.props.BoolProperty(
-	# 	name = "Library Link mob",
-	# 	description = "Library link instead of append the group",
-	# 	default = False
-	# 	)
-	# option to force load from library instead of reuse local group?
+    block: bpy.props.EnumProperty(items=swap_enum, name="Meshswap block")
+    method: bpy.props.EnumProperty(
+        name="Import method",
+        items=[
+            # Making collection first to be effective default.
+            ("collection", "Collection/group asset", "Collection/group asset"),
+            ("object", "Object asset", "Object asset"),
+        ],
+        options={"HIDDEN"},
+    )
+    location: bpy.props.FloatVectorProperty(default=(0, 0, 0), name="Location")
+    append_layer: bpy.props.IntProperty(
+        name="Append layer",
+        default=20,
+        min=0,
+        max=20,
+        description="Set the layer for appending groups, 0 means same as active layers",
+    )
+    prep_materials: bpy.props.BoolProperty(
+        name="Prep materials",
+        default=True,
+        description="Run prep materials on objects after appending",
+    )
+    snapping: bpy.props.EnumProperty(
+        name="Snapping",
+        items=[
+            ("none", "No snap", "Keep exact location"),
+            ("center", "Snap center", "Snap to block center"),
+            ("offset", "Snap offset", "Snap to block center with 0.5 offset"),
+        ],
+        description="Automatically snap to whole block locations",
+    )
+    make_real: bpy.props.BoolProperty(
+        name="Make real",
+        default=False,  # TODO: make True once able to retain animations like fire
+        description="Automatically make groups real after placement",
+    )
 
-	@classmethod
-	def poll(self, context):
-		return context.mode == 'OBJECT'
+    # toLink: bpy.props.BoolProperty(
+    # 	name = "Library Link mob",
+    # 	description = "Library link instead of append the group",
+    # 	default = False
+    # 	)
+    # option to force load from library instead of reuse local group?
 
-	track_function = "meshswapSpawner"
-	track_param = None
-	@tracking.report_error
-	def execute(self, context):
-		pre_groups = list(util.collections())
+    @classmethod
+    def poll(self, context):
+        return context.mode == "OBJECT"
 
-		meshSwapPath = bpy.path.abspath(context.scene.meshswap_path)
-		block = self.block
-		method = self.method
-		if method == "collection":
-			is_object = False
-			method = "Group" if hasattr(bpy.data, "groups") else "Collection"
-		elif method == "object":
-			is_object = True
-			method = "Object"
-		link = False
-		use_cache = False
-		group = None
+    track_function = "meshswapSpawner"
+    track_param = None
 
-		if not is_object and block in util.collections():
-			group = util.collections()[block]
-			# if blender 2.8, see if collection part of the MCprepLib coll.
-			use_cache = True
-		else:
-			util.bAppendLink(os.path.join(meshSwapPath, method), block, link)
+    @tracking.report_error
+    def execute(self, context):
+        pre_groups = list(util.collections())
 
-		if is_object:
-			# Object-level disabled! Must have better
-			# asset management for this to work
-			for ob in bpy.context.selected_objects:
-				if ob.type != 'MESH':
-					util.select_set(ob, False)
-			try:
-				importedObj = bpy.context.selected_objects[0]
-			except:
-				# in case nothing selected.. which happens even during selection?
-				print("selected object not found")
-				self.report({'WARNING'}, "Imported object not found")
-				return {'CANCELLED'}
-			importedObj["MCprep_noSwap"] = 1
-			importedObj.location = self.location
-			if self.prep_materials is True:
-				try:
-					bpy.ops.mcprep.prep_materials(
-						autoFindMissingTextures=False,
-						improveUiSettings=False,
-						skipUsage=True)  # if cycles
-				except:
-					print("Could not prep materials")
-					self.report({"WARNING"}, "Could not prep materials")
-		else:
-			if not use_cache:
-				group = spawn_util.prep_collection(
-					self, context, block, pre_groups)
+        meshSwapPath = bpy.path.abspath(context.scene.meshswap_path)
+        block = self.block
+        method = self.method
+        if method == "collection":
+            is_object = False
+            method = "Group" if hasattr(bpy.data, "groups") else "Collection"
+        elif method == "object":
+            is_object = True
+            method = "Object"
+        link = False
+        use_cache = False
+        group = None
 
-			if not group:
-				env.log("No group identified, could not retrieve imported group")
-				self.report({"ERROR"}, "Could not retrieve imported group")
-				return {'CANCELLED'}
+        if not is_object and block in util.collections():
+            group = util.collections()[block]
+            # if blender 2.8, see if collection part of the MCprepLib coll.
+            use_cache = True
+        else:
+            util.bAppendLink(os.path.join(meshSwapPath, method), block, link)
 
-			# now finally add the group instance
-			for obj in util.get_objects_conext(context):
-				util.select_set(obj, False)
-			ob = util.addGroupInstance(group.name, self.location)
-			if util.bv28():
-				util.move_to_collection(ob, context.collection)
-			if self.snapping == "center":
-				offset = 0  # could be 0.5
-				ob.location = [round(x + offset) - offset for x in self.location]
-			elif self.snapping == "offset":
-				offset = 0.5  # could be 0.5
-				ob.location = [round(x + offset) - offset for x in self.location]
-			ob["MCprep_noSwap"] = 1
+        if is_object:
+            # Object-level disabled! Must have better
+            # asset management for this to work
+            for ob in bpy.context.selected_objects:
+                if ob.type != "MESH":
+                    util.select_set(ob, False)
+            try:
+                importedObj = bpy.context.selected_objects[0]
+            except:
+                # in case nothing selected.. which happens even during selection?
+                print("selected object not found")
+                self.report({"WARNING"}, "Imported object not found")
+                return {"CANCELLED"}
+            importedObj["MCprep_noSwap"] = 1
+            importedObj.location = self.location
+            if self.prep_materials is True:
+                try:
+                    bpy.ops.mcprep.prep_materials(
+                        autoFindMissingTextures=False,
+                        improveUiSettings=False,
+                        skipUsage=True,
+                    )  # if cycles
+                except:
+                    print("Could not prep materials")
+                    self.report({"WARNING"}, "Could not prep materials")
+        else:
+            if not use_cache:
+                group = spawn_util.prep_collection(self, context, block, pre_groups)
 
-			if self.make_real:
-				if util.bv28():
-					# make real doesn't select resulting output now (true for
-					# earlier versions of 2.8, not true in 2.82 at least where
-					# selects everything BUT the source of original instance
+            if not group:
+                env.log("No group identified, could not retrieve imported group")
+                self.report({"ERROR"}, "Could not retrieve imported group")
+                return {"CANCELLED"}
 
-					pre_objs = list(bpy.data.objects)
-					bpy.ops.object.duplicates_make_real()
-					post_objs = list(bpy.data.objects)
-					new_objs = list(set(post_objs) - set(pre_objs))
-					for obj in new_objs:
-						util.select_set(obj, True)
+            # now finally add the group instance
+            for obj in util.get_objects_conext(context):
+                util.select_set(obj, False)
+            ob = util.addGroupInstance(group.name, self.location)
+            if util.bv28():
+                util.move_to_collection(ob, context.collection)
+            if self.snapping == "center":
+                offset = 0  # could be 0.5
+                ob.location = [round(x + offset) - offset for x in self.location]
+            elif self.snapping == "offset":
+                offset = 0.5  # could be 0.5
+                ob.location = [round(x + offset) - offset for x in self.location]
+            ob["MCprep_noSwap"] = 1
 
-						# Re-apply animation if any
-						# TODO: Causes an issue for any animation that depends
-						# on direct xyz placement (noting that parents are
-						# cleared on Make Real). Could try adding a parent to
-						# any given object's current location and give the
-						# equivalent xyz offset at some point in time.
-						"""
+            if self.make_real:
+                if util.bv28():
+                    # make real doesn't select resulting output now (true for
+                    # earlier versions of 2.8, not true in 2.82 at least where
+                    # selects everything BUT the source of original instance
+
+                    pre_objs = list(bpy.data.objects)
+                    bpy.ops.object.duplicates_make_real()
+                    post_objs = list(bpy.data.objects)
+                    new_objs = list(set(post_objs) - set(pre_objs))
+                    for obj in new_objs:
+                        util.select_set(obj, True)
+
+                        # Re-apply animation if any
+                        # TODO: Causes an issue for any animation that depends
+                        # on direct xyz placement (noting that parents are
+                        # cleared on Make Real). Could try adding a parent to
+                        # any given object's current location and give the
+                        # equivalent xyz offset at some point in time.
+                        """
 						orig_objs = [obo for obo in group.objects
 							if util.nameGeneralize(obj.name) == util.nameGeneralize(obo.name)]
 						if not orig_objs:
@@ -345,993 +352,1069 @@ class MCPREP_OT_meshswap_spawner(bpy.types.Operator):
 							obj.animation_data_create()
 						obj.animation_data.action = obo.animation_data.action
 						"""
-				else:
-					bpy.ops.object.duplicates_make_real()
+                else:
+                    bpy.ops.object.duplicates_make_real()
 
-				if group is not None:
-					spawn_util.fix_armature_target(
-						self, context, context.selected_objects, group)
+                if group is not None:
+                    spawn_util.fix_armature_target(
+                        self, context, context.selected_objects, group
+                    )
 
-				# remove the empty added by making duplicates real.
-				if ob in bpy.data.objects[:] and ob.type == "EMPTY":
-					util.obj_unlink_remove(ob, True, context)
-				else:
-					for ob in context.selected_objects:
-						if ob.type != "EMPTY":
-							continue
-						elif ob.parent or ob.children:
-							continue
-						util.obj_unlink_remove(ob, True, context)
-				# TODO: Consider actually keeping the empty, and parenting the
-				# spawned items to this empty (not the defautl behavior)
-			else:
-				# change the draw size
-				if hasattr(ob, "empty_draw_size"):
-					ob.empty_draw_size = 0.25
-				else:
-					ob.empty_display_size = 0.25
-				# mark as active object
-				util.set_active_object(context, ob)
+                # remove the empty added by making duplicates real.
+                if ob in bpy.data.objects[:] and ob.type == "EMPTY":
+                    util.obj_unlink_remove(ob, True, context)
+                else:
+                    for ob in context.selected_objects:
+                        if ob.type != "EMPTY":
+                            continue
+                        elif ob.parent or ob.children:
+                            continue
+                        util.obj_unlink_remove(ob, True, context)
+                # TODO: Consider actually keeping the empty, and parenting the
+                # spawned items to this empty (not the defautl behavior)
+            else:
+                # change the draw size
+                if hasattr(ob, "empty_draw_size"):
+                    ob.empty_draw_size = 0.25
+                else:
+                    ob.empty_display_size = 0.25
+                # mark as active object
+                util.set_active_object(context, ob)
 
-			# Move source of group instance into excluded view layer
-			if util.bv28() and group:
-				util.move_assets_to_excluded_layer(context, [group])
+            # Move source of group instance into excluded view layer
+            if util.bv28() and group:
+                util.move_assets_to_excluded_layer(context, [group])
 
-		self.track_param = "{}/{}".format(self.method, self.block)
-		return {'FINISHED'}
+        self.track_param = "{}/{}".format(self.method, self.block)
+        return {"FINISHED"}
 
-	def prep_collection(self, context, block, pre_groups):
-		"""Prep the imported collection, ran only if newly imported (not cached)"""
+    def prep_collection(self, context, block, pre_groups):
+        """Prep the imported collection, ran only if newly imported (not cached)"""
 
-		# Group method first, move append to according layer
-		for ob in util.get_objects_conext(context):
-			util.select_set(ob, False)
+        # Group method first, move append to according layer
+        for ob in util.get_objects_conext(context):
+            util.select_set(ob, False)
 
-		layers = [False] * 20
-		if not hasattr(context.scene, "layers"):
-			# TODO: here add all subcollections to an MCprepLib collection.
-			pass
-		elif self.append_layer == 0:
-			layers = context.scene.layers
-		else:
-			layers[self.append_layer - 1] = True
-		objlist = []
-		group = None
-		for coll in util.collections():
-			if coll in pre_groups:
-				continue
-			if coll.name.lower().startswith("collection"):
-				continue  # Will drop e.g. "Collection 1" from blender 2.7x.
-			for ob in coll.objects:
-				if ob.name in context.scene.objects:
-					# context.scene.objects.unlink(ob)
-					objlist.append(ob)
-			if util.nameGeneralize(coll.name) == util.nameGeneralize(block):
-				group = coll
+        layers = [False] * 20
+        if not hasattr(context.scene, "layers"):
+            # TODO: here add all subcollections to an MCprepLib collection.
+            pass
+        elif self.append_layer == 0:
+            layers = context.scene.layers
+        else:
+            layers[self.append_layer - 1] = True
+        objlist = []
+        group = None
+        for coll in util.collections():
+            if coll in pre_groups:
+                continue
+            if coll.name.lower().startswith("collection"):
+                continue  # Will drop e.g. "Collection 1" from blender 2.7x.
+            for ob in coll.objects:
+                if ob.name in context.scene.objects:
+                    # context.scene.objects.unlink(ob)
+                    objlist.append(ob)
+            if util.nameGeneralize(coll.name) == util.nameGeneralize(block):
+                group = coll
 
-		if group is None:
-			return None
+        if group is None:
+            return None
 
-		if self.prep_materials is True:
-			for ob in objlist:
-				util.select_set(ob, True)
-			try:
-				bpy.ops.mcprep.prep_materials(
-					autoFindMissingTextures=False,
-					improveUiSettings=False,
-					skipUsage=True)  # If cycles.
-			except:
-				print("Could not prep materials")
-			for ob in util.get_objects_conext(context):
-				util.select_set(ob, False)
+        if self.prep_materials is True:
+            for ob in objlist:
+                util.select_set(ob, True)
+            try:
+                bpy.ops.mcprep.prep_materials(
+                    autoFindMissingTextures=False,
+                    improveUiSettings=False,
+                    skipUsage=True,
+                )  # If cycles.
+            except:
+                print("Could not prep materials")
+            for ob in util.get_objects_conext(context):
+                util.select_set(ob, False)
 
-		if hasattr(context.scene, "layers"):  # 2.7 only
-			for obj in objlist:
-				obj.layers = layers
-		return group
+        if hasattr(context.scene, "layers"):  # 2.7 only
+            for obj in objlist:
+                obj.layers = layers
+        return group
 
 
 class MCPREP_OT_reload_meshswap(bpy.types.Operator):
-	"""Force reload the MeshSwap objects and cache."""
-	bl_idname = "mcprep.reload_meshswap"
-	bl_label = "Reload MeshSwap"
+    """Force reload the MeshSwap objects and cache."""
 
-	@tracking.report_error
-	def execute(self, context):
-		if not context.scene.meshswap_path.lower().endswith('.blend'):
-			self.report({'WARNING'}, "Meshswap file must be a .blend, try resetting")
-		elif not os.path.isfile(bpy.path.abspath(context.scene.meshswap_path)):
-			self.report({'WARNING'}, "Meshswap blend file does not exist")
+    bl_idname = "mcprep.reload_meshswap"
+    bl_label = "Reload MeshSwap"
 
-		# still reload even with above issues, cache/UI should be cleared
-		get_meshswap_cache(context, clear=True)
-		updateMeshswapList(context)
-		return {'FINISHED'}
+    @tracking.report_error
+    def execute(self, context):
+        if not context.scene.meshswap_path.lower().endswith(".blend"):
+            self.report({"WARNING"}, "Meshswap file must be a .blend, try resetting")
+        elif not os.path.isfile(bpy.path.abspath(context.scene.meshswap_path)):
+            self.report({"WARNING"}, "Meshswap blend file does not exist")
+
+        # still reload even with above issues, cache/UI should be cleared
+        get_meshswap_cache(context, clear=True)
+        updateMeshswapList(context)
+        return {"FINISHED"}
 
 
 class MCPREP_OT_meshswap(bpy.types.Operator):
-	"""Swap minecraft objects from world imports for custom 3D models in the according meshSwap blend file"""
-	bl_idname = "mcprep.meshswap"
-	bl_label = "Mesh Swap"
-	bl_options = {'REGISTER', 'UNDO'}
-
-	# used for only occasionally refreshing the 3D scene while mesh swapping
-	counterObject = 0  # used in count
-	countMax = 5  # count compared to this, frequency of refresh (number of objs)
-	runcount = 0  # current counter status of swapped meshes
-
-	# properties for draw
-	meshswap_join: bpy.props.BoolProperty(
-		name="Join same blocks",
-		default=True,
-		description=(
-			"Join together swapped blocks of the same type "
-			"(unless swapped with a group)"))
-	use_dupliverts: bpy.props.BoolProperty(
-		name="Use dupliverts (faster)",
-		default=True,
-		description="Use dupliverts to add meshes")
-	link_groups: bpy.props.BoolProperty(
-		name="Link groups",
-		default=False,
-		description="Link groups instead of appending")
-	prep_materials: bpy.props.BoolProperty(
-		name="Prep materials",
-		default=False,
-		description=(
-			"Automatically apply prep materials (with default settings) "
-			"to blocks added in"))
-	append_layer: bpy.props.IntProperty(
-		name="Append layer",
-		default=20,
-		min=0,
-		max=20,
-		description=(
-			"When groups are appended instead of linked, "
-			"the objects part of the group will be placed in this "
-			"layer, 0 means same as active layers"))
-
-	@classmethod
-	def poll(cls, context):
-		addon_prefs = util.get_user_preferences(context)
-		return addon_prefs.MCprep_exporter_type != "(choose)" and context.mode == 'OBJECT'
-
-	def invoke(self, context, event):
-		return context.window_manager.invoke_props_dialog(
-			self, width=400 * util.ui_scale())
-
-	def draw(self, context):
-		layout = self.layout
-
-		# please save the file first. Not implemented
-		if False:
-			layout.label(
-				text="You must save your blend file before meshswapping",
-				icon="ERROR")
-			return
-
-		layout.label(text="GENERAL SETTINGS")
-		row = layout.row()
-		# row.prop(self,"use_dupliverts") # coming soon
-		row.prop(self, "meshswap_join")
-		row = layout.row()
-		row.prop(self, "link_groups")
-		row.prop(self, "prep_materials")
-		row = layout.row()
-		if not util.bv28():
-			row.prop(self, "append_layer")
-
-		# multi settings, to come
-		# layout.split()
-		# layout.label(text="HOW TO ADD LIGHTS")
-		# row = layout.row()
-		# row.prop(self,"meshswap_lamps", expand=True)
-		# row = layout.row()
-		# row.prop(self,"filmic_values")
-
-		if True:
-			layout.split()
-			col = layout.column()
-			col.scale_y = 0.7
-			col.label(
-				text="WARNING: May take a long time to process!!", icon="ERROR")
-			col.label(
-				text="If you selected a large number of blocks to meshswap,",
-				icon="BLANK1")
-			col.label(
-				text="consider using a smaller area closer to the camera",
-				icon="BLANK1")
-
-	track_function = "meshswap"
-	track_exporter = None
-	@tracking.report_error
-	def execute(self, context):
-		tprep = time.time()
-		addon_prefs = util.get_user_preferences(context)
-		self.track_exporter = addon_prefs.MCprep_exporter_type
-
-		direc = context.scene.meshswap_path
-		if not direc.lower().endswith('.blend'):
-			self.report({'WARNING'}, "Meshswap file must be a .blend!")
-			bpy.ops.mcprep.prompt_reset_spawners('INVOKE_DEFAULT')
-			return {'CANCELLED'}
-
-		if not os.path.isfile(direc):
-			direc = bpy.path.abspath(direc)
-			if not os.path.isfile(direc):
-				# better, actual "error" popup.
-				self.report({'WARNING'}, "Meshswap blend file not found!")
-				bpy.ops.mcprep.prompt_reset_spawners('INVOKE_DEFAULT')
-				return {'CANCELLED'}
-
-		# Assign vars used across operator
-		self.runcount = 0  # counter; if zero by end, raise error nothing matched
-		objList = self.prep_obj_list(context)
-		selList = context.selected_objects  # re-grab having made new objects
-		new_groups = []  # for new imported groups
-		removeList = []  # for objects that should be removed
-		new_objects = []  # all the newly added objects
-
-		# setup the progress bar
-		denom = len(objList)
-		env.log("Meshswap to check over {} objects".format(denom))
-		bpy.context.window_manager.progress_begin(0, 100)
-
-		tprep = time.time() - tprep
-		t0s = []  # start of loop
-		t1s = []  # between prep and face process
-		t2s = []  # between face process and
-		t3s = []  # end of loop
-
-		# primary loop, for each OBJECT needing swapping
-		for iter_index, swap in enumerate(objList):
-			t0s.append(time.time())
-			t1s.append(t0s[-1])
-			t2s.append(t0s[-1])
-			t3s.append(t0s[-1])
-			bpy.context.window_manager.progress_update(iter_index / denom)
-			swapGen = util.nameGeneralize(swap.name)
-			# swapGen = generate.get_mc_canonical_name(swap.name)
-			env.log("Simplified name: {x}".format(x=swapGen))
-			# IMPORTS, gets lists properties, etc
-			swapProps = self.checkExternal(context, swapGen)
-
-			# issue in swapProps, e.g. not a mesh or not in lib or some error
-			if swapProps is False:
-				continue
-
-			if swapProps.get('new_groups'):
-				new_groups += swapProps['new_groups']
-			# special cases, for "extra" mesh pieces we don't want around afterwards
-			if swapProps['removable']:
-				removeList.append(swap)
-				continue
-			# just selecting mesh with same name and if in objList
-			if not (swapProps['meshSwap'] or swapProps['groupSwap']):
-				continue
-
-			env.log(
-				"Swapping '{x}', simplified name '{y}".format(
-					x=swap.name, y=swapGen))
-
-			# loop through each face or "polygon" of mesh, throw out invalids
-			t1s[-1] = time.time()
-			offset = 0.5 if self.track_exporter == 'Mineways' else 0
-			facebook = self.get_face_list(swap, offset)
-
-			if not util.bv28():
-				for obj in context.selected_objects:
-					util.select_set(obj, False)
-
-			# removing duplicates and checking orientation
-			# structure of: "x-y-z":[[x,y,z], [xr, yr, zr]]
-			instance_configs = {}
-			for face in facebook:
-				# updates instance_configs
-				self.proccess_poly_orientations(face, swapProps, swapGen, instance_configs)
-
-			# Primary function for adding the actual instances
-			# Critical path process section!
-			t2s[-1] = time.time()
-			grouped, dupedObj = self.add_instances_with_transforms(
-				context, swap, swapProps, instance_configs)
-			base = swapProps["object"]
-
-			# Having completed adding instances, remove the 'base copy'
-			if not grouped:
-				if base in dupedObj:
-					dupedObj.pop(dupedObj.index(base))
-				if base in selList:  # gaurd for stability, but shouldn't happen
-					selList.pop(selList.index(base))
-				util.obj_unlink_remove(base, True, context)
-
-			if grouped:
-				new_objects += dupedObj  # list
-			elif dupedObj and self.meshswap_join:
-				# join meshes together, carefully removing old selected objects
-				# from selection lists
-				util.set_active_object(context, dupedObj[0])
-				for d in dupedObj:
-					if d.type != 'MESH':
-						continue
-					util.select_set(d, True)
-				if context.mode != "OBJECT":
-					bpy.ops.object.mode_set(mode='OBJECT')
-
-				# to avoid reselection later objects that were joined
-				for obtemp in context.selected_objects:
-					if obtemp in selList:
-						selList.pop(selList.index(obtemp))
-					if obtemp in dupedObj:
-						dupedObj.pop(dupedObj.index(obtemp))
-				bpy.ops.object.join()
-				if context.selected_objects:
-					new_objects.append(context.selected_objects[0])
-				else:
-					env.log("No selected objects after join")
-			else:
-				# no joining, so just directly append to new_objects
-				new_objects += dupedObj  # a list
-
-			removeList.append(swap)
-
-			# Setup for later re-selection and applying no-re-meshswap property
-			for obj in new_objects:
-				if obj in removeList:
-					continue
-				# Setup below is for cross compatibility, in 2.8 & 2.7
-				# where accessing a field on deleted object will raise error
-				# (but, we should have already excluded deleted objects anyways)
-				try:
-					if not hasattr(obj, "users"):
-						continue
-					if not obj.name:  # accessing name itself could cause crash/error
-						continue
-				except ReferenceError:
-					continue
-				selList.append(obj)
-				obj['MCprep_noSwap'] = 1  # property to avoid duplicate future swap
-			t3s[-1] = time.time()
-
-		t4 = time.time()
-		# final re-selection and deletion
-		if self.runcount > 0:
-			for rm in removeList:
-				if rm in selList:
-					# prevent later operations on deleted object
-					selList.pop(selList.index(rm))
-				if rm in new_objects:
-					# prevent later operations on deleted object
-					new_objects.pop(new_objects.index(rm))
-				try:
-					util.obj_unlink_remove(rm, True, context)
-				except:
-					print("Failed to clear user/remove object: " + rm.name)
-
-		for obj in selList:
-			# Risk if object was joined against another object that its data
-			# no longer exists, which can result in a failure e.g. for 2.72
-			# However, pre-work should have prevented interacting with already
-			# deleted object here, so the try/except is more for later blender
-			# versions to fail gracefully just in case
-			try:
-				if not hasattr(obj, "users"):  # can be crashing point pre 2.79(?)
-					continue
-			except ReferenceError:
-				continue
-			util.select_set(obj, True)
-
-		# Create nicer nested organization of meshswapped assets, and excluding
-		# this meshswap group to avoid showing in render. Also move newly
-		# spawned instances into a collection of its own (2.8 only)
-		if util.bv28():
-			swaped_vl = util.get_or_create_viewlayer(context, "Meshswap Render")
-			for obj in new_objects:
-				util.move_to_collection(obj, swaped_vl.collection)
-
-			util.move_assets_to_excluded_layer(context, new_groups)
-
-		# end progress bar, end of primary section
-		bpy.context.window_manager.progress_end()
-		t5 = time.time()
-
-		# run timing calculations
-		if env.very_verbose:
-			loop_prep = sum(t1s) - sum(t0s)
-			face_process = sum(t2s) - sum(t1s)
-			instancing = sum(t3s) - sum(t2s)
-			cleanup = t5 - t4
-			total = tprep + loop_prep + face_process + instancing + cleanup
-			env.log("Total time: {}s, init: {}, prep: {}, poly process: {}, instance:{}, cleanup: {}".format(
-				round(total, 1), round(tprep, 1), round(loop_prep, 1),
-				round(face_process, 1), round(instancing, 1), round(cleanup, 1)))
-
-		if self.runcount == 0:
-			self.report({'ERROR'}, (
-				"Nothing swapped, likely no materials of "
-				"selected objects match the meshswap file objects/groups"))
-			return {'CANCELLED'}
-		elif self.runcount == 1:
-			self.report({'INFO'}, "Swapped 1 object")
-			return {'FINISHED'}
-		self.report({'INFO'}, "Swapped {} objects".format(self.runcount))
-		return {'FINISHED'}
-
-	def prep_obj_list(self, context):
-		"""Initial operator prep to get list of objects to check over"""
-		try:
-			bpy.ops.object.convert(target='MESH')
-		except:
-			pass
-		bpy.ops.mesh.separate(type='MATERIAL')
-
-		# now do type checking and fix any name discrepancies
-		objList = []
-		for obj in context.selected_objects:
-			# ignore non mesh selected objects or objs labeled to not double swap
-			if obj.type != 'MESH' or ("MCprep_noSwap" in obj):
-				continue
-			if not obj.active_material:
-				continue
-			objList.append(obj)
-			# obj.data.name = obj.active_material.name
-			# obj.name = obj.active_material.name
-			if obj.active_material:
-				obj.name = util.nameGeneralize(obj.active_material.name)
-		return objList
-
-	def get_face_list(self, swap, offset):
-		"""Returns list of relevant faces and mapped coordinates.
-
-		Offset is for Mineways to virtually shift all block centers to half ints
-
-		Returns list with each item: n (normal), g (global pos), l (local pos)
-		"""
-		facebook = []
-		for poly in swap.data.polygons:
-			gtmp = util.matmul(
-				swap.matrix_world, mathutils.Vector(poly.center))
-			# even without offset, list this to make values unlinked to mesh
-			g = [gtmp[0] + offset, gtmp[1] + offset, gtmp[2] + offset]
-			n = poly.normal  # in local coordinates
-			tmp2 = poly.center
-			# even without offset, list this
-			l = [tmp2[0] + offset, tmp2[1] + offset, tmp2[2] + offset]
-			if 0.015 < poly.area and poly.area < 0.016:
-				# hack to avoid too many torches show up, both jmc2obj and Mineways
-				continue
-			facebook.append(face_struct(n, g, l))  # g is global, l is local
-		return facebook
-
-	def checkExternal(self, context, name):
-		"""Called for each object in the loop as soon as possible."""
-
-		groupSwap = False
-		meshSwap = False  # if object in both group and mesh swap, group will be used
-		edgeFlush = False  # blocks perfectly on edges, require rotation
-		edgeFloat = False  # floating off edge into air, require rotation ['vines','ladder','lilypad']
-		torchlike = False  # ['torch','redstone_torch_on','redstone_torch_off']
-		removable = False  # to be removed, hard coded.
-		doorlike = False  # appears like a door.
-
-		front_face_rotate = False
-		# rotate mesh with this material's face forward (+y local=default)
-		# for varied positions from exactly center on the block, 1 for Z random too
-		# 1= x,y,z random; 0= only x,y random; 2=rotation random only (vertical)
-		# variance = [ ['tall_grass',1], ['double_plant_grass_bottom',1],
-		# ['flower_yellow',0], ['flower_red',0] ]
-		variance = [False, 0]  # needs to be in this structure
-		new_groups = []  # list of newly added groups in this process
-
-		meshSwapPath = context.scene.meshswap_path
-		rmable = []
-		if self.track_exporter == "jmc2obj":
-			rmable = [
-				'book', 'brewing_stand', 'cactus_bottom', 'cactus_top', 'campfire_fire',
-				'campfire_log_lit', 'door_acacia_upper', 'door_birch_upper',
-				'door_dark_oak_upper', 'door_iron_top', 'door_jungle_upper',
-				'door_spruce_upper', 'door_wood_top', 'double_plant_grass_top',
-				'enchant_table_bottom', 'enchant_table_side', 'furnace_side',
-				'furnace_top', 'pumpkin_side_lit', 'pumpkin_top_lit', 'sunflower_back',
-				'sunflower_front', 'sunflower_top', 'tnt_bottom', 'tnt_side',
-				'torch_flame', 'workbench_back', 'workbench_front'
-			]
-		elif self.track_exporter == "Mineways":
-			rmable = [
-				'acacia_door_top', 'birch_door_top', 'cactus_top', 'campfire_fire',
-				'campfire_log_lit', 'dark_oak_door_top', 'enchanting_table_side',
-				'iron_door_top', 'jungle_door_top', 'oak_door_top',
-				'spruce_door_top', 'sunflower_back', 'sunflower_front',
-				'sunflower_top', 'tall_grass_top', 'tnt_bottom' 'tnt_side'
-			]
-		else:
-			# need to select one of the exporters!
-			return False  # {'CANCELLED'}
-		# delete unnecessary ones first
-		if name in rmable:
-			removable = True
-			env.log("Removable!")
-			return {'removable': removable}
-
-		# check the actual name against the library
-		name = generate.get_mc_canonical_name(name)[0]
-		cache = get_meshswap_cache(context)
-		if name in env.json_data["blocks"]["canon_mapping_block"]:
-			# e.g. remaps entity/chest/normal back to chest
-			name_remap = env.json_data["blocks"]["canon_mapping_block"][name]
-		else:
-			name_remap = None
-
-		if name in cache["groups"] or name in util.collections():
-			groupSwap = True
-		elif name in cache["objects"]:
-			meshSwap = True
-		elif not name_remap:
-			return False
-		elif name_remap in cache["groups"] or name_remap in util.collections():
-			groupSwap = True
-			name = name_remap
-		elif name_remap in cache["objects"]:
-			meshSwap = True
-			name = name_remap
-		else:
-			return False  # if not present, continue
-
-		# now import
-		env.log("about to link, group {} / mesh {}?".format(
-			groupSwap, meshSwap))
-		toLink = self.link_groups
-		for ob in context.selected_objects:
-			util.select_set(ob, False)
-
-		# import: guaranteed to have same name as "appendObj" for the first
-		# instant afterwards.
-
-		# Used to check if to join or not.
-		grouped = False
-		# Need to initialize to something, though this obj not used.
-		importedObj = None
-		groupAppendLayer = self.append_layer
-
-		# for blender 2.8 compatibility
-		if hasattr(bpy.data, "groups"):
-			g_or_c = 'Group'
-		elif hasattr(bpy.data, "collections"):
-			g_or_c = 'Collection'
-
-		if groupSwap:
-			if name not in util.collections():
-				# if group not linked, put appended group data onto the GUI field layer
-				if hasattr(context.scene, "layers"):  # blender 2.7x
-					activeLayers = list(context.scene.layers)
-				else:
-					activeLayers = None
-				if (not toLink) and (groupAppendLayer != 0):
-					x = [False] * 20
-					x[groupAppendLayer - 1] = True
-					if hasattr(context.scene, "layers"):
-						context.scene.layers = x
-
-				# Get prelist of groups/collections to check against afterwards
-				pre_colls = list(util.collections())
-
-				# special cases, make another list for this? number of variants can vary..
-				if name == "torch" or name == "Torch":
-					if name + ".1" not in pre_colls:
-						util.bAppendLink(os.path.join(meshSwapPath, g_or_c), name + ".1", toLink)
-					if name + ".2" not in pre_colls:
-						util.bAppendLink(os.path.join(meshSwapPath, g_or_c), name + ".2", toLink)
-				util.bAppendLink(os.path.join(meshSwapPath, g_or_c), name, toLink)
-
-				if util.bv28():
-					post_colls = list(util.collections())
-					new_groups += list(set(post_colls) - set(pre_colls))
-
-				grouped = True
-				# if activated a different layer, go back to the original ones
-				if hasattr(context.scene, "layers") and activeLayers:
-					context.scene.layers = activeLayers
-				# 2.8 handled later with everything at once
-			grouped = True
-			# set properties
-			for item in util.collections()[name].items():
-				env.log("GROUP PROPS:" + str(item))
-				try:
-					x = item[1].name  # will NOT work if property UI
-				except:
-					x = item[0]  # the name of the property, [1] is the value
-					if x == 'variance':
-						variance = [True, item[1]]
-					elif x == 'edgeFloat':
-						edgeFloat = True
-					elif x == 'doorlike':
-						doorlike = True
-					elif x == 'edgeFlush':
-						edgeFlush = True
-					elif x == 'torchlike':
-						torchlike = True
-					elif x == 'removable':
-						removable = True
-					elif x == 'frontFaceRotate':
-						front_face_rotate = True
-		else:
-			util.bAppendLink(os.path.join(meshSwapPath, 'Object'), name, False)
-			# ## NOTICE: IF THERE IS A DISCREPENCY BETWEEN ASSETS FILE AND WHAT IT SAYS SHOULD
-			# ## BE IN FILE, EG NAME OF MESH TO SWAP CHANGED, INDEX ERROR IS THROWN HERE
-			# ## >> MAKE a more graceful error indication.
-			# filter out non-meshes in case of parent grouping or other pull-ins
-			# env.log("DEBUG - post importing {}, selected objects: {}".format(
-			# 	name, list(bpy.context.selected_objects)), vv_only=True)
-
-			for ob in bpy.context.selected_objects:
-				# 2.79b specific hack to clear brought in empties with the mesh
-				# e.g. in case of animated deformation modifiers via object
-				if ob.type != 'MESH':
-					util.select_set(ob, False)
-			try:
-				importedObj = bpy.context.selected_objects[0]
-			except:
-				# in case nothing selected.. which happens even during selection?
-				return False
-			importedObj["MCprep_noSwap"] = 1
-			# now check properties
-			for item in importedObj.items():
-				try:
-					x = item[1].name  # will NOT work if property UI
-				except:
-					x = item[0]  # the name of the property, [1] is the value
-					if x == 'variance':
-						variance = [True, item[1]]
-					elif x == 'edgeFloat':
-						edgeFloat = True
-					elif x == 'doorlike':
-						doorlike = True
-					elif x == 'edgeFlush':
-						edgeFlush = True
-					elif x == 'torchlike':
-						torchlike = True
-					elif x == 'removable':
-						removable = True
-			for ob in context.selected_objects:
-				util.select_set(ob, False)
-		# #### HERE set the other properties, e.g. variance and edgefloat, now that the obj exists
-		env.log("groupSwap: {}, meshSwap: {}".format(groupSwap, meshSwap))
-		env.log("edgeFloat: {}, variance: {}, torchlike: {}".format(
-			edgeFloat, variance, torchlike))
-		return {
-			'importName': name, 'object': importedObj, 'meshSwap': meshSwap,
-			'groupSwap': groupSwap, 'variance': variance, 'edgeFlush': edgeFlush,
-			'edgeFloat': edgeFloat, 'torchlike': torchlike, 'removable': removable,
-			'doorlike': doorlike, 'new_groups': new_groups}
-
-	def proccess_poly_orientations(self, face, swapProps, swapGen, instance_configs):
-		"""Iterate over individual face, updating instance loc/rotation
-
-		Arguments:
-			face: face struct with n (normal), g (global coord), l (local coord)
-			instance_configs: pass by ref dict of instances to make, with rot and loc info
-		"""
-
-		offset = 0.5 if self.track_exporter == 'Mineways' else 0
-
-		# Transform so centers are half ints (jmc2obj default), from local coords
-		x = round(face.l[0])
-		y = round(face.l[1])
-		z = round(face.l[2])
-
-		# Reverses which block to count 'on edge' for so that the instances
-		# are placed in "front" of where it hangs, as this is how the meshswap
-		# assets are setup (object origin will be in front of the hanging item)
-		outside_hanging = 1 if swapProps['edgeFloat'] else -1
-		# check if face is on unit block boundary (local coord!)
-		if util.face_on_edge(face.l):
-			a = face.n[0] * 0.1 * outside_hanging
-			b = face.n[1] * 0.1 * outside_hanging
-			c = face.n[2] * 0.1 * outside_hanging
-			x = round(face.l[0] + a)
-			y = round(face.l[1] + b)
-			z = round(face.l[2] + c)
-			# print("ON EDGE, BRO! line, "+str(x) +","+str(y)+","+str(z))
-			# print([facebook[ind].l[0], facebook[ind].l[1], facebook[ind].l[2]])
-		else:
-			a, b, c = 0, 0, 0
-
-		instance_key = "{}-{}-{}".format(x, y, z)
-		loc = [x, y, z]
-
-		# ### TORCHES, hack removes duplicates while not removing "edge" floats
-		# if facebook[ind].l[1]+0.5 - math.floor(facebook[ind].l[1]+0.5) < 0.3:
-		# 	#continue if coord. is < 1/3 of block height, to do with torch's base
-		#   #in wrong cube.
-		# 	if not swapProps['edgeFloat']:
-		# 		#continue
-		# 		print("do nothing, this is for jmc2obj")
-		env.log(
-			"Instance:  loc, face.local, face.nrm, hanging offset, if_edgeFloat:",
-			vv_only=True)
-		env.log(
-			str([loc, face.l, face.n, [a, b, c], outside_hanging]),
-			vv_only=True)
-
-		# ## START HACK PATCH, FOR MINEWAYS (single-tex export) double-tall blocks
-		# prevent double high grass... which mineways names sunflowers.
-		hack_check = ["Sunflower", "Iron_Door", "Wooden_Door"]
-		if swapGen in hack_check and "{}-{}-{}".format(x, y - 1, z) in instance_configs:
-			overwrite = -1
-		elif swapGen in hack_check and "{}-{}-{}".format(x, y + 1, z) in instance_configs:
-			# dupList[dupList.index([x,y+1,z])] = [x,y,z]
-			instance_configs["{}-{}-{}".format(x, y + 1, z)][0] = loc  # update loc only
-			overwrite = -1
-		else:
-			overwrite = 0  # 0 = normal, -1 = skip, 1 = overwrite the block below
-		# ## END HACK PATCH
-
-		# rotation value (second append value: 0 means no rotation, rest is 1-4)
-		if overwrite < 0:
-			return
-
-		if instance_key in instance_configs and not swapProps['edgeFloat']:
-			return  # no need to overwrite
-
-		# dupList.append([x,y,z])
-		# check difference from rounding, this gets us the rotation!
-		x_diff = x - face.l[0]
-		z_diff = z - face.l[2]
-
-		# append rotation, exporter dependent
-		if self.track_exporter == "jmc2obj":
-			if swapProps['torchlike']:  # needs fixing
-				if (x_diff > .1 and x_diff < 0.4):
-					rot_type = 1
-				elif (z_diff > .1 and z_diff < 0.4):
-					rot_type = 2
-				elif (x_diff < -.1 and x_diff > -0.4):
-					rot_type = 3
-				elif (z_diff < -.1 and z_diff > -0.4):
-					rot_type = 4
-				else:
-					rot_type = 0
-			elif swapProps['edgeFloat']:
-				env.log("Edge float!", vv_only=True)
-				if (y - face.l[1] < 0):
-					rot_type = 8
-				elif (x_diff > 0.3):
-					rot_type = 7
-				elif (z_diff > 0.3):
-					rot_type = 0
-				elif (z_diff < -0.3):
-					rot_type = 6
-				else:
-					rot_type = 5
-			elif swapProps['edgeFlush']:
-				# actually 6 cases here, can need rotation below...
-				# currently not necessary/used, so not programmed..
-				rot_type = 0
-			elif swapProps['doorlike']:
-				if (y - face.l[1] < 0):
-					rot_type = 8
-				elif (x_diff > 0.3):
-					rot_type = 7
-				elif (z_diff > 0.3):
-					rot_type = 0
-				elif (z_diff < -0.3):
-					rot_type = 6
-				else:
-					rot_type = 5
-			else:
-				rot_type = 0
-		elif self.track_exporter == "Mineways":
-			env.log("checking: {} {}".format(x_diff, z_diff))
-			if swapProps['torchlike']:  # needs fixing
-				env.log("recognized it's a torchlike obj..")
-				if (x_diff > .1 and x_diff < 0.6):
-					rot_type = 1
-				elif (z_diff > .1 and z_diff < 0.6):
-					rot_type = 2
-				elif (x_diff < -.1 and x_diff > -0.6):
-					rot_type = 3
-				elif (z_diff < -.1 and z_diff > -0.6):
-					rot_type = 4
-				else:
-					rot_type = 0
-			elif swapProps['edgeFloat']:
-				if (y - face.l[1] < 0):
-					rot_type = 8
-				elif (x_diff > 0.3):
-					rot_type = 7
-				elif (z_diff > 0.3):
-					rot_type = 0
-				elif (z_diff < -0.3):
-					rot_type = 6
-				else:
-					rot_type = 5
-			elif swapProps['edgeFlush']:
-				# actually 6 cases here, can need rotation below...
-				# currently not necessary/used, so not programmed..
-				rot_type = 0
-			elif swapProps['doorlike']:
-				if (y - face.l[1] < 0):
-					rot_type = 8
-				elif (x_diff > 0.3):
-					rot_type = 7
-				elif (z_diff > 0.3):
-					rot_type = 0
-				elif (z_diff < -0.3):
-					rot_type = 6
-				else:
-					rot_type = 5
-			else:
-				rot_type = 0
-		else:
-			rot_type = 0
-
-		# update the instance ref for this face
-		offset = -0.5 if self.track_exporter == 'Mineways' else 0
-		loc_unoffset = [pos + offset for pos in loc]
-		instance_configs[instance_key] = [loc_unoffset, rot_type]
-
-	def add_instances_with_transforms(self, context, swap, swapProps, instance_configs):
-		"""Creates all block instances for a single object.
-
-		Will add and apply rotations, add loc variances, and run random group
-		imports if any relevant.
-		"""
-
-		base = swapProps["object"]
-		grouped = swapProps["groupSwap"]
-		dupedObj = []  # duplicating, rotating and moving
-
-		for instance_key in list(instance_configs):
-			loc_local, rot = instance_configs[instance_key]
-
-			# ## HIGH COMPUTATION/CRITICAL SECTION
-			# refresh the scene every once in awhile
-			self.counterObject += 1
-			self.runcount += 1
-			if (self.counterObject > self.countMax):
-				self.counterObject = 0
-				if not util.bv28():
-					pass
-					# bpy.ops.wm.redraw_timer(type='DRAW_WIN_SWAP', iterations=1)
-				elif hasattr(context, "view_layer"):
-					context.view_layer.update()  # but does not redraw ui
-
-			loc = util.matmul(swap.matrix_world, mathutils.Vector(loc_local))
-
-			# loc = swap.matrix_world*mathutils.Vector(set) #local to global
-			if grouped:
-				# definition for randimization, defined at top!
-				randGroup = util.randomizeMeshSawp(swapProps['importName'], 3)
-				env.log("Rand group: {}".format(randGroup))
-				new_ob = util.addGroupInstance(randGroup, loc)
-				if hasattr(new_ob, "empty_draw_size"):
-					new_ob.empty_draw_size = 0.25
-				else:
-					new_ob.empty_display_size = 0.25
-				dupedObj.append(new_ob)
-			else:
-				# TODO: Change to adding a single vertex, dupliverts
-				new_ob = util.obj_copy(base, context)
-				new_ob.location = mathutils.Vector(loc)
-				util.select_set(new_ob, True)  # needed?
-				dupedObj.append(new_ob)
-
-			# obj = new_ob # bpy.context.selected_objects[-1]
-			# do extra transformations now as necessary
-			new_ob.rotation_euler = swap.rotation_euler
-
-			# special case of un-applied,
-			# 90(+/- 0.01)-0-0 rotation on source (y-up conversion)
-			checkcon = swap.rotation_euler[0] >= math.pi / 2 - .01
-			checkcon &= swap.rotation_euler[0] <= math.pi / 2 + .01
-			checkcon &= swap.rotation_euler[1] == 0
-			checkcon &= swap.rotation_euler[2] == 0
-			if checkcon:
-				new_ob.rotation_euler[0] -= math.pi / 2
-			new_ob.scale = swap.scale
-
-			# rotation/translation for walls, assumes last added object still selected
-			x, y, offset, rotValue, z = 0, 0, 0.28, 0.436332, 0.12
-
-			if rot == 1:
-				# torch rotation 1
-				x = -offset
-				new_ob.location += mathutils.Vector((x, y, z))
-				new_ob.rotation_euler[1] += rotValue
-			elif rot == 2:
-				# torch rotation 2
-				y = offset
-				new_ob.location += mathutils.Vector((x, y, z))
-				new_ob.rotation_euler[0] += rotValue
-			elif rot == 3:
-				# torch rotation 3
-				x = offset
-				new_ob.location += mathutils.Vector((x, y, z))
-				new_ob.rotation_euler[1] -= rotValue
-			elif rot == 4:
-				# torch rotation 4
-				y = -offset
-				new_ob.location += mathutils.Vector((x, y, z))
-				new_ob.rotation_euler[0] -= rotValue
-			elif rot == 5:
-				# edge block rotation 1
-				new_ob.rotation_euler[2] += -math.pi / 2
-			elif rot == 6:
-				# edge block rotation 2
-				new_ob.rotation_euler[2] += math.pi
-			elif rot == 7:
-				# edge block rotation 3
-				new_ob.rotation_euler[2] += math.pi / 2
-			elif rot == 8:
-				# edge block rotation 4 (ceiling, not 'keep same')
-				new_ob.rotation_euler[0] += math.pi / 2
-
-			# extra variance to break up regularity, e.g. for tall grass
-			# first, xy and z variance
-			if [True, 1] == swapProps['variance']:
-				x = (random.random() - 0.5) * 0.5
-				y = (random.random() - 0.5) * 0.5
-				z = (random.random() / 2 - 0.5) * 0.6
-				new_ob.location += mathutils.Vector((x, y, z))
-			# now for just xy variance, base stays the same
-			elif [True, 0] == swapProps['variance']:  # for non-z variance
-				# values LOWER than *1.0 make it less variable
-				x = (random.random() - 0.5) * 0.5
-				y = (random.random() - 0.5) * 0.5
-				new_ob.location += mathutils.Vector((x, y, 0))
-
-			# Clear selection before moving on with next iteration
-			for ob in context.selected_objects:
-				if util.bv28():
-					continue
-				util.select_set(ob, False)
-		return grouped, dupedObj
-
-	def offsetByHalf(self, obj):
-		if obj.type != 'MESH':
-			return
-		env.log("doing offset")
-		active = bpy.context.object  # preserve current active
-		util.set_active_object(bpy.context, obj)
-		bpy.ops.object.mode_set(mode='EDIT')
-		bpy.ops.mesh.select_all(action='SELECT')
-		bpy.ops.transform.translate(value=(0.5, 0.5, 0.5))
-		bpy.ops.object.mode_set(mode='OBJECT')
-		obj.location[0] -= .5
-		obj.location[1] -= .5
-		obj.location[2] -= .5
-		util.set_active_object(bpy.context, active)
+    """Swap minecraft objects from world imports for custom 3D models in the according meshSwap blend file"""
+
+    bl_idname = "mcprep.meshswap"
+    bl_label = "Mesh Swap"
+    bl_options = {"REGISTER", "UNDO"}
+
+    # used for only occasionally refreshing the 3D scene while mesh swapping
+    counterObject = 0  # used in count
+    countMax = 5  # count compared to this, frequency of refresh (number of objs)
+    runcount = 0  # current counter status of swapped meshes
+
+    # properties for draw
+    meshswap_join: bpy.props.BoolProperty(
+        name="Join same blocks",
+        default=True,
+        description=(
+            "Join together swapped blocks of the same type "
+            "(unless swapped with a group)"
+        ),
+    )
+    use_dupliverts: bpy.props.BoolProperty(
+        name="Use dupliverts (faster)",
+        default=True,
+        description="Use dupliverts to add meshes",
+    )
+    link_groups: bpy.props.BoolProperty(
+        name="Link groups",
+        default=False,
+        description="Link groups instead of appending",
+    )
+    prep_materials: bpy.props.BoolProperty(
+        name="Prep materials",
+        default=False,
+        description=(
+            "Automatically apply prep materials (with default settings) "
+            "to blocks added in"
+        ),
+    )
+    append_layer: bpy.props.IntProperty(
+        name="Append layer",
+        default=20,
+        min=0,
+        max=20,
+        description=(
+            "When groups are appended instead of linked, "
+            "the objects part of the group will be placed in this "
+            "layer, 0 means same as active layers"
+        ),
+    )
+
+    @classmethod
+    def poll(cls, context):
+        addon_prefs = util.get_user_preferences(context)
+        return (
+            addon_prefs.MCprep_exporter_type != "(choose)" and context.mode == "OBJECT"
+        )
+
+    def invoke(self, context, event):
+        return context.window_manager.invoke_props_dialog(
+            self, width=400 * util.ui_scale()
+        )
+
+    def draw(self, context):
+        layout = self.layout
+
+        # please save the file first. Not implemented
+        if False:
+            layout.label(
+                text="You must save your blend file before meshswapping", icon="ERROR"
+            )
+            return
+
+        layout.label(text="GENERAL SETTINGS")
+        row = layout.row()
+        # row.prop(self,"use_dupliverts") # coming soon
+        row.prop(self, "meshswap_join")
+        row = layout.row()
+        row.prop(self, "link_groups")
+        row.prop(self, "prep_materials")
+        row = layout.row()
+        if not util.bv28():
+            row.prop(self, "append_layer")
+
+        # multi settings, to come
+        # layout.split()
+        # layout.label(text="HOW TO ADD LIGHTS")
+        # row = layout.row()
+        # row.prop(self,"meshswap_lamps", expand=True)
+        # row = layout.row()
+        # row.prop(self,"filmic_values")
+
+        if True:
+            layout.split()
+            col = layout.column()
+            col.scale_y = 0.7
+            col.label(text="WARNING: May take a long time to process!!", icon="ERROR")
+            col.label(
+                text="If you selected a large number of blocks to meshswap,",
+                icon="BLANK1",
+            )
+            col.label(
+                text="consider using a smaller area closer to the camera", icon="BLANK1"
+            )
+
+    track_function = "meshswap"
+    track_exporter = None
+
+    @tracking.report_error
+    def execute(self, context):
+        tprep = time.time()
+        addon_prefs = util.get_user_preferences(context)
+        self.track_exporter = addon_prefs.MCprep_exporter_type
+
+        direc = context.scene.meshswap_path
+        if not direc.lower().endswith(".blend"):
+            self.report({"WARNING"}, "Meshswap file must be a .blend!")
+            bpy.ops.mcprep.prompt_reset_spawners("INVOKE_DEFAULT")
+            return {"CANCELLED"}
+
+        if not os.path.isfile(direc):
+            direc = bpy.path.abspath(direc)
+            if not os.path.isfile(direc):
+                # better, actual "error" popup.
+                self.report({"WARNING"}, "Meshswap blend file not found!")
+                bpy.ops.mcprep.prompt_reset_spawners("INVOKE_DEFAULT")
+                return {"CANCELLED"}
+
+        # Assign vars used across operator
+        self.runcount = 0  # counter; if zero by end, raise error nothing matched
+        objList = self.prep_obj_list(context)
+        selList = context.selected_objects  # re-grab having made new objects
+        new_groups = []  # for new imported groups
+        removeList = []  # for objects that should be removed
+        new_objects = []  # all the newly added objects
+
+        # setup the progress bar
+        denom = len(objList)
+        env.log("Meshswap to check over {} objects".format(denom))
+        bpy.context.window_manager.progress_begin(0, 100)
+
+        tprep = time.time() - tprep
+        t0s = []  # start of loop
+        t1s = []  # between prep and face process
+        t2s = []  # between face process and
+        t3s = []  # end of loop
+
+        # primary loop, for each OBJECT needing swapping
+        for iter_index, swap in enumerate(objList):
+            t0s.append(time.time())
+            t1s.append(t0s[-1])
+            t2s.append(t0s[-1])
+            t3s.append(t0s[-1])
+            bpy.context.window_manager.progress_update(iter_index / denom)
+            swapGen = util.nameGeneralize(swap.name)
+            # swapGen = generate.get_mc_canonical_name(swap.name)
+            env.log("Simplified name: {x}".format(x=swapGen))
+            # IMPORTS, gets lists properties, etc
+            swapProps = self.checkExternal(context, swapGen)
+
+            # issue in swapProps, e.g. not a mesh or not in lib or some error
+            if swapProps is False:
+                continue
+
+            if swapProps.get("new_groups"):
+                new_groups += swapProps["new_groups"]
+            # special cases, for "extra" mesh pieces we don't want around afterwards
+            if swapProps["removable"]:
+                removeList.append(swap)
+                continue
+            # just selecting mesh with same name and if in objList
+            if not (swapProps["meshSwap"] or swapProps["groupSwap"]):
+                continue
+
+            env.log(
+                "Swapping '{x}', simplified name '{y}".format(x=swap.name, y=swapGen)
+            )
+
+            # loop through each face or "polygon" of mesh, throw out invalids
+            t1s[-1] = time.time()
+            offset = 0.5 if self.track_exporter == "Mineways" else 0
+            facebook = self.get_face_list(swap, offset)
+
+            if not util.bv28():
+                for obj in context.selected_objects:
+                    util.select_set(obj, False)
+
+            # removing duplicates and checking orientation
+            # structure of: "x-y-z":[[x,y,z], [xr, yr, zr]]
+            instance_configs = {}
+            for face in facebook:
+                # updates instance_configs
+                self.proccess_poly_orientations(
+                    face, swapProps, swapGen, instance_configs
+                )
+
+            # Primary function for adding the actual instances
+            # Critical path process section!
+            t2s[-1] = time.time()
+            grouped, dupedObj = self.add_instances_with_transforms(
+                context, swap, swapProps, instance_configs
+            )
+            base = swapProps["object"]
+
+            # Having completed adding instances, remove the 'base copy'
+            if not grouped:
+                if base in dupedObj:
+                    dupedObj.pop(dupedObj.index(base))
+                if base in selList:  # gaurd for stability, but shouldn't happen
+                    selList.pop(selList.index(base))
+                util.obj_unlink_remove(base, True, context)
+
+            if grouped:
+                new_objects += dupedObj  # list
+            elif dupedObj and self.meshswap_join:
+                # join meshes together, carefully removing old selected objects
+                # from selection lists
+                util.set_active_object(context, dupedObj[0])
+                for d in dupedObj:
+                    if d.type != "MESH":
+                        continue
+                    util.select_set(d, True)
+                if context.mode != "OBJECT":
+                    bpy.ops.object.mode_set(mode="OBJECT")
+
+                # to avoid reselection later objects that were joined
+                for obtemp in context.selected_objects:
+                    if obtemp in selList:
+                        selList.pop(selList.index(obtemp))
+                    if obtemp in dupedObj:
+                        dupedObj.pop(dupedObj.index(obtemp))
+                bpy.ops.object.join()
+                if context.selected_objects:
+                    new_objects.append(context.selected_objects[0])
+                else:
+                    env.log("No selected objects after join")
+            else:
+                # no joining, so just directly append to new_objects
+                new_objects += dupedObj  # a list
+
+            removeList.append(swap)
+
+            # Setup for later re-selection and applying no-re-meshswap property
+            for obj in new_objects:
+                if obj in removeList:
+                    continue
+                # Setup below is for cross compatibility, in 2.8 & 2.7
+                # where accessing a field on deleted object will raise error
+                # (but, we should have already excluded deleted objects anyways)
+                try:
+                    if not hasattr(obj, "users"):
+                        continue
+                    if not obj.name:  # accessing name itself could cause crash/error
+                        continue
+                except ReferenceError:
+                    continue
+                selList.append(obj)
+                obj["MCprep_noSwap"] = 1  # property to avoid duplicate future swap
+            t3s[-1] = time.time()
+
+        t4 = time.time()
+        # final re-selection and deletion
+        if self.runcount > 0:
+            for rm in removeList:
+                if rm in selList:
+                    # prevent later operations on deleted object
+                    selList.pop(selList.index(rm))
+                if rm in new_objects:
+                    # prevent later operations on deleted object
+                    new_objects.pop(new_objects.index(rm))
+                try:
+                    util.obj_unlink_remove(rm, True, context)
+                except:
+                    print("Failed to clear user/remove object: " + rm.name)
+
+        for obj in selList:
+            # Risk if object was joined against another object that its data
+            # no longer exists, which can result in a failure e.g. for 2.72
+            # However, pre-work should have prevented interacting with already
+            # deleted object here, so the try/except is more for later blender
+            # versions to fail gracefully just in case
+            try:
+                if not hasattr(obj, "users"):  # can be crashing point pre 2.79(?)
+                    continue
+            except ReferenceError:
+                continue
+            util.select_set(obj, True)
+
+        # Create nicer nested organization of meshswapped assets, and excluding
+        # this meshswap group to avoid showing in render. Also move newly
+        # spawned instances into a collection of its own (2.8 only)
+        if util.bv28():
+            swaped_vl = util.get_or_create_viewlayer(context, "Meshswap Render")
+            for obj in new_objects:
+                util.move_to_collection(obj, swaped_vl.collection)
+
+            util.move_assets_to_excluded_layer(context, new_groups)
+
+        # end progress bar, end of primary section
+        bpy.context.window_manager.progress_end()
+        t5 = time.time()
+
+        # run timing calculations
+        if env.very_verbose:
+            loop_prep = sum(t1s) - sum(t0s)
+            face_process = sum(t2s) - sum(t1s)
+            instancing = sum(t3s) - sum(t2s)
+            cleanup = t5 - t4
+            total = tprep + loop_prep + face_process + instancing + cleanup
+            env.log(
+                "Total time: {}s, init: {}, prep: {}, poly process: {}, instance:{}, cleanup: {}".format(
+                    round(total, 1),
+                    round(tprep, 1),
+                    round(loop_prep, 1),
+                    round(face_process, 1),
+                    round(instancing, 1),
+                    round(cleanup, 1),
+                )
+            )
+
+        if self.runcount == 0:
+            self.report(
+                {"ERROR"},
+                (
+                    "Nothing swapped, likely no materials of "
+                    "selected objects match the meshswap file objects/groups"
+                ),
+            )
+            return {"CANCELLED"}
+        elif self.runcount == 1:
+            self.report({"INFO"}, "Swapped 1 object")
+            return {"FINISHED"}
+        self.report({"INFO"}, "Swapped {} objects".format(self.runcount))
+        return {"FINISHED"}
+
+    def prep_obj_list(self, context):
+        """Initial operator prep to get list of objects to check over"""
+        try:
+            bpy.ops.object.convert(target="MESH")
+        except:
+            pass
+        bpy.ops.mesh.separate(type="MATERIAL")
+
+        # now do type checking and fix any name discrepancies
+        objList = []
+        for obj in context.selected_objects:
+            # ignore non mesh selected objects or objs labeled to not double swap
+            if obj.type != "MESH" or ("MCprep_noSwap" in obj):
+                continue
+            if not obj.active_material:
+                continue
+            objList.append(obj)
+            # obj.data.name = obj.active_material.name
+            # obj.name = obj.active_material.name
+            if obj.active_material:
+                obj.name = util.nameGeneralize(obj.active_material.name)
+        return objList
+
+    def get_face_list(self, swap, offset):
+        """Returns list of relevant faces and mapped coordinates.
+
+        Offset is for Mineways to virtually shift all block centers to half ints
+
+        Returns list with each item: n (normal), g (global pos), l (local pos)
+        """
+        facebook = []
+        for poly in swap.data.polygons:
+            gtmp = util.matmul(swap.matrix_world, mathutils.Vector(poly.center))
+            # even without offset, list this to make values unlinked to mesh
+            g = [gtmp[0] + offset, gtmp[1] + offset, gtmp[2] + offset]
+            n = poly.normal  # in local coordinates
+            tmp2 = poly.center
+            # even without offset, list this
+            l = [tmp2[0] + offset, tmp2[1] + offset, tmp2[2] + offset]
+            if 0.015 < poly.area and poly.area < 0.016:
+                # hack to avoid too many torches show up, both jmc2obj and Mineways
+                continue
+            facebook.append(face_struct(n, g, l))  # g is global, l is local
+        return facebook
+
+    def checkExternal(self, context, name):
+        """Called for each object in the loop as soon as possible."""
+
+        groupSwap = False
+        meshSwap = False  # if object in both group and mesh swap, group will be used
+        edgeFlush = False  # blocks perfectly on edges, require rotation
+        edgeFloat = False  # floating off edge into air, require rotation ['vines','ladder','lilypad']
+        torchlike = False  # ['torch','redstone_torch_on','redstone_torch_off']
+        removable = False  # to be removed, hard coded.
+        doorlike = False  # appears like a door.
+
+        front_face_rotate = False
+        # rotate mesh with this material's face forward (+y local=default)
+        # for varied positions from exactly center on the block, 1 for Z random too
+        # 1= x,y,z random; 0= only x,y random; 2=rotation random only (vertical)
+        # variance = [ ['tall_grass',1], ['double_plant_grass_bottom',1],
+        # ['flower_yellow',0], ['flower_red',0] ]
+        variance = [False, 0]  # needs to be in this structure
+        new_groups = []  # list of newly added groups in this process
+
+        meshSwapPath = context.scene.meshswap_path
+        rmable = []
+        if self.track_exporter == "jmc2obj":
+            rmable = [
+                "book",
+                "brewing_stand",
+                "cactus_bottom",
+                "cactus_top",
+                "campfire_fire",
+                "campfire_log_lit",
+                "door_acacia_upper",
+                "door_birch_upper",
+                "door_dark_oak_upper",
+                "door_iron_top",
+                "door_jungle_upper",
+                "door_spruce_upper",
+                "door_wood_top",
+                "double_plant_grass_top",
+                "enchant_table_bottom",
+                "enchant_table_side",
+                "furnace_side",
+                "furnace_top",
+                "pumpkin_side_lit",
+                "pumpkin_top_lit",
+                "sunflower_back",
+                "sunflower_front",
+                "sunflower_top",
+                "tnt_bottom",
+                "tnt_side",
+                "torch_flame",
+                "workbench_back",
+                "workbench_front",
+            ]
+        elif self.track_exporter == "Mineways":
+            rmable = [
+                "acacia_door_top",
+                "birch_door_top",
+                "cactus_top",
+                "campfire_fire",
+                "campfire_log_lit",
+                "dark_oak_door_top",
+                "enchanting_table_side",
+                "iron_door_top",
+                "jungle_door_top",
+                "oak_door_top",
+                "spruce_door_top",
+                "sunflower_back",
+                "sunflower_front",
+                "sunflower_top",
+                "tall_grass_top",
+                "tnt_bottom" "tnt_side",
+            ]
+        else:
+            # need to select one of the exporters!
+            return False  # {'CANCELLED'}
+        # delete unnecessary ones first
+        if name in rmable:
+            removable = True
+            env.log("Removable!")
+            return {"removable": removable}
+
+        # check the actual name against the library
+        name = generate.get_mc_canonical_name(name)[0]
+        cache = get_meshswap_cache(context)
+        if name in env.json_data["blocks"]["canon_mapping_block"]:
+            # e.g. remaps entity/chest/normal back to chest
+            name_remap = env.json_data["blocks"]["canon_mapping_block"][name]
+        else:
+            name_remap = None
+
+        if name in cache["groups"] or name in util.collections():
+            groupSwap = True
+        elif name in cache["objects"]:
+            meshSwap = True
+        elif not name_remap:
+            return False
+        elif name_remap in cache["groups"] or name_remap in util.collections():
+            groupSwap = True
+            name = name_remap
+        elif name_remap in cache["objects"]:
+            meshSwap = True
+            name = name_remap
+        else:
+            return False  # if not present, continue
+
+        # now import
+        env.log("about to link, group {} / mesh {}?".format(groupSwap, meshSwap))
+        toLink = self.link_groups
+        for ob in context.selected_objects:
+            util.select_set(ob, False)
+
+        # import: guaranteed to have same name as "appendObj" for the first
+        # instant afterwards.
+
+        # Used to check if to join or not.
+        grouped = False
+        # Need to initialize to something, though this obj not used.
+        importedObj = None
+        groupAppendLayer = self.append_layer
+
+        # for blender 2.8 compatibility
+        if hasattr(bpy.data, "groups"):
+            g_or_c = "Group"
+        elif hasattr(bpy.data, "collections"):
+            g_or_c = "Collection"
+
+        if groupSwap:
+            if name not in util.collections():
+                # if group not linked, put appended group data onto the GUI field layer
+                if hasattr(context.scene, "layers"):  # blender 2.7x
+                    activeLayers = list(context.scene.layers)
+                else:
+                    activeLayers = None
+                if (not toLink) and (groupAppendLayer != 0):
+                    x = [False] * 20
+                    x[groupAppendLayer - 1] = True
+                    if hasattr(context.scene, "layers"):
+                        context.scene.layers = x
+
+                # Get prelist of groups/collections to check against afterwards
+                pre_colls = list(util.collections())
+
+                # special cases, make another list for this? number of variants can vary..
+                if name == "torch" or name == "Torch":
+                    if name + ".1" not in pre_colls:
+                        util.bAppendLink(
+                            os.path.join(meshSwapPath, g_or_c), name + ".1", toLink
+                        )
+                    if name + ".2" not in pre_colls:
+                        util.bAppendLink(
+                            os.path.join(meshSwapPath, g_or_c), name + ".2", toLink
+                        )
+                util.bAppendLink(os.path.join(meshSwapPath, g_or_c), name, toLink)
+
+                if util.bv28():
+                    post_colls = list(util.collections())
+                    new_groups += list(set(post_colls) - set(pre_colls))
+
+                grouped = True
+                # if activated a different layer, go back to the original ones
+                if hasattr(context.scene, "layers") and activeLayers:
+                    context.scene.layers = activeLayers
+                # 2.8 handled later with everything at once
+            grouped = True
+            # set properties
+            for item in util.collections()[name].items():
+                env.log("GROUP PROPS:" + str(item))
+                try:
+                    x = item[1].name  # will NOT work if property UI
+                except:
+                    x = item[0]  # the name of the property, [1] is the value
+                    if x == "variance":
+                        variance = [True, item[1]]
+                    elif x == "edgeFloat":
+                        edgeFloat = True
+                    elif x == "doorlike":
+                        doorlike = True
+                    elif x == "edgeFlush":
+                        edgeFlush = True
+                    elif x == "torchlike":
+                        torchlike = True
+                    elif x == "removable":
+                        removable = True
+                    elif x == "frontFaceRotate":
+                        front_face_rotate = True
+        else:
+            util.bAppendLink(os.path.join(meshSwapPath, "Object"), name, False)
+            # ## NOTICE: IF THERE IS A DISCREPENCY BETWEEN ASSETS FILE AND WHAT IT SAYS SHOULD
+            # ## BE IN FILE, EG NAME OF MESH TO SWAP CHANGED, INDEX ERROR IS THROWN HERE
+            # ## >> MAKE a more graceful error indication.
+            # filter out non-meshes in case of parent grouping or other pull-ins
+            # env.log("DEBUG - post importing {}, selected objects: {}".format(
+            # 	name, list(bpy.context.selected_objects)), vv_only=True)
+
+            for ob in bpy.context.selected_objects:
+                # 2.79b specific hack to clear brought in empties with the mesh
+                # e.g. in case of animated deformation modifiers via object
+                if ob.type != "MESH":
+                    util.select_set(ob, False)
+            try:
+                importedObj = bpy.context.selected_objects[0]
+            except:
+                # in case nothing selected.. which happens even during selection?
+                return False
+            importedObj["MCprep_noSwap"] = 1
+            # now check properties
+            for item in importedObj.items():
+                try:
+                    x = item[1].name  # will NOT work if property UI
+                except:
+                    x = item[0]  # the name of the property, [1] is the value
+                    if x == "variance":
+                        variance = [True, item[1]]
+                    elif x == "edgeFloat":
+                        edgeFloat = True
+                    elif x == "doorlike":
+                        doorlike = True
+                    elif x == "edgeFlush":
+                        edgeFlush = True
+                    elif x == "torchlike":
+                        torchlike = True
+                    elif x == "removable":
+                        removable = True
+            for ob in context.selected_objects:
+                util.select_set(ob, False)
+        # #### HERE set the other properties, e.g. variance and edgefloat, now that the obj exists
+        env.log("groupSwap: {}, meshSwap: {}".format(groupSwap, meshSwap))
+        env.log(
+            "edgeFloat: {}, variance: {}, torchlike: {}".format(
+                edgeFloat, variance, torchlike
+            )
+        )
+        return {
+            "importName": name,
+            "object": importedObj,
+            "meshSwap": meshSwap,
+            "groupSwap": groupSwap,
+            "variance": variance,
+            "edgeFlush": edgeFlush,
+            "edgeFloat": edgeFloat,
+            "torchlike": torchlike,
+            "removable": removable,
+            "doorlike": doorlike,
+            "new_groups": new_groups,
+        }
+
+    def proccess_poly_orientations(self, face, swapProps, swapGen, instance_configs):
+        """Iterate over individual face, updating instance loc/rotation
+
+        Arguments:
+                face: face struct with n (normal), g (global coord), l (local coord)
+                instance_configs: pass by ref dict of instances to make, with rot and loc info
+        """
+
+        offset = 0.5 if self.track_exporter == "Mineways" else 0
+
+        # Transform so centers are half ints (jmc2obj default), from local coords
+        x = round(face.l[0])
+        y = round(face.l[1])
+        z = round(face.l[2])
+
+        # Reverses which block to count 'on edge' for so that the instances
+        # are placed in "front" of where it hangs, as this is how the meshswap
+        # assets are setup (object origin will be in front of the hanging item)
+        outside_hanging = 1 if swapProps["edgeFloat"] else -1
+        # check if face is on unit block boundary (local coord!)
+        if util.face_on_edge(face.l):
+            a = face.n[0] * 0.1 * outside_hanging
+            b = face.n[1] * 0.1 * outside_hanging
+            c = face.n[2] * 0.1 * outside_hanging
+            x = round(face.l[0] + a)
+            y = round(face.l[1] + b)
+            z = round(face.l[2] + c)
+            # print("ON EDGE, BRO! line, "+str(x) +","+str(y)+","+str(z))
+            # print([facebook[ind].l[0], facebook[ind].l[1], facebook[ind].l[2]])
+        else:
+            a, b, c = 0, 0, 0
+
+        instance_key = "{}-{}-{}".format(x, y, z)
+        loc = [x, y, z]
+
+        # ### TORCHES, hack removes duplicates while not removing "edge" floats
+        # if facebook[ind].l[1]+0.5 - math.floor(facebook[ind].l[1]+0.5) < 0.3:
+        # 	#continue if coord. is < 1/3 of block height, to do with torch's base
+        #   #in wrong cube.
+        # 	if not swapProps['edgeFloat']:
+        # 		#continue
+        # 		print("do nothing, this is for jmc2obj")
+        env.log(
+            "Instance:  loc, face.local, face.nrm, hanging offset, if_edgeFloat:",
+            vv_only=True,
+        )
+        env.log(str([loc, face.l, face.n, [a, b, c], outside_hanging]), vv_only=True)
+
+        # ## START HACK PATCH, FOR MINEWAYS (single-tex export) double-tall blocks
+        # prevent double high grass... which mineways names sunflowers.
+        hack_check = ["Sunflower", "Iron_Door", "Wooden_Door"]
+        if swapGen in hack_check and "{}-{}-{}".format(x, y - 1, z) in instance_configs:
+            overwrite = -1
+        elif (
+            swapGen in hack_check and "{}-{}-{}".format(x, y + 1, z) in instance_configs
+        ):
+            # dupList[dupList.index([x,y+1,z])] = [x,y,z]
+            instance_configs["{}-{}-{}".format(x, y + 1, z)][0] = loc  # update loc only
+            overwrite = -1
+        else:
+            overwrite = 0  # 0 = normal, -1 = skip, 1 = overwrite the block below
+        # ## END HACK PATCH
+
+        # rotation value (second append value: 0 means no rotation, rest is 1-4)
+        if overwrite < 0:
+            return
+
+        if instance_key in instance_configs and not swapProps["edgeFloat"]:
+            return  # no need to overwrite
+
+        # dupList.append([x,y,z])
+        # check difference from rounding, this gets us the rotation!
+        x_diff = x - face.l[0]
+        z_diff = z - face.l[2]
+
+        # append rotation, exporter dependent
+        if self.track_exporter == "jmc2obj":
+            if swapProps["torchlike"]:  # needs fixing
+                if x_diff > 0.1 and x_diff < 0.4:
+                    rot_type = 1
+                elif z_diff > 0.1 and z_diff < 0.4:
+                    rot_type = 2
+                elif x_diff < -0.1 and x_diff > -0.4:
+                    rot_type = 3
+                elif z_diff < -0.1 and z_diff > -0.4:
+                    rot_type = 4
+                else:
+                    rot_type = 0
+            elif swapProps["edgeFloat"]:
+                env.log("Edge float!", vv_only=True)
+                if y - face.l[1] < 0:
+                    rot_type = 8
+                elif x_diff > 0.3:
+                    rot_type = 7
+                elif z_diff > 0.3:
+                    rot_type = 0
+                elif z_diff < -0.3:
+                    rot_type = 6
+                else:
+                    rot_type = 5
+            elif swapProps["edgeFlush"]:
+                # actually 6 cases here, can need rotation below...
+                # currently not necessary/used, so not programmed..
+                rot_type = 0
+            elif swapProps["doorlike"]:
+                if y - face.l[1] < 0:
+                    rot_type = 8
+                elif x_diff > 0.3:
+                    rot_type = 7
+                elif z_diff > 0.3:
+                    rot_type = 0
+                elif z_diff < -0.3:
+                    rot_type = 6
+                else:
+                    rot_type = 5
+            else:
+                rot_type = 0
+        elif self.track_exporter == "Mineways":
+            env.log("checking: {} {}".format(x_diff, z_diff))
+            if swapProps["torchlike"]:  # needs fixing
+                env.log("recognized it's a torchlike obj..")
+                if x_diff > 0.1 and x_diff < 0.6:
+                    rot_type = 1
+                elif z_diff > 0.1 and z_diff < 0.6:
+                    rot_type = 2
+                elif x_diff < -0.1 and x_diff > -0.6:
+                    rot_type = 3
+                elif z_diff < -0.1 and z_diff > -0.6:
+                    rot_type = 4
+                else:
+                    rot_type = 0
+            elif swapProps["edgeFloat"]:
+                if y - face.l[1] < 0:
+                    rot_type = 8
+                elif x_diff > 0.3:
+                    rot_type = 7
+                elif z_diff > 0.3:
+                    rot_type = 0
+                elif z_diff < -0.3:
+                    rot_type = 6
+                else:
+                    rot_type = 5
+            elif swapProps["edgeFlush"]:
+                # actually 6 cases here, can need rotation below...
+                # currently not necessary/used, so not programmed..
+                rot_type = 0
+            elif swapProps["doorlike"]:
+                if y - face.l[1] < 0:
+                    rot_type = 8
+                elif x_diff > 0.3:
+                    rot_type = 7
+                elif z_diff > 0.3:
+                    rot_type = 0
+                elif z_diff < -0.3:
+                    rot_type = 6
+                else:
+                    rot_type = 5
+            else:
+                rot_type = 0
+        else:
+            rot_type = 0
+
+        # update the instance ref for this face
+        offset = -0.5 if self.track_exporter == "Mineways" else 0
+        loc_unoffset = [pos + offset for pos in loc]
+        instance_configs[instance_key] = [loc_unoffset, rot_type]
+
+    def add_instances_with_transforms(self, context, swap, swapProps, instance_configs):
+        """Creates all block instances for a single object.
+
+        Will add and apply rotations, add loc variances, and run random group
+        imports if any relevant.
+        """
+
+        base = swapProps["object"]
+        grouped = swapProps["groupSwap"]
+        dupedObj = []  # duplicating, rotating and moving
+
+        for instance_key in list(instance_configs):
+            loc_local, rot = instance_configs[instance_key]
+
+            # ## HIGH COMPUTATION/CRITICAL SECTION
+            # refresh the scene every once in awhile
+            self.counterObject += 1
+            self.runcount += 1
+            if self.counterObject > self.countMax:
+                self.counterObject = 0
+                if not util.bv28():
+                    pass
+                    # bpy.ops.wm.redraw_timer(type='DRAW_WIN_SWAP', iterations=1)
+                elif hasattr(context, "view_layer"):
+                    context.view_layer.update()  # but does not redraw ui
+
+            loc = util.matmul(swap.matrix_world, mathutils.Vector(loc_local))
+
+            # loc = swap.matrix_world*mathutils.Vector(set) #local to global
+            if grouped:
+                # definition for randimization, defined at top!
+                randGroup = util.randomizeMeshSawp(swapProps["importName"], 3)
+                env.log("Rand group: {}".format(randGroup))
+                new_ob = util.addGroupInstance(randGroup, loc)
+                if hasattr(new_ob, "empty_draw_size"):
+                    new_ob.empty_draw_size = 0.25
+                else:
+                    new_ob.empty_display_size = 0.25
+                dupedObj.append(new_ob)
+            else:
+                # TODO: Change to adding a single vertex, dupliverts
+                new_ob = util.obj_copy(base, context)
+                new_ob.location = mathutils.Vector(loc)
+                util.select_set(new_ob, True)  # needed?
+                dupedObj.append(new_ob)
+
+            # obj = new_ob # bpy.context.selected_objects[-1]
+            # do extra transformations now as necessary
+            new_ob.rotation_euler = swap.rotation_euler
+
+            # special case of un-applied,
+            # 90(+/- 0.01)-0-0 rotation on source (y-up conversion)
+            checkcon = swap.rotation_euler[0] >= math.pi / 2 - 0.01
+            checkcon &= swap.rotation_euler[0] <= math.pi / 2 + 0.01
+            checkcon &= swap.rotation_euler[1] == 0
+            checkcon &= swap.rotation_euler[2] == 0
+            if checkcon:
+                new_ob.rotation_euler[0] -= math.pi / 2
+            new_ob.scale = swap.scale
+
+            # rotation/translation for walls, assumes last added object still selected
+            x, y, offset, rotValue, z = 0, 0, 0.28, 0.436332, 0.12
+
+            if rot == 1:
+                # torch rotation 1
+                x = -offset
+                new_ob.location += mathutils.Vector((x, y, z))
+                new_ob.rotation_euler[1] += rotValue
+            elif rot == 2:
+                # torch rotation 2
+                y = offset
+                new_ob.location += mathutils.Vector((x, y, z))
+                new_ob.rotation_euler[0] += rotValue
+            elif rot == 3:
+                # torch rotation 3
+                x = offset
+                new_ob.location += mathutils.Vector((x, y, z))
+                new_ob.rotation_euler[1] -= rotValue
+            elif rot == 4:
+                # torch rotation 4
+                y = -offset
+                new_ob.location += mathutils.Vector((x, y, z))
+                new_ob.rotation_euler[0] -= rotValue
+            elif rot == 5:
+                # edge block rotation 1
+                new_ob.rotation_euler[2] += -math.pi / 2
+            elif rot == 6:
+                # edge block rotation 2
+                new_ob.rotation_euler[2] += math.pi
+            elif rot == 7:
+                # edge block rotation 3
+                new_ob.rotation_euler[2] += math.pi / 2
+            elif rot == 8:
+                # edge block rotation 4 (ceiling, not 'keep same')
+                new_ob.rotation_euler[0] += math.pi / 2
+
+            # extra variance to break up regularity, e.g. for tall grass
+            # first, xy and z variance
+            if [True, 1] == swapProps["variance"]:
+                x = (random.random() - 0.5) * 0.5
+                y = (random.random() - 0.5) * 0.5
+                z = (random.random() / 2 - 0.5) * 0.6
+                new_ob.location += mathutils.Vector((x, y, z))
+            # now for just xy variance, base stays the same
+            elif [True, 0] == swapProps["variance"]:  # for non-z variance
+                # values LOWER than *1.0 make it less variable
+                x = (random.random() - 0.5) * 0.5
+                y = (random.random() - 0.5) * 0.5
+                new_ob.location += mathutils.Vector((x, y, 0))
+
+            # Clear selection before moving on with next iteration
+            for ob in context.selected_objects:
+                if util.bv28():
+                    continue
+                util.select_set(ob, False)
+        return grouped, dupedObj
+
+    def offsetByHalf(self, obj):
+        if obj.type != "MESH":
+            return
+        env.log("doing offset")
+        active = bpy.context.object  # preserve current active
+        util.set_active_object(bpy.context, obj)
+        bpy.ops.object.mode_set(mode="EDIT")
+        bpy.ops.mesh.select_all(action="SELECT")
+        bpy.ops.transform.translate(value=(0.5, 0.5, 0.5))
+        bpy.ops.object.mode_set(mode="OBJECT")
+        obj.location[0] -= 0.5
+        obj.location[1] -= 0.5
+        obj.location[2] -= 0.5
+        util.set_active_object(bpy.context, active)
 
 
 class MCPREP_OT_fix_mineways_scale(bpy.types.Operator):
-	"""Quick upscaling of Mineways import by 10 for meshswapping"""
-	bl_idname = "object.fixmeshswapsize"
-	bl_label = "Mineways quick upscale"
-	bl_options = {'REGISTER', 'UNDO'}
+    """Quick upscaling of Mineways import by 10 for meshswapping"""
 
-	@tracking.report_error
-	def execute(self, context):
-		env.log("Attempting to fix Mineways scaling for meshswap")
+    bl_idname = "object.fixmeshswapsize"
+    bl_label = "Mineways quick upscale"
+    bl_options = {"REGISTER", "UNDO"}
 
-		# get cursor loc first? shouldn't matter which mode/location though
-		tmp_loc = util.get_cuser_location(context)
-		if hasattr(context.space_data, "pivot_point"):
-			tmp = context.space_data.pivot_point
-			bpy.context.space_data.pivot_point = 'CURSOR'
-		else:
-			tmp = context.scene.tool_settings.transform_pivot_point
-			context.scene.tool_settings.transform_pivot_point = 'CURSOR'
-		util.set_cuser_location((0, 0, 0), context)
+    @tracking.report_error
+    def execute(self, context):
+        env.log("Attempting to fix Mineways scaling for meshswap")
 
-		bpy.ops.transform.resize(value=(10, 10, 10))
-		bpy.ops.object.transform_apply(location=False, rotation=False, scale=True)
+        # get cursor loc first? shouldn't matter which mode/location though
+        tmp_loc = util.get_cuser_location(context)
+        if hasattr(context.space_data, "pivot_point"):
+            tmp = context.space_data.pivot_point
+            bpy.context.space_data.pivot_point = "CURSOR"
+        else:
+            tmp = context.scene.tool_settings.transform_pivot_point
+            context.scene.tool_settings.transform_pivot_point = "CURSOR"
+        util.set_cuser_location((0, 0, 0), context)
 
-		if hasattr(context.space_data, "pivot_point"):
-			bpy.context.space_data.pivot_point = tmp
-		else:
-			context.scene.tool_settings.transform_pivot_point = tmp
-		util.set_cuser_location(tmp_loc, context)
-		return {'FINISHED'}
+        bpy.ops.transform.resize(value=(10, 10, 10))
+        bpy.ops.object.transform_apply(location=False, rotation=False, scale=True)
+
+        if hasattr(context.space_data, "pivot_point"):
+            bpy.context.space_data.pivot_point = tmp
+        else:
+            context.scene.tool_settings.transform_pivot_point = tmp
+        util.set_cuser_location(tmp_loc, context)
+        return {"FINISHED"}
 
 
 # -----------------------------------------------------------------------------
@@ -1340,29 +1423,29 @@ class MCPREP_OT_fix_mineways_scale(bpy.types.Operator):
 
 
 classes = (
-	MCPREP_OT_meshswap_path_reset,
-	MCPREP_OT_meshswap_spawner,
-	MCPREP_OT_reload_meshswap,
-	MCPREP_OT_meshswap,
-	MCPREP_OT_fix_mineways_scale,
+    MCPREP_OT_meshswap_path_reset,
+    MCPREP_OT_meshswap_spawner,
+    MCPREP_OT_reload_meshswap,
+    MCPREP_OT_meshswap,
+    MCPREP_OT_fix_mineways_scale,
 )
 
 
 def register():
-	for cls in classes:
-		bpy.utils.register_class(cls)
+    for cls in classes:
+        bpy.utils.register_class(cls)
 
-	global meshswap_cache
-	global meshswap_cache_path
-	meshswap_cache = {}
-	meshswap_cache_path = None
+    global meshswap_cache
+    global meshswap_cache_path
+    meshswap_cache = {}
+    meshswap_cache_path = None
 
 
 def unregister():
-	for cls in reversed(classes):
-		bpy.utils.unregister_class(cls)
+    for cls in reversed(classes):
+        bpy.utils.unregister_class(cls)
 
-	global meshswap_cache
-	global meshswap_cache_path
-	meshswap_cache = {}
-	meshswap_cache_path = None
+    global meshswap_cache
+    global meshswap_cache_path
+    meshswap_cache = {}
+    meshswap_cache_path = None

--- a/MCprep_addon/spawner/mobs.py
+++ b/MCprep_addon/spawner/mobs.py
@@ -39,156 +39,165 @@ from . import spawn_util
 
 
 def get_rig_list(context):
-	"""Only used for operator UI Enum property in redo last / popups"""
+    """Only used for operator UI Enum property in redo last / popups"""
 
-	# may redraw too many times, perhaps have flag to prevent re-runs
-	if not context.scene.mcprep_props.mob_list_all:
-		update_rig_list(context)
-	ret_list = [
-		(mob.mcmob_type, mob.name, mob.description)
-		for mob in context.scene.mcprep_props.mob_list_all]
-	return ret_list
+    # may redraw too many times, perhaps have flag to prevent re-runs
+    if not context.scene.mcprep_props.mob_list_all:
+        update_rig_list(context)
+    ret_list = [
+        (mob.mcmob_type, mob.name, mob.description)
+        for mob in context.scene.mcprep_props.mob_list_all
+    ]
+    return ret_list
 
 
 def update_rig_path(self, context):
-	"""List for UI mobs callback of property spawn_rig_category."""
-	env.log("Updating rig path", vv_only=True)
-	env.rig_categories = []
-	update_rig_list(context)
-	spawn_rigs_categories(self, context)
+    """List for UI mobs callback of property spawn_rig_category."""
+    env.log("Updating rig path", vv_only=True)
+    env.rig_categories = []
+    update_rig_list(context)
+    spawn_rigs_categories(self, context)
 
 
 def update_rig_list(context):
-	"""Update the rig list and subcategory list"""
+    """Update the rig list and subcategory list"""
 
-	def _add_rigs_from_blend(path, blend_name, category):
-		"""Block for loading blend file groups to get rigs"""
-		with bpy.data.libraries.load(path) as (data_from, data_to):
+    def _add_rigs_from_blend(path, blend_name, category):
+        """Block for loading blend file groups to get rigs"""
+        with bpy.data.libraries.load(path) as (data_from, data_to):
+            extensions = [".png", ".jpg", ".jpeg"]
+            icon_folder = os.path.join(os.path.dirname(path), "icons")
+            run_icons = os.path.isdir(icon_folder)
+            if not env.use_icons or env.preview_collections["mobs"] == "":
+                run_icons = False
 
-			extensions = [".png", ".jpg", ".jpeg"]
-			icon_folder = os.path.join(os.path.dirname(path), "icons")
-			run_icons = os.path.isdir(icon_folder)
-			if not env.use_icons or env.preview_collections["mobs"] == "":
-				run_icons = False
+            mob_names = spawn_util.filter_collections(data_from)
 
-			mob_names = spawn_util.filter_collections(data_from)
+            for name in mob_names:
+                mob = context.scene.mcprep_props.mob_list_all.add()
+                if spawn_util.INCLUDE_COLL.lower() in name.lower():
+                    subname = name.lower().replace(spawn_util.INCLUDE_COLL.lower(), "")
+                    subname = subname.strip()
+                else:
+                    subname = name
 
-			for name in mob_names:
-				mob = context.scene.mcprep_props.mob_list_all.add()
-				if spawn_util.INCLUDE_COLL.lower() in name.lower():
-					subname = name.lower().replace(
-						spawn_util.INCLUDE_COLL.lower(), "")
-					subname = subname.strip()
-				else:
-					subname = name
+                description = "Spawn one {x} rig".format(x=subname)
+                mob.description = description  # add in non all-list
+                mob.name = subname.title()
+                mob.category = category
+                mob.index = len(context.scene.mcprep_props.mob_list_all)
+                if category:
+                    mob.mcmob_type = os.path.join(category, blend_name) + ":/:" + name
+                else:
+                    mob.mcmob_type = blend_name + ":/:" + name
 
-				description = "Spawn one {x} rig".format(x=subname)
-				mob.description = description  # add in non all-list
-				mob.name = subname.title()
-				mob.category = category
-				mob.index = len(context.scene.mcprep_props.mob_list_all)
-				if category:
-					mob.mcmob_type = os.path.join(
-						category, blend_name) + ":/:" + name
-				else:
-					mob.mcmob_type = blend_name + ":/:" + name
+                # if available, load the custom icon too
+                if not run_icons:
+                    continue
 
-				# if available, load the custom icon too
-				if not run_icons:
-					continue
+                icons = [
+                    f
+                    for f in os.listdir(icon_folder)
+                    if os.path.isfile(os.path.join(icon_folder, f))
+                    and subname.lower() == os.path.splitext(f.lower())[0]
+                    and not f.startswith(".")
+                    and os.path.splitext(f.lower())[-1] in extensions
+                ]
+                if not icons:
+                    continue
+                env.preview_collections["mobs"].load(
+                    "mob-{}".format(mob.index),
+                    os.path.join(icon_folder, icons[0]),
+                    "IMAGE",
+                )
 
-				icons = [
-					f for f in os.listdir(icon_folder)
-					if os.path.isfile(os.path.join(icon_folder, f))
-					and subname.lower() == os.path.splitext(f.lower())[0]
-					and not f.startswith(".")
-					and os.path.splitext(f.lower())[-1] in extensions]
-				if not icons:
-					continue
-				env.preview_collections["mobs"].load(
-					"mob-{}".format(mob.index),
-					os.path.join(icon_folder, icons[0]),
-					'IMAGE')
+    rigpath = bpy.path.abspath(context.scene.mcprep_mob_path)
+    context.scene.mcprep_props.mob_list.clear()
+    context.scene.mcprep_props.mob_list_all.clear()
 
-	rigpath = bpy.path.abspath(context.scene.mcprep_mob_path)
-	context.scene.mcprep_props.mob_list.clear()
-	context.scene.mcprep_props.mob_list_all.clear()
+    if env.use_icons and env.preview_collections["mobs"]:
+        print("Removing mobs preview collection")
+        try:
+            bpy.utils.previews.remove(env.preview_collections["mobs"])
+        except:
+            env.log("MCPREP: Failed to remove icon set, mobs")
 
-	if env.use_icons and env.preview_collections["mobs"]:
-		print("Removing mobs preview collection")
-		try:
-			bpy.utils.previews.remove(env.preview_collections["mobs"])
-		except:
-			env.log("MCPREP: Failed to remove icon set, mobs")
+    if os.path.isdir(rigpath) is False:
+        env.log("Rigpath directory not found")
+        return
 
-	if os.path.isdir(rigpath) is False:
-		env.log("Rigpath directory not found")
-		return
+    categories = [
+        f
+        for f in os.listdir(rigpath)
+        if os.path.isdir(os.path.join(rigpath, f)) and not f.startswith(".")
+    ]
+    no_category_blends = [
+        f
+        for f in os.listdir(rigpath)
+        if os.path.isfile(os.path.join(rigpath, f))
+        and f.endswith(".blend")
+        and not f.startswith(".")
+    ]
 
-	categories = [
-		f for f in os.listdir(rigpath)
-		if os.path.isdir(os.path.join(rigpath, f)) and not f.startswith(".")]
-	no_category_blends = [
-		f for f in os.listdir(rigpath)
-		if os.path.isfile(os.path.join(rigpath, f))
-		and f.endswith(".blend")
-		and not f.startswith(".")]
+    for category in categories:
+        cat_path = os.path.join(rigpath, category)
+        blend_files = [
+            f
+            for f in os.listdir(cat_path)
+            if os.path.isfile(os.path.join(cat_path, f))
+            and f.endswith(".blend")
+            and not f.startswith(".")
+        ]
 
-	for category in categories:
-		cat_path = os.path.join(rigpath, category)
-		blend_files = [
-			f for f in os.listdir(cat_path)
-			if os.path.isfile(os.path.join(cat_path, f))
-			and f.endswith(".blend")
-			and not f.startswith(".")]
+        for blend_name in blend_files:
+            if not spawn_util.check_blend_eligible(blend_name, blend_files):
+                continue  # Not eligible, use allowed blend in list instead.
+            blend_path = os.path.join(cat_path, blend_name)
+            _add_rigs_from_blend(blend_path, blend_name, category)
 
-		for blend_name in blend_files:
-			if not spawn_util.check_blend_eligible(blend_name, blend_files):
-				continue  # Not eligible, use allowed blend in list instead.
-			blend_path = os.path.join(cat_path, blend_name)
-			_add_rigs_from_blend(blend_path, blend_name, category)
+    # Update the list with non-categorized mobs (ie root of target folder)
+    for blend_name in no_category_blends:
+        if not spawn_util.check_blend_eligible(blend_name, no_category_blends):
+            return  # Not eligible, use allowed blend in list instead.
+        blend_path = os.path.join(rigpath, blend_name)
+        _add_rigs_from_blend(blend_path, blend_name, "")
 
-	# Update the list with non-categorized mobs (ie root of target folder)
-	for blend_name in no_category_blends:
-		if not spawn_util.check_blend_eligible(blend_name, no_category_blends):
-			return  # Not eligible, use allowed blend in list instead.
-		blend_path = os.path.join(rigpath, blend_name)
-		_add_rigs_from_blend(blend_path, blend_name, "")
-
-	update_rig_category(context)
+    update_rig_category(context)
 
 
 def update_rig_category(context):
-	"""Update the list of mobs for the given category from the master list"""
+    """Update the list of mobs for the given category from the master list"""
 
-	scn_props = context.scene.mcprep_props
+    scn_props = context.scene.mcprep_props
 
-	if not scn_props.mob_list_all:
-		env.log("No rigs found, failed to update category")
-		scn_props.mob_list.clear()
-		return
+    if not scn_props.mob_list_all:
+        env.log("No rigs found, failed to update category")
+        scn_props.mob_list.clear()
+        return
 
-	category = scn_props.spawn_rig_category
-	if category == "no_category":
-		category = ""  # to match how the attribute is saved
-	scn_props.mob_list.clear()
+    category = scn_props.spawn_rig_category
+    if category == "no_category":
+        category = ""  # to match how the attribute is saved
+    scn_props.mob_list.clear()
 
-	cat_mobs = [
-		mob for mob in scn_props.mob_list_all
-		if mob.category == category or category == "all"]
-	cat_mobs.sort(key=lambda x: x.name, reverse=False)
+    cat_mobs = [
+        mob
+        for mob in scn_props.mob_list_all
+        if mob.category == category or category == "all"
+    ]
+    cat_mobs.sort(key=lambda x: x.name, reverse=False)
 
-	# consider bringing the player rigs up first
-	for mob in cat_mobs:
-		item = scn_props.mob_list.add()
-		item.description = mob.description
-		item.name = mob.name
-		item.mcmob_type = mob.mcmob_type
-		item.category = mob.category
-		item.index = mob.index  # for icons
+    # consider bringing the player rigs up first
+    for mob in cat_mobs:
+        item = scn_props.mob_list.add()
+        item.description = mob.description
+        item.name = mob.name
+        item.mcmob_type = mob.mcmob_type
+        item.category = mob.category
+        item.index = mob.index  # for icons
 
-	if scn_props.mob_list_index >= len(scn_props.mob_list):
-		scn_props.mob_list_index = len(scn_props.mob_list) - 1
+    if scn_props.mob_list_index >= len(scn_props.mob_list):
+        scn_props.mob_list_index = len(scn_props.mob_list) - 1
 
 
 # -----------------------------------------------------------------------------
@@ -197,467 +206,479 @@ def update_rig_category(context):
 
 
 class MCPREP_OT_reload_mobs(bpy.types.Operator):
-	"""Force reload the mob spawner rigs, use after manually adding rigs to folders"""
-	bl_idname = "mcprep.reload_mobs"
-	bl_label = "Reload the rigs and cache"
+    """Force reload the mob spawner rigs, use after manually adding rigs to folders"""
 
-	@tracking.report_error
-	def execute(self, context):
-		env.rig_categories = []
-		update_rig_list(context)
-		return {'FINISHED'}
+    bl_idname = "mcprep.reload_mobs"
+    bl_label = "Reload the rigs and cache"
+
+    @tracking.report_error
+    def execute(self, context):
+        env.rig_categories = []
+        update_rig_list(context)
+        return {"FINISHED"}
 
 
 class MCPREP_OT_mob_spawner(bpy.types.Operator):
-	"""Show menu and spawn built-in or custom rigs into a scene"""
-	bl_idname = "mcprep.mob_spawner"
-	bl_label = "Mob Spawner"
-	bl_description = "Spawn built-in or custom rigs into the scene"
-	bl_options = {'REGISTER', 'UNDO'}
+    """Show menu and spawn built-in or custom rigs into a scene"""
 
-	def riglist_enum(self, context):
-		return get_rig_list(context)
+    bl_idname = "mcprep.mob_spawner"
+    bl_label = "Mob Spawner"
+    bl_description = "Spawn built-in or custom rigs into the scene"
+    bl_options = {"REGISTER", "UNDO"}
 
-	mcmob_type: bpy.props.EnumProperty(items=riglist_enum, name="Mob Type")
-	relocation: bpy.props.EnumProperty(
-		items=[
-			('Cursor', 'Cursor', 'Move the rig to the cursor'),
-			('Clear', 'Origin', 'Move the rig to the origin'),
-			('Offset', 'Offset root', (
-				'Offset the root bone to cursor while leaving the rest pose '
-				'at the origin'))],
-		name="Relocation")
-	toLink: bpy.props.BoolProperty(
-		name="Library Link",
-		description="Library link instead of append the group",
-		default=False)
-	clearPose: bpy.props.BoolProperty(
-		name="Clear Pose",
-		description="Clear the pose to rest position",
-		default=True)
-	prep_materials: bpy.props.BoolProperty(
-		name="Prep materials (will reset nodes)",
-		description=(
-			"Prep materials of the added rig, will replace cycles node groups "
-			"with default"),
-		default=True)
+    def riglist_enum(self, context):
+        return get_rig_list(context)
 
-	skipUsage: bpy.props.BoolProperty(
-		default=False,
-		options={'HIDDEN'})
+    mcmob_type: bpy.props.EnumProperty(items=riglist_enum, name="Mob Type")
+    relocation: bpy.props.EnumProperty(
+        items=[
+            ("Cursor", "Cursor", "Move the rig to the cursor"),
+            ("Clear", "Origin", "Move the rig to the origin"),
+            (
+                "Offset",
+                "Offset root",
+                (
+                    "Offset the root bone to cursor while leaving the rest pose "
+                    "at the origin"
+                ),
+            ),
+        ],
+        name="Relocation",
+    )
+    toLink: bpy.props.BoolProperty(
+        name="Library Link",
+        description="Library link instead of append the group",
+        default=False,
+    )
+    clearPose: bpy.props.BoolProperty(
+        name="Clear Pose", description="Clear the pose to rest position", default=True
+    )
+    prep_materials: bpy.props.BoolProperty(
+        name="Prep materials (will reset nodes)",
+        description=(
+            "Prep materials of the added rig, will replace cycles node groups "
+            "with default"
+        ),
+        default=True,
+    )
 
-	def draw(self, context):
-		"""Draw in redo last menu or F6"""
-		row = self.layout.row()
-		row.prop(self, "relocation")
+    skipUsage: bpy.props.BoolProperty(default=False, options={"HIDDEN"})
 
-		row = self.layout.row(align=True)
-		row.prop(self, "toLink")
-		row.prop(self, "clearPose")
-		row = self.layout.row(align=True)
-		engine = context.scene.render.engine
-		if engine == 'CYCLES' or engine == 'BLENDER_EEVEE':
-			row.prop(self, "prep_materials")
-		else:
-			row.prop(self, "prep_materials", text="Prep materials")
+    def draw(self, context):
+        """Draw in redo last menu or F6"""
+        row = self.layout.row()
+        row.prop(self, "relocation")
 
-	track_function = "mobSpawner"
-	track_param = None
-	@tracking.report_error
-	def execute(self, context):
-		try:
-			[path, name] = self.mcmob_type.split(':/:')
-		except Exception as err:
-			env.log("Error: Failed to parse mcmob_type")
-			self.report({'ERROR'}, "Failed to parse mcmob_type, try reloading mobs")
-			return {'CANCELLED'}
-		path = os.path.join(context.scene.mcprep_mob_path, path)
-		env.log("Path is now ", path)
+        row = self.layout.row(align=True)
+        row.prop(self, "toLink")
+        row.prop(self, "clearPose")
+        row = self.layout.row(align=True)
+        engine = context.scene.render.engine
+        if engine == "CYCLES" or engine == "BLENDER_EEVEE":
+            row.prop(self, "prep_materials")
+        else:
+            row.prop(self, "prep_materials", text="Prep materials")
 
-		try:
-			# must be in object mode, this make similar behavior to other objs
-			bpy.ops.object.mode_set(mode='OBJECT')
-		except:
-			pass  # Can fail to this e.g. if no objects are selected.
+    track_function = "mobSpawner"
+    track_param = None
 
-		init_objs = list(bpy.data.objects)
+    @tracking.report_error
+    def execute(self, context):
+        try:
+            [path, name] = self.mcmob_type.split(":/:")
+        except Exception as err:
+            env.log("Error: Failed to parse mcmob_type")
+            self.report({"ERROR"}, "Failed to parse mcmob_type, try reloading mobs")
+            return {"CANCELLED"}
+        path = os.path.join(context.scene.mcprep_mob_path, path)
+        env.log("Path is now ", path)
 
-		if self.toLink:
-			if path == '//':
-				env.log("This is the local file. Cancelling...")
-				return {'CANCELLED'}
-			_ = spawn_util.load_linked(self, context, path, name)
-		else:
-			_ = spawn_util.load_append(self, context, path, name)
+        try:
+            # must be in object mode, this make similar behavior to other objs
+            bpy.ops.object.mode_set(mode="OBJECT")
+        except:
+            pass  # Can fail to this e.g. if no objects are selected.
 
-		post_objs = list(bpy.data.objects)
-		new_objs = list(set(post_objs) - set(init_objs))
-		self.set_fake_users(context, new_objs)
+        init_objs = list(bpy.data.objects)
 
-		# If there is a script with this rig, attempt to run it.
-		spawn_util.attemptScriptLoad(path)
+        if self.toLink:
+            if path == "//":
+                env.log("This is the local file. Cancelling...")
+                return {"CANCELLED"}
+            _ = spawn_util.load_linked(self, context, path, name)
+        else:
+            _ = spawn_util.load_append(self, context, path, name)
 
-		if self.prep_materials and not self.toLink and context.selected_objects:
-			try:
-				bpy.ops.mcprep.prep_materials(
-					improveUiSettings=False, skipUsage=True)
-			except:
-				self.report({"WARNING"}, "Failed to prep materials on mob load")
+        post_objs = list(bpy.data.objects)
+        new_objs = list(set(post_objs) - set(init_objs))
+        self.set_fake_users(context, new_objs)
 
-		self.track_param = self.mcmob_type.split(":/:")[1]
-		return {'FINISHED'}
+        # If there is a script with this rig, attempt to run it.
+        spawn_util.attemptScriptLoad(path)
 
-	def set_fake_users(self, context, new_objs):
-		"""Set certain object types to fake user if modifier targets.
+        if self.prep_materials and not self.toLink and context.selected_objects:
+            try:
+                bpy.ops.mcprep.prep_materials(improveUiSettings=False, skipUsage=True)
+            except:
+                self.report({"WARNING"}, "Failed to prep materials on mob load")
 
-		This is the workaround to address an issue with blender 3.0 where objs
-		that are not linked to the scene but are used by modifiers aren't seen
-		by blender as being "used", and get removed after a file reload. Hence,
-		we must assign them as a fake user.
-		https://github.com/TheDuckCow/MCprep/issues/307
-		"""
-		if not util.bv30():
-			return
-		mod_objs = []
-		for obj in new_objs:
-			for mod in obj.modifiers:
-				if hasattr(mod, "object") and mod.object:
-					mod_objs.append(mod.object)
-		for obj in mod_objs:
-			if obj not in list(context.scene.collection.all_objects):
-				obj.use_fake_user = True
-				env.log("Set {} as fake user".format(obj.name))
+        self.track_param = self.mcmob_type.split(":/:")[1]
+        return {"FINISHED"}
+
+    def set_fake_users(self, context, new_objs):
+        """Set certain object types to fake user if modifier targets.
+
+        This is the workaround to address an issue with blender 3.0 where objs
+        that are not linked to the scene but are used by modifiers aren't seen
+        by blender as being "used", and get removed after a file reload. Hence,
+        we must assign them as a fake user.
+        https://github.com/TheDuckCow/MCprep/issues/307
+        """
+        if not util.bv30():
+            return
+        mod_objs = []
+        for obj in new_objs:
+            for mod in obj.modifiers:
+                if hasattr(mod, "object") and mod.object:
+                    mod_objs.append(mod.object)
+        for obj in mod_objs:
+            if obj not in list(context.scene.collection.all_objects):
+                obj.use_fake_user = True
+                env.log("Set {} as fake user".format(obj.name))
 
 
 class MCPREP_OT_install_mob(bpy.types.Operator, ImportHelper):
-	"""Install mob operator."""
-	bl_idname = "mcprep.mob_install_menu"
-	bl_label = "Install new mob"
-	bl_description = (
-		"Install custom rig popup for the mob spawner, all groups/collections "
-		"in selected blend file will become individually spawnable")
+    """Install mob operator."""
 
-	filename_ext = ".blend"
-	filter_glob: bpy.props.StringProperty(
-		default="*.blend",
-		options={'HIDDEN'},
-	)
-	fileselectparams = "use_filter_blender"
+    bl_idname = "mcprep.mob_install_menu"
+    bl_label = "Install new mob"
+    bl_description = (
+        "Install custom rig popup for the mob spawner, all groups/collections "
+        "in selected blend file will become individually spawnable"
+    )
 
-	def getCategories(self, context):
-		path = bpy.path.abspath(context.scene.mcprep_mob_path)
-		ret = []
-		ret.append(("all", "No Category", "Uncategorized mob"))
-		try:
-			ret += [
-				(f, f.title(), "{} mob".format(f.title()))
-				for f in os.listdir(path)
-				if os.path.isdir(os.path.join(path, f)) and not f.startswith(".")]
-		except FileNotFoundError:
-			pass  # mobs folder not found, so just pass.
-		ret.append(("no_category", "No Category", "Uncategorized mob"))  # last entry
-		return ret
+    filename_ext = ".blend"
+    filter_glob: bpy.props.StringProperty(
+        default="*.blend",
+        options={"HIDDEN"},
+    )
+    fileselectparams = "use_filter_blender"
 
-	mob_category: bpy.props.EnumProperty(
-		items=getCategories,
-		name="Mob Category")
+    def getCategories(self, context):
+        path = bpy.path.abspath(context.scene.mcprep_mob_path)
+        ret = []
+        ret.append(("all", "No Category", "Uncategorized mob"))
+        try:
+            ret += [
+                (f, f.title(), "{} mob".format(f.title()))
+                for f in os.listdir(path)
+                if os.path.isdir(os.path.join(path, f)) and not f.startswith(".")
+            ]
+        except FileNotFoundError:
+            pass  # mobs folder not found, so just pass.
+        ret.append(("no_category", "No Category", "Uncategorized mob"))  # last entry
+        return ret
 
-	@tracking.report_error
-	def execute(self, context):
-		drpath = context.scene.mcprep_mob_path
-		newrig = bpy.path.abspath(self.filepath)
+    mob_category: bpy.props.EnumProperty(items=getCategories, name="Mob Category")
 
-		if not os.path.isfile(newrig):
-			env.log("Error: Rig blend file not found!")
-			self.report({'ERROR'}, "Rig blend file not found!")
-			return {'CANCELLED'}
+    @tracking.report_error
+    def execute(self, context):
+        drpath = context.scene.mcprep_mob_path
+        newrig = bpy.path.abspath(self.filepath)
 
-		if not newrig.lower().endswith('.blend'):
-			env.log("Error: Not a blend file! Select a .blend file with a rig")
-			self.report({'ERROR'}, "Not a blend file! Select a .blend file with a rig")
-			return {'CANCELLED'}
+        if not os.path.isfile(newrig):
+            env.log("Error: Rig blend file not found!")
+            self.report({"ERROR"}, "Rig blend file not found!")
+            return {"CANCELLED"}
 
-		# now check the rigs folder indeed exists
-		drpath = bpy.path.abspath(drpath)
-		if not os.path.isdir(drpath):
-			env.log("Error: Rig directory is not valid!")
-			self.report({'ERROR'}, "Rig directory is not valid!")
-			return {'CANCELLED'}
+        if not newrig.lower().endswith(".blend"):
+            env.log("Error: Not a blend file! Select a .blend file with a rig")
+            self.report({"ERROR"}, "Not a blend file! Select a .blend file with a rig")
+            return {"CANCELLED"}
 
-		# check the file for any groups, any error return failed
-		with bpy.data.libraries.load(newrig) as (data_from, data_to):
-			install_groups = spawn_util.filter_collections(data_from)
+        # now check the rigs folder indeed exists
+        drpath = bpy.path.abspath(drpath)
+        if not os.path.isdir(drpath):
+            env.log("Error: Rig directory is not valid!")
+            self.report({"ERROR"}, "Rig directory is not valid!")
+            return {"CANCELLED"}
 
-		if 'Collection' in install_groups:  # don't count the default 2.8 group
-			install_groups.pop(install_groups.index('Collection'))
+        # check the file for any groups, any error return failed
+        with bpy.data.libraries.load(newrig) as (data_from, data_to):
+            install_groups = spawn_util.filter_collections(data_from)
 
-		if not install_groups:
-			env.log("Error: no groups found in blend file!")
-			self.report({'ERROR'}, "No groups found in blend file!")
-			return {'CANCELLED'}
+        if "Collection" in install_groups:  # don't count the default 2.8 group
+            install_groups.pop(install_groups.index("Collection"))
 
-		# copy this file to the rig folder
-		filename = os.path.basename(newrig)
-		if self.mob_category != "no_category" and self.mob_category != "all":
-			end_path = os.path.join(drpath, self.mob_category)
-		else:
-			end_path = drpath
+        if not install_groups:
+            env.log("Error: no groups found in blend file!")
+            self.report({"ERROR"}, "No groups found in blend file!")
+            return {"CANCELLED"}
 
-		try:
-			shutil.copy2(newrig, os.path.join(end_path, filename))
-		except IOError as err:
-			print(err)
-			# can fail if permission denied, i.e. an IOError error
-			self.report(
-				{'ERROR'},
-				"Failed to copy, manually install by copying blend to folder: {}".format(
-					end_path))
-			return {'CANCELLED'}
+        # copy this file to the rig folder
+        filename = os.path.basename(newrig)
+        if self.mob_category != "no_category" and self.mob_category != "all":
+            end_path = os.path.join(drpath, self.mob_category)
+        else:
+            end_path = drpath
 
-		# now do same to install py files if any or icons
-		# failure here is non critical
-		try:
-			if os.path.isfile(newrig[:-5] + "py"):
-				# if there is a script, install that too
-				shutil.copy2(
-					newrig[:-5] + "py",
-					os.path.join(end_path, filename[:-5] + "py"))
-		except IOError as err:
-			print(err)
-			self.report(
-				{'WARNING'},
-				"Failed attempt to copy python file: {}".format(
-					end_path))
+        try:
+            shutil.copy2(newrig, os.path.join(end_path, filename))
+        except IOError as err:
+            print(err)
+            # can fail if permission denied, i.e. an IOError error
+            self.report(
+                {"ERROR"},
+                "Failed to copy, manually install by copying blend to folder: {}".format(
+                    end_path
+                ),
+            )
+            return {"CANCELLED"}
 
-		# copy all relevant icons, based on groups installed
-		# ## matching same folde or subfolder icons to append
-		if env.use_icons:
-			basedir = os.path.dirname(newrig)
-			icon_files = self.identify_icons(install_groups, basedir)
-			icondir = os.path.join(basedir, "icons")
-			if os.path.isdir(icondir):
-				icon_files += self.identify_icons(install_groups, icondir)
-			if icon_files:
-				dst = os.path.join(end_path, "icons")
-				if not os.path.isdir(dst):
-					try:
-						os.mkdir(dst)
-					except OSError as exc:
-						if exc.errno == errno.EACCES:
-							print("Permission denied, try running blender as admin")
-							print(dst)
-							print(exc)
-						elif exc.errno != errno.EEXIST:
-							print("Path does not exist: " + dst)
-							print(exc)
-				for icn in icon_files:
-					icn_base = os.path.basename(icn)
-					try:
-						shutil.copy2(icn, os.path.join(dst, icn_base))
-					except IOError as err:
-						print("Failed to copy over icon file " + icn)
-						print("to " + os.path.join(icondir, icn_base))
-						print(err)
+        # now do same to install py files if any or icons
+        # failure here is non critical
+        try:
+            if os.path.isfile(newrig[:-5] + "py"):
+                # if there is a script, install that too
+                shutil.copy2(
+                    newrig[:-5] + "py", os.path.join(end_path, filename[:-5] + "py")
+                )
+        except IOError as err:
+            print(err)
+            self.report(
+                {"WARNING"}, "Failed attempt to copy python file: {}".format(end_path)
+            )
 
-		# reload the cache
-		update_rig_list(context)
-		self.report({'INFO'}, "Mob-file Installed")
+        # copy all relevant icons, based on groups installed
+        # ## matching same folde or subfolder icons to append
+        if env.use_icons:
+            basedir = os.path.dirname(newrig)
+            icon_files = self.identify_icons(install_groups, basedir)
+            icondir = os.path.join(basedir, "icons")
+            if os.path.isdir(icondir):
+                icon_files += self.identify_icons(install_groups, icondir)
+            if icon_files:
+                dst = os.path.join(end_path, "icons")
+                if not os.path.isdir(dst):
+                    try:
+                        os.mkdir(dst)
+                    except OSError as exc:
+                        if exc.errno == errno.EACCES:
+                            print("Permission denied, try running blender as admin")
+                            print(dst)
+                            print(exc)
+                        elif exc.errno != errno.EEXIST:
+                            print("Path does not exist: " + dst)
+                            print(exc)
+                for icn in icon_files:
+                    icn_base = os.path.basename(icn)
+                    try:
+                        shutil.copy2(icn, os.path.join(dst, icn_base))
+                    except IOError as err:
+                        print("Failed to copy over icon file " + icn)
+                        print("to " + os.path.join(icondir, icn_base))
+                        print(err)
 
-		return {'FINISHED'}
+        # reload the cache
+        update_rig_list(context)
+        self.report({"INFO"}, "Mob-file Installed")
 
-	def identify_icons(self, group_names, path):
-		"""Copy over all matching icons from single specific folder"""
-		if not group_names:
-			return []
-		extensions = [".png", ".jpg", ".jpeg"]
-		icons = []
-		for name in group_names:
-			icons += [
-				os.path.join(path, f) for f in os.listdir(path)
-				if os.path.isfile(os.path.join(path, f))
-				and name.lower() in f.lower()
-				and not f.startswith(".")
-				and os.path.splitext(f.lower())[-1] in extensions]
-		return icons
+        return {"FINISHED"}
+
+    def identify_icons(self, group_names, path):
+        """Copy over all matching icons from single specific folder"""
+        if not group_names:
+            return []
+        extensions = [".png", ".jpg", ".jpeg"]
+        icons = []
+        for name in group_names:
+            icons += [
+                os.path.join(path, f)
+                for f in os.listdir(path)
+                if os.path.isfile(os.path.join(path, f))
+                and name.lower() in f.lower()
+                and not f.startswith(".")
+                and os.path.splitext(f.lower())[-1] in extensions
+            ]
+        return icons
 
 
 class MCPREP_OT_uninstall_mob(bpy.types.Operator):
-	"""Uninstall selected mob by deleting source blend file"""
-	bl_idname = "mcprep.mob_uninstall"
-	bl_label = "Uninstall mob"
+    """Uninstall selected mob by deleting source blend file"""
 
-	path = ""
-	listing = []
+    bl_idname = "mcprep.mob_uninstall"
+    bl_label = "Uninstall mob"
 
-	def invoke(self, context, event):
-		self.preDraw(context)
-		return context.window_manager.invoke_props_dialog(
-			self, width=400 * util.ui_scale())
+    path = ""
+    listing = []
 
-	def preDraw(self, context):
-		scn_props = context.scene.mcprep_props
-		mob = scn_props.mob_list[scn_props.mob_list_index].mcmob_type
-		self.path = ""
+    def invoke(self, context, event):
+        self.preDraw(context)
+        return context.window_manager.invoke_props_dialog(
+            self, width=400 * util.ui_scale()
+        )
 
-		try:
-			self.path = mob.split(":/:")[0]
-		except Exception as e:
-			self.report({'ERROR'}, "Could not resolve file to delete")
-			print("Error: {}".format(e))
-			return {'CANCELLED'}
+    def preDraw(self, context):
+        scn_props = context.scene.mcprep_props
+        mob = scn_props.mob_list[scn_props.mob_list_index].mcmob_type
+        self.path = ""
 
-		# see how many groups use this blend file
-		count = 0
-		self.listing = []
-		for mob in scn_props.mob_list_all:
-			path, name = mob.mcmob_type.split(":/:")
-			if path == self.path:
-				self.listing.append(name)
-				count += 1
+        try:
+            self.path = mob.split(":/:")[0]
+        except Exception as e:
+            self.report({"ERROR"}, "Could not resolve file to delete")
+            print("Error: {}".format(e))
+            return {"CANCELLED"}
 
-	def draw(self, context):
-		row = self.layout.row()
-		row.scale_y = 0.5
-		scn_props = context.scene.mcprep_props
-		mob = scn_props.mob_list[scn_props.mob_list_index].mcmob_type
-		path = mob.split(":/:")[0]
-		path = os.path.join(context.scene.mcprep_mob_path, path)
-		if len(self.listing) > 1:
-			row.label(text="Multiple mobs found in target blend file:")
-			row = self.layout.row()
-			row.scale_y = 0.5
+        # see how many groups use this blend file
+        count = 0
+        self.listing = []
+        for mob in scn_props.mob_list_all:
+            path, name = mob.mcmob_type.split(":/:")
+            if path == self.path:
+                self.listing.append(name)
+                count += 1
 
-			# draw 3-column list of mobs to be deleted
-			col1 = row.column()
-			col1.scale_y = 0.6
-			col2 = row.column()
-			col2.scale_y = 0.6
-			col3 = row.column()
-			col3.scale_y = 0.6
-			count = 0
-			for grp in self.listing:
-				count += 1
-				if count % 3 == 0:
-					col1.label(text=grp)
-				elif count % 3 == 1:
-					col2.label(text=grp)
-				else:
-					col3.label(text=grp)
-			row = self.layout.row()
-			row.label(text="Press okay to delete these mobs and file:")
-		else:
-			col = row.column()
-			col.scale_y = 0.7
-			col.label(text="Press okay to delete mob and file:")
-		row = self.layout.row()
-		row.label(text=path)
+    def draw(self, context):
+        row = self.layout.row()
+        row.scale_y = 0.5
+        scn_props = context.scene.mcprep_props
+        mob = scn_props.mob_list[scn_props.mob_list_index].mcmob_type
+        path = mob.split(":/:")[0]
+        path = os.path.join(context.scene.mcprep_mob_path, path)
+        if len(self.listing) > 1:
+            row.label(text="Multiple mobs found in target blend file:")
+            row = self.layout.row()
+            row.scale_y = 0.5
 
-	@tracking.report_error
-	def execute(self, context):
-		scn_props = context.scene.mcprep_props
-		mob = scn_props.mob_list[scn_props.mob_list_index].mcmob_type
-		try:
-			path = mob.split(":/:")[0]
-			path = os.path.join(context.scene.mcprep_mob_path, path)
-		except Exception as e:
-			self.report({'ERROR'}, "Could not resolve file to delete")
-			print("Error trying to remove mob file: " + str(e))
-			return {'CANCELLED'}
+            # draw 3-column list of mobs to be deleted
+            col1 = row.column()
+            col1.scale_y = 0.6
+            col2 = row.column()
+            col2.scale_y = 0.6
+            col3 = row.column()
+            col3.scale_y = 0.6
+            count = 0
+            for grp in self.listing:
+                count += 1
+                if count % 3 == 0:
+                    col1.label(text=grp)
+                elif count % 3 == 1:
+                    col2.label(text=grp)
+                else:
+                    col3.label(text=grp)
+            row = self.layout.row()
+            row.label(text="Press okay to delete these mobs and file:")
+        else:
+            col = row.column()
+            col.scale_y = 0.7
+            col.label(text="Press okay to delete mob and file:")
+        row = self.layout.row()
+        row.label(text=path)
 
-		if os.path.isfile(path) is False:
-			env.log("Error: Source filepath not found, didn't delete: " + path)
-			self.report({'ERROR'}, "Source filepath not found, didn't delete")
-			return {'CANCELLED'}
-		else:
-			try:
-				os.remove(path)
-			except Exception as err:
-				env.log("Error: could not delete file: " + str(err))
-				self.report({'ERROR'}, "Could not delete file")
-				return {'CANCELLED'}
-		self.report({'INFO'}, "Removed: " + str(path))
-		env.log("Removed file: " + str(path))
-		bpy.ops.mcprep.reload_mobs()
-		return {'FINISHED'}
+    @tracking.report_error
+    def execute(self, context):
+        scn_props = context.scene.mcprep_props
+        mob = scn_props.mob_list[scn_props.mob_list_index].mcmob_type
+        try:
+            path = mob.split(":/:")[0]
+            path = os.path.join(context.scene.mcprep_mob_path, path)
+        except Exception as e:
+            self.report({"ERROR"}, "Could not resolve file to delete")
+            print("Error trying to remove mob file: " + str(e))
+            return {"CANCELLED"}
+
+        if os.path.isfile(path) is False:
+            env.log("Error: Source filepath not found, didn't delete: " + path)
+            self.report({"ERROR"}, "Source filepath not found, didn't delete")
+            return {"CANCELLED"}
+        else:
+            try:
+                os.remove(path)
+            except Exception as err:
+                env.log("Error: could not delete file: " + str(err))
+                self.report({"ERROR"}, "Could not delete file")
+                return {"CANCELLED"}
+        self.report({"INFO"}, "Removed: " + str(path))
+        env.log("Removed file: " + str(path))
+        bpy.ops.mcprep.reload_mobs()
+        return {"FINISHED"}
 
 
 class MCPREP_OT_install_mob_icon(bpy.types.Operator, ImportHelper):
-	"""Install custom icon for select group in mob spawner UI list"""
-	bl_idname = "mcprep.mob_install_icon"
-	bl_label = "Install mob icon"
+    """Install custom icon for select group in mob spawner UI list"""
 
-	filter_glob: bpy.props.StringProperty(
-		default="",
-		options={'HIDDEN'})
-	fileselectparams = "use_filter_blender"
-	filter_image: bpy.props.BoolProperty(
-		default=True,
-		options={'HIDDEN', 'SKIP_SAVE'})
+    bl_idname = "mcprep.mob_install_icon"
+    bl_label = "Install mob icon"
 
-	def execute(self, context):
-		if not self.filepath:
-			self.report({'ERROR'}, "No filename selected")
-			return {'CANCELLED'}
-		elif not os.path.isfile(self.filepath):
-			self.report({'ERROR'}, "File not found")
-			return {'CANCELLED'}
+    filter_glob: bpy.props.StringProperty(default="", options={"HIDDEN"})
+    fileselectparams = "use_filter_blender"
+    filter_image: bpy.props.BoolProperty(default=True, options={"HIDDEN", "SKIP_SAVE"})
 
-		extensions = [".png", ".jpg", ".jpeg"]
-		ext = os.path.splitext(self.filepath)[-1]  # get extension, includes .
-		if ext.lower() not in extensions:
-			self.report({'ERROR'}, "Wrong filetype, must be png or jpg")
-			return {'CANCELLED'}
+    def execute(self, context):
+        if not self.filepath:
+            self.report({"ERROR"}, "No filename selected")
+            return {"CANCELLED"}
+        elif not os.path.isfile(self.filepath):
+            self.report({"ERROR"}, "File not found")
+            return {"CANCELLED"}
 
-		scn_props = context.scene.mcprep_props
-		mob = scn_props.mob_list[scn_props.mob_list_index]
-		_, name = mob.mcmob_type.split(':/:')
-		path = context.scene.mcprep_mob_path
+        extensions = [".png", ".jpg", ".jpeg"]
+        ext = os.path.splitext(self.filepath)[-1]  # get extension, includes .
+        if ext.lower() not in extensions:
+            self.report({"ERROR"}, "Wrong filetype, must be png or jpg")
+            return {"CANCELLED"}
 
-		icon_dir = os.path.join(path, mob.category, "icons")
-		new_file = os.path.join(icon_dir, name + ext)
-		print("New icon file name would be:")
-		print(new_file)
+        scn_props = context.scene.mcprep_props
+        mob = scn_props.mob_list[scn_props.mob_list_index]
+        _, name = mob.mcmob_type.split(":/:")
+        path = context.scene.mcprep_mob_path
 
-		if not os.path.isdir(icon_dir):
-			try:
-				os.mkdir(icon_dir)
-			except OSError as exc:
-				if exc.errno == errno.EACCES:
-					print("Permission denied, try running blender as admin")
-				elif exc.errno != errno.EEXIST:
-					print("Path does not exist: " + icon_dir)
+        icon_dir = os.path.join(path, mob.category, "icons")
+        new_file = os.path.join(icon_dir, name + ext)
+        print("New icon file name would be:")
+        print(new_file)
 
-		# if the file exists already, remove it.
-		if os.path.isfile(new_file):
-			try:
-				os.remove(new_file)
-			except Exception as err:
-				print("Failed to remove previous icon file")
-				print(err)
+        if not os.path.isdir(icon_dir):
+            try:
+                os.mkdir(icon_dir)
+            except OSError as exc:
+                if exc.errno == errno.EACCES:
+                    print("Permission denied, try running blender as admin")
+                elif exc.errno != errno.EEXIST:
+                    print("Path does not exist: " + icon_dir)
 
-		try:
-			shutil.copy2(self.filepath, new_file)
-		except IOError as err:
-			print("Failed to copy, manually copy to file name: {}".format(
-				new_file))
-			print(err)
-			self.report(
-				{'ERROR'},
-				"Failed to copy, manually copy to file name: {}".format(
-					new_file))
-			return {'CANCELLED'}
+        # if the file exists already, remove it.
+        if os.path.isfile(new_file):
+            try:
+                os.remove(new_file)
+            except Exception as err:
+                print("Failed to remove previous icon file")
+                print(err)
 
-		# if successful, load or reload icon id
-		icon_id = "mob-{}".format(mob.index)
-		if icon_id in env.preview_collections["mobs"]:
-			print("Deloading old icon for this mob")
-			print(dir(env.preview_collections["mobs"][icon_id]))
-			env.preview_collections["mobs"][icon_id].reload()
-		else:
-			env.preview_collections["mobs"].load(icon_id, new_file, 'IMAGE')
-			print("Icon reloaded")
+        try:
+            shutil.copy2(self.filepath, new_file)
+        except IOError as err:
+            print("Failed to copy, manually copy to file name: {}".format(new_file))
+            print(err)
+            self.report(
+                {"ERROR"},
+                "Failed to copy, manually copy to file name: {}".format(new_file),
+            )
+            return {"CANCELLED"}
 
-		return {'FINISHED'}
+        # if successful, load or reload icon id
+        icon_id = "mob-{}".format(mob.index)
+        if icon_id in env.preview_collections["mobs"]:
+            print("Deloading old icon for this mob")
+            print(dir(env.preview_collections["mobs"][icon_id]))
+            env.preview_collections["mobs"][icon_id].reload()
+        else:
+            env.preview_collections["mobs"].load(icon_id, new_file, "IMAGE")
+            print("Icon reloaded")
+
+        return {"FINISHED"}
+
 
 # -----------------------------------------------------------------------------
 # Mob category related
@@ -665,33 +686,34 @@ class MCPREP_OT_install_mob_icon(bpy.types.Operator, ImportHelper):
 
 
 def spawn_rigs_categories(self, context):
-	"""Used as enum UI list for spawn_rig_category dropdown"""
-	items = []
-	items.append(("all", "All Mobs", "Show all mobs loaded"))
+    """Used as enum UI list for spawn_rig_category dropdown"""
+    items = []
+    items.append(("all", "All Mobs", "Show all mobs loaded"))
 
-	categories = env.rig_categories
-	if not env.rig_categories:
-		it = context.scene.mcprep_mob_path
-		try:
-			categories = [
-				f for f in os.listdir(it) if os.path.isdir(os.path.join(it, f))]
-			env.rig_categories = categories
-		except FileNotFoundError:
-			pass  # Directory has changed or is not found.
-	for item in categories:
-		ui_name = item + " mobs"
-		items.append((
-			item, ui_name.title(),
-			"Show all mobs in the '" + item + "' category"))
+    categories = env.rig_categories
+    if not env.rig_categories:
+        it = context.scene.mcprep_mob_path
+        try:
+            categories = [
+                f for f in os.listdir(it) if os.path.isdir(os.path.join(it, f))
+            ]
+            env.rig_categories = categories
+        except FileNotFoundError:
+            pass  # Directory has changed or is not found.
+    for item in categories:
+        ui_name = item + " mobs"
+        items.append(
+            (item, ui_name.title(), "Show all mobs in the '" + item + "' category")
+        )
 
-	items.append(("no_category", "Uncategorized", "Show all uncategorized mobs"))
-	return items
+    items.append(("no_category", "Uncategorized", "Show all uncategorized mobs"))
+    return items
 
 
 def spawn_rigs_category_load(self, context):
-	"""Update function for UI property spawn rig category"""
-	update_rig_category(context)
-	return
+    """Update function for UI property spawn rig category"""
+    update_rig_category(context)
+    return
 
 
 # -----------------------------------------------------------------------------
@@ -700,19 +722,19 @@ def spawn_rigs_category_load(self, context):
 
 
 classes = (
-	MCPREP_OT_reload_mobs,
-	MCPREP_OT_mob_spawner,
-	MCPREP_OT_install_mob,
-	MCPREP_OT_uninstall_mob,
-	MCPREP_OT_install_mob_icon
+    MCPREP_OT_reload_mobs,
+    MCPREP_OT_mob_spawner,
+    MCPREP_OT_install_mob,
+    MCPREP_OT_uninstall_mob,
+    MCPREP_OT_install_mob_icon,
 )
 
 
 def register():
-	for cls in classes:
-		bpy.utils.register_class(cls)
+    for cls in classes:
+        bpy.utils.register_class(cls)
 
 
 def unregister():
-	for cls in reversed(classes):
-		bpy.utils.unregister_class(cls)
+    for cls in reversed(classes):
+        bpy.utils.unregister_class(cls)

--- a/MCprep_addon/spawner/spawn_util.py
+++ b/MCprep_addon/spawner/spawn_util.py
@@ -35,11 +35,11 @@ SKIP_COLL_LEGACY = "noimport"  # Supporting older MCprep Meshswap lib.
 
 # Icon backwards compatibility.
 if util.bv30():
-	COLL_ICON = 'OUTLINER_COLLECTION'
+    COLL_ICON = "OUTLINER_COLLECTION"
 elif util.bv28():
-	COLL_ICON = 'COLLECTION_NEW'
+    COLL_ICON = "COLLECTION_NEW"
 else:
-	COLL_ICON = 'GROUP'
+    COLL_ICON = "GROUP"
 
 # -----------------------------------------------------------------------------
 # Reusable functions for spawners
@@ -47,596 +47,598 @@ else:
 
 
 def filter_collections(data_from):
-	"""Generalized way to prefilter collections in a blend file.
+    """Generalized way to prefilter collections in a blend file.
 
-	Enforces the awareness of inclusion and exlcusion collection names, and
-	some hard coded cases to always ignore.
+    Enforces the awareness of inclusion and exlcusion collection names, and
+    some hard coded cases to always ignore.
 
-	Args:
-		data_from: The `from` part a bpy file reader scope.
-	"""
-	if hasattr(data_from, "groups"):  # blender 2.7
-		get_attr = "groups"
-	else:  # 2.8
-		get_attr = "collections"
+    Args:
+            data_from: The `from` part a bpy file reader scope.
+    """
+    if hasattr(data_from, "groups"):  # blender 2.7
+        get_attr = "groups"
+    else:  # 2.8
+        get_attr = "collections"
 
-	coll_list = [name for name in getattr(data_from, get_attr)]
+    coll_list = [name for name in getattr(data_from, get_attr)]
 
-	all_names = []
-	mcprep_names = []
+    all_names = []
+    mcprep_names = []
 
-	# Do a check to see if there are any collections that explicitly
-	# do include the text "MCprep" as a way of filtering which
-	# collections to include. Additionally, skip any rigs containing
-	# the special text for skipping.
-	any_mcprep = False
+    # Do a check to see if there are any collections that explicitly
+    # do include the text "MCprep" as a way of filtering which
+    # collections to include. Additionally, skip any rigs containing
+    # the special text for skipping.
+    any_mcprep = False
 
-	for name in coll_list:
-		# special cases, skip some groups
-		if util.nameGeneralize(name).lower() == "Rigidbodyworld".lower():
-			continue
-		if name.lower().startswith("collection"):
-			continue  # will drop e.g. "Collection 1" from blender 2.7x
+    for name in coll_list:
+        # special cases, skip some groups
+        if util.nameGeneralize(name).lower() == "Rigidbodyworld".lower():
+            continue
+        if name.lower().startswith("collection"):
+            continue  # will drop e.g. "Collection 1" from blender 2.7x
 
-		short = name.replace(" ", "").replace("-", "").replace("_", "")
-		if SKIP_COLL in short.lower():
-			env.log("Skipping collection: " + name)
-			continue
-		if SKIP_COLL_LEGACY in short.lower():
-			env.log("Skipping legacy collection: " + name)
-			continue
-		elif INCLUDE_COLL in name.lower():
-			any_mcprep = True
-			mcprep_names.append(name)
-		all_names.append(name)
+        short = name.replace(" ", "").replace("-", "").replace("_", "")
+        if SKIP_COLL in short.lower():
+            env.log("Skipping collection: " + name)
+            continue
+        if SKIP_COLL_LEGACY in short.lower():
+            env.log("Skipping legacy collection: " + name)
+            continue
+        elif INCLUDE_COLL in name.lower():
+            any_mcprep = True
+            mcprep_names.append(name)
+        all_names.append(name)
 
-	if any_mcprep:
-		env.log("Filtered from {} down to {} MCprep collections".format(
-			len(all_names), len(mcprep_names)))
-		all_names = mcprep_names
-	return all_names
+    if any_mcprep:
+        env.log(
+            "Filtered from {} down to {} MCprep collections".format(
+                len(all_names), len(mcprep_names)
+            )
+        )
+        all_names = mcprep_names
+    return all_names
 
 
 def check_blend_eligible(this_file, all_files):
-	"""Returns true if this_file is the BEST blend file variant for this rig.
+    """Returns true if this_file is the BEST blend file variant for this rig.
 
-	Created to better support older blender versions without having to
-	completely remake new rig contributions from scratch. See for more details:
-	https://github.com/TheDuckCow/MCprep/issues/317
+    Created to better support older blender versions without having to
+    completely remake new rig contributions from scratch. See for more details:
+    https://github.com/TheDuckCow/MCprep/issues/317
 
-	This function searches for "pre#.#.#" in the filename of passed in files,
-	where if found, it indicates that file should only be used if the current
-	running blender version is below that version (non inclusive). The function
-	then finds the highest versioned file and checks if this_file is that
-	the same one. If so, it returns true, otherwise returns false. Most rigs
-	do not have versioned names are are assumed to work with the latest blender
-	version, hence they are treated as a "max_ver" to never get thrown out.
+    This function searches for "pre#.#.#" in the filename of passed in files,
+    where if found, it indicates that file should only be used if the current
+    running blender version is below that version (non inclusive). The function
+    then finds the highest versioned file and checks if this_file is that
+    the same one. If so, it returns true, otherwise returns false. Most rigs
+    do not have versioned names are are assumed to work with the latest blender
+    version, hence they are treated as a "max_ver" to never get thrown out.
 
-	Examples, presuming current blender is v2.93
-	for list ["rig pre2.8.0", "rig"]
-		-> returns true for "rig"
-	for list ["rig pre2.8.0", "rig pre3.0.0", "rig"]
-		-> returns true for "rig pre3.0.0"
+    Examples, presuming current blender is v2.93
+    for list ["rig pre2.8.0", "rig"]
+            -> returns true for "rig"
+    for list ["rig pre2.8.0", "rig pre3.0.0", "rig"]
+            -> returns true for "rig pre3.0.0"
 
-	"""
-	basename = os.path.splitext(this_file)[0]
-	max_ver = (99, 99, 99)  # Standin for an impossibly high blender version.
+    """
+    basename = os.path.splitext(this_file)[0]
+    max_ver = (99, 99, 99)  # Standin for an impossibly high blender version.
 
-	# Regex code to any matches of pre#.#.# at very end of name.
-	# (pre) for exact match,
-	# [0-9]+ to match any 1+ numbers
-	# (\.[0-9]+) for any repeat number of .#
-	# +$ to ensure it's an ending group.
-	code = r'(?i)(pre)[0-9]+(\.[0-9]+)+$'
-	find_suffix = re.compile(code)
+    # Regex code to any matches of pre#.#.# at very end of name.
+    # (pre) for exact match,
+    # [0-9]+ to match any 1+ numbers
+    # (\.[0-9]+) for any repeat number of .#
+    # +$ to ensure it's an ending group.
+    code = r"(?i)(pre)[0-9]+(\.[0-9]+)+$"
+    find_suffix = re.compile(code)
 
-	def tuple_from_match(match):
-		prestr = match.group(0)  # At most one group given +$ ending condition.
-		vstr = prestr[3:]  # Chop off "pre".
-		tuple_ver = tuple([int(n) for n in vstr.split(".")])
-		return tuple_ver
+    def tuple_from_match(match):
+        prestr = match.group(0)  # At most one group given +$ ending condition.
+        vstr = prestr[3:]  # Chop off "pre".
+        tuple_ver = tuple([int(n) for n in vstr.split(".")])
+        return tuple_ver
 
-	matches = find_suffix.search(basename)
-	base_match = basename
+    matches = find_suffix.search(basename)
+    base_match = basename
 
-	# Exit early, or find the common base after splitting out " pre#.#.#.blend"
-	if matches:
-		base_match = re.split(code, basename)[0].strip()
-		this_ver = tuple_from_match(matches)
-		res = util.min_bv(this_ver, inclusive=True)
-		if res is True:
-			# E.g. rig pre3.0.0 in blender 3.0.1 or 3.0.0, so file ineligible.
-			return False
-		else:
-			# ie rig pre3.0.0 with current blender 2.9, so this is eligible -
-			# but another file might still be a better match.
-			pass
-	else:
-		this_ver = max_ver
+    # Exit early, or find the common base after splitting out " pre#.#.#.blend"
+    if matches:
+        base_match = re.split(code, basename)[0].strip()
+        this_ver = tuple_from_match(matches)
+        res = util.min_bv(this_ver, inclusive=True)
+        if res is True:
+            # E.g. rig pre3.0.0 in blender 3.0.1 or 3.0.0, so file ineligible.
+            return False
+        else:
+            # ie rig pre3.0.0 with current blender 2.9, so this is eligible -
+            # but another file might still be a better match.
+            pass
+    else:
+        this_ver = max_ver
 
-	# Iterate over all files, structure of:
-	# List of list[filepath, tuple detected]
-	other_eligible = []
-	for afile in all_files:
-		if not afile.startswith(base_match):
-			continue  # Not part of the same base name, skip it
+    # Iterate over all files, structure of:
+    # List of list[filepath, tuple detected]
+    other_eligible = []
+    for afile in all_files:
+        if not afile.startswith(base_match):
+            continue  # Not part of the same base name, skip it
 
-		base_afile = os.path.splitext(afile)[0]
-		matches = find_suffix.search(base_afile)
-		if matches:
-			tuple_ver = tuple_from_match(matches)
-			res = util.min_bv(tuple_ver, inclusive=True)
-			if res is False:
-				# E.g. rig pre3.0.0 in blender 2.9 is an eligible choice
-				other_eligible.append([tuple_ver, afile])
-		else:
-			# This would be the typical case of a "latest, non versioned" file.
-			# E.g. rig.blend with no "pre3.3.0" text, also a eligible choice.
-			# Give an artificial version to compare against for next step.
-			other_eligible.append([max_ver, afile])
+        base_afile = os.path.splitext(afile)[0]
+        matches = find_suffix.search(base_afile)
+        if matches:
+            tuple_ver = tuple_from_match(matches)
+            res = util.min_bv(tuple_ver, inclusive=True)
+            if res is False:
+                # E.g. rig pre3.0.0 in blender 2.9 is an eligible choice
+                other_eligible.append([tuple_ver, afile])
+        else:
+            # This would be the typical case of a "latest, non versioned" file.
+            # E.g. rig.blend with no "pre3.3.0" text, also a eligible choice.
+            # Give an artificial version to compare against for next step.
+            other_eligible.append([max_ver, afile])
 
-	if len(other_eligible) == 1:
-		# Only this_file is eligible, and thus must be "the one".
-		return True
+    if len(other_eligible) == 1:
+        # Only this_file is eligible, and thus must be "the one".
+        return True
 
-	# If multiple files, then we should use the one that is the largest version
-	# without being equal to or greater than the current running blender ver.
-	sorted_eligible = sorted(other_eligible, key=lambda x: x[0])
-	latest_allowed = None
-	for tple, afile in sorted_eligible:
-		if util.min_bv(tple, inclusive=True) is False:
-			latest_allowed = afile
-		else:
-			break
+    # If multiple files, then we should use the one that is the largest version
+    # without being equal to or greater than the current running blender ver.
+    sorted_eligible = sorted(other_eligible, key=lambda x: x[0])
+    latest_allowed = None
+    for tple, afile in sorted_eligible:
+        if util.min_bv(tple, inclusive=True) is False:
+            latest_allowed = afile
+        else:
+            break
 
-	return latest_allowed != this_file
+    return latest_allowed != this_file
 
 
 def attemptScriptLoad(path):
-	"""Search for script that matches name of the blend file"""
+    """Search for script that matches name of the blend file"""
 
-	# TODO: should also look into the blend if appropriate
-	# if the script already exists in blender, assume can reuse this
-	if not path[-5:] == "blend":
-		return
-	path = path[:-5] + "py"
+    # TODO: should also look into the blend if appropriate
+    # if the script already exists in blender, assume can reuse this
+    if not path[-5:] == "blend":
+        return
+    path = path[:-5] + "py"
 
-	if os.path.basename(path) in [txt.name for txt in bpy.data.texts]:
-		env.log("Script {} already imported, not importing a new one".format(
-			os.path.basename(path)))
-		return
+    if os.path.basename(path) in [txt.name for txt in bpy.data.texts]:
+        env.log(
+            "Script {} already imported, not importing a new one".format(
+                os.path.basename(path)
+            )
+        )
+        return
 
-	if not os.path.isfile(path):
-		return  # no script found
-	env.log("Script found, loading and running it")
-	text = bpy.data.texts.load(filepath=path, internal=True)
-	try:
-		ctx = bpy.context.copy()
-		ctx['edit_text'] = text
-	except Exception as err:
-		print("MCprep: Error trying to create context to run script in:")
-		print(str(err))
-	try:
-		bpy.ops.text.run_script(ctx)
-		ctx.use_fake_user = True
-		ctx.use_module = True
-	except:
-		env.log("Failed to run the script, not registering")
-		return
-	env.log("Ran the script")
-	text.use_module = True
+    if not os.path.isfile(path):
+        return  # no script found
+    env.log("Script found, loading and running it")
+    text = bpy.data.texts.load(filepath=path, internal=True)
+    try:
+        ctx = bpy.context.copy()
+        ctx["edit_text"] = text
+    except Exception as err:
+        print("MCprep: Error trying to create context to run script in:")
+        print(str(err))
+    try:
+        bpy.ops.text.run_script(ctx)
+        ctx.use_fake_user = True
+        ctx.use_module = True
+    except:
+        env.log("Failed to run the script, not registering")
+        return
+    env.log("Ran the script")
+    text.use_module = True
 
 
 def fix_armature_target(self, context, new_objs, src_coll):
-	"""Addresses 2.8 bug where make real might not update armature source"""
+    """Addresses 2.8 bug where make real might not update armature source"""
 
-	src_armas = [
-		arma for arma in src_coll.objects if arma.type == 'ARMATURE']
-	new_armas = [
-		arma for arma in new_objs if arma.type == 'ARMATURE']
-	src_armas_basnames = [util.nameGeneralize(obj.name) for obj in src_armas]
-	new_armas_basnames = [util.nameGeneralize(obj.name) for obj in new_armas]
-	if not new_armas:
-		return  # Nothing we can do to fix if new arma not existing.
-	for obj in new_objs:
-		for mod in obj.modifiers:
-			# two scenarios:
-			# if 2.7: armature modifier already changed, copy over anim data
-			# if 2.8: swap modifier armature and also copy over anim data
-			if mod.type != 'ARMATURE':
-				continue
-			# if not (mod.object in new_objs or mod.object in src_armas):
-			#       continue # all good (from mod arma target perspective)
-			if mod.object not in src_armas and mod.object not in new_armas:
-				continue  # Unknown source, no way to know how to fix this.
-			target_base = util.nameGeneralize(mod.object.name)
-			if target_base not in new_armas_basnames:
-				continue  # Shouldn't occur, but skip if it does.
+    src_armas = [arma for arma in src_coll.objects if arma.type == "ARMATURE"]
+    new_armas = [arma for arma in new_objs if arma.type == "ARMATURE"]
+    src_armas_basnames = [util.nameGeneralize(obj.name) for obj in src_armas]
+    new_armas_basnames = [util.nameGeneralize(obj.name) for obj in new_armas]
+    if not new_armas:
+        return  # Nothing we can do to fix if new arma not existing.
+    for obj in new_objs:
+        for mod in obj.modifiers:
+            # two scenarios:
+            # if 2.7: armature modifier already changed, copy over anim data
+            # if 2.8: swap modifier armature and also copy over anim data
+            if mod.type != "ARMATURE":
+                continue
+            # if not (mod.object in new_objs or mod.object in src_armas):
+            #       continue # all good (from mod arma target perspective)
+            if mod.object not in src_armas and mod.object not in new_armas:
+                continue  # Unknown source, no way to know how to fix this.
+            target_base = util.nameGeneralize(mod.object.name)
+            if target_base not in new_armas_basnames:
+                continue  # Shouldn't occur, but skip if it does.
 
-			new_target = new_armas[new_armas_basnames.index(target_base)]
-			old_target = src_armas[src_armas_basnames.index(target_base)]
+            new_target = new_armas[new_armas_basnames.index(target_base)]
+            old_target = src_armas[src_armas_basnames.index(target_base)]
 
-			# for blender 2.8, bug is that target is still old_target
-			# but for blender 2.7, the mod target will already have changed
-			if old_target.animation_data:
-				new_target.animation_data_create()
-				new_target.animation_data.action = old_target.animation_data.action
-				env.log(
-					"Updated animation of armature for instance of " + src_coll.name)
+            # for blender 2.8, bug is that target is still old_target
+            # but for blender 2.7, the mod target will already have changed
+            if old_target.animation_data:
+                new_target.animation_data_create()
+                new_target.animation_data.action = old_target.animation_data.action
+                env.log(
+                    "Updated animation of armature for instance of " + src_coll.name
+                )
 
-			if mod.object in new_objs:
-				continue  # Was already the new object target for modifier.
-			mod.object = new_target
-			env.log(
-				"Updated target of armature for instance of " + src_coll.name)
+            if mod.object in new_objs:
+                continue  # Was already the new object target for modifier.
+            mod.object = new_target
+            env.log("Updated target of armature for instance of " + src_coll.name)
 
 
 def prep_collection(self, context, name, pre_groups):
-	"""Prep the imported collection, ran only if newly imported (not cached)"""
+    """Prep the imported collection, ran only if newly imported (not cached)"""
 
-	# Group method first, move append to according layer
-	for ob in util.get_objects_conext(context):
-		util.select_set(ob, False)
+    # Group method first, move append to according layer
+    for ob in util.get_objects_conext(context):
+        util.select_set(ob, False)
 
-	layers = [False] * 20
-	if not hasattr(context.scene, "layers"):
-		# TODO: here add all subcollections to an MCprepLib collection.
-		pass
-	elif self.append_layer == 0:
-		layers = context.scene.layers
-	else:
-		layers[self.append_layer - 1] = True
-	objlist = []
-	group = None
-	for coll in util.collections():
-		if coll in pre_groups:
-			continue
-		if coll.name.lower().startswith("collection"):
-			continue  # Will drop e.g. "Collection 1" from blender 2.7x.
-		for ob in coll.objects:
-			if ob.name in context.scene.objects:
-				# context.scene.objects.unlink(ob)
-				objlist.append(ob)
-		if util.nameGeneralize(coll.name) == util.nameGeneralize(name):
-			group = coll
+    layers = [False] * 20
+    if not hasattr(context.scene, "layers"):
+        # TODO: here add all subcollections to an MCprepLib collection.
+        pass
+    elif self.append_layer == 0:
+        layers = context.scene.layers
+    else:
+        layers[self.append_layer - 1] = True
+    objlist = []
+    group = None
+    for coll in util.collections():
+        if coll in pre_groups:
+            continue
+        if coll.name.lower().startswith("collection"):
+            continue  # Will drop e.g. "Collection 1" from blender 2.7x.
+        for ob in coll.objects:
+            if ob.name in context.scene.objects:
+                # context.scene.objects.unlink(ob)
+                objlist.append(ob)
+        if util.nameGeneralize(coll.name) == util.nameGeneralize(name):
+            group = coll
 
-	if group is None:
-		return None
+    if group is None:
+        return None
 
-	if self.prep_materials is True:
-		for ob in objlist:
-			util.select_set(ob, True)
-		try:
-			bpy.ops.mcprep.prep_materials(
-				autoFindMissingTextures=False,
-				improveUiSettings=False,
-				skipUsage=True)  # if cycles
-		except:
-			print("Could not prep materials")
-		for ob in util.get_objects_conext(context):
-			util.select_set(ob, False)
+    if self.prep_materials is True:
+        for ob in objlist:
+            util.select_set(ob, True)
+        try:
+            bpy.ops.mcprep.prep_materials(
+                autoFindMissingTextures=False, improveUiSettings=False, skipUsage=True
+            )  # if cycles
+        except:
+            print("Could not prep materials")
+        for ob in util.get_objects_conext(context):
+            util.select_set(ob, False)
 
-	if hasattr(context.scene, "layers"):  # 2.7 only
-		for obj in objlist:
-			obj.layers = layers
-	return group
+    if hasattr(context.scene, "layers"):  # 2.7 only
+        for obj in objlist:
+            obj.layers = layers
+    return group
 
 
 def get_rig_from_objects(objects):
-	"""From a list of objects, return the the primary rig (best guess)"""
-	prox_obj = None
-	for obj in objects:
-		if obj.type != 'ARMATURE':
-			continue
-		elif obj.name.lower().endswith('.arma'):
-			prox_obj = obj
-			break
-		elif not prox_obj:
-			prox_obj = obj
-		elif "rig" in obj.name.lower() and "rig" not in prox_obj.name.lower():
-			prox_obj = obj
-	return prox_obj
+    """From a list of objects, return the the primary rig (best guess)"""
+    prox_obj = None
+    for obj in objects:
+        if obj.type != "ARMATURE":
+            continue
+        elif obj.name.lower().endswith(".arma"):
+            prox_obj = obj
+            break
+        elif not prox_obj:
+            prox_obj = obj
+        elif "rig" in obj.name.lower() and "rig" not in prox_obj.name.lower():
+            prox_obj = obj
+    return prox_obj
 
 
 def offset_root_bone(context, armature):
-	"""Used to offset bone to world location (cursor)"""
-	env.log("Attempting offset root")
-	set_bone = False
-	lower_bones = [bone.name.lower() for bone in armature.pose.bones]
-	lower_name = None
-	for name in ["main", "root", "base", "master"]:
-		if name in lower_bones:
-			lower_name = name
-			break
-	if not lower_name:
-		return False
+    """Used to offset bone to world location (cursor)"""
+    env.log("Attempting offset root")
+    set_bone = False
+    lower_bones = [bone.name.lower() for bone in armature.pose.bones]
+    lower_name = None
+    for name in ["main", "root", "base", "master"]:
+        if name in lower_bones:
+            lower_name = name
+            break
+    if not lower_name:
+        return False
 
-	for bone in armature.pose.bones:
-		if bone.name.lower() != lower_name:
-			continue
-		bone.location = util.matmul(
-			bone.bone.matrix.inverted(),
-			util.get_cuser_location(context),
-			armature.matrix_world.inverted()
-		)
+    for bone in armature.pose.bones:
+        if bone.name.lower() != lower_name:
+            continue
+        bone.location = util.matmul(
+            bone.bone.matrix.inverted(),
+            util.get_cuser_location(context),
+            armature.matrix_world.inverted(),
+        )
 
-		set_bone = True
-		break
-	return set_bone
+        set_bone = True
+        break
+    return set_bone
 
 
 def load_linked(self, context, path, name):
-	"""Process for loading mob or entity via linked library.
+    """Process for loading mob or entity via linked library.
 
-	Used by mob spawner when chosing to link instead of append.
-	"""
+    Used by mob spawner when chosing to link instead of append.
+    """
 
-	path = bpy.path.abspath(path)
-	act = None
-	if hasattr(bpy.data, "groups"):
-		res = util.bAppendLink(path + '/Group', name, True)
-		act = context.object  # assumption of object after linking, 2.7 only
-	elif hasattr(bpy.data, "collections"):
-		res = util.bAppendLink(path + '/Collection', name, True)
-		if len(context.selected_objects) > 0:
-			act = context.selected_objects[0]  # better for 2.8
-		else:
-			print("Error: Should have had at least one object selected.")
+    path = bpy.path.abspath(path)
+    act = None
+    if hasattr(bpy.data, "groups"):
+        res = util.bAppendLink(path + "/Group", name, True)
+        act = context.object  # assumption of object after linking, 2.7 only
+    elif hasattr(bpy.data, "collections"):
+        res = util.bAppendLink(path + "/Collection", name, True)
+        if len(context.selected_objects) > 0:
+            act = context.selected_objects[0]  # better for 2.8
+        else:
+            print("Error: Should have had at least one object selected.")
 
-	if res is False:
-		# Most likely scenario, path was wrong and raised "not a library".
-		# end and automatically reload assets.
-		self.report({'WARNING'}, "Failed to load asset file")
-		bpy.ops.mcprep.prompt_reset_spawners('INVOKE_DEFAULT')
-		return
+    if res is False:
+        # Most likely scenario, path was wrong and raised "not a library".
+        # end and automatically reload assets.
+        self.report({"WARNING"}, "Failed to load asset file")
+        bpy.ops.mcprep.prompt_reset_spawners("INVOKE_DEFAULT")
+        return
 
-	# util.bAppendLink(os.path.join(path, g_or_c), name, True)
-	# proxy any and all armatures
-	# here should do all that jazz with hacking by copying files, checking
-	# nth number probably consists of checking currently linked libraries,
-	# checking if which have already been linked into existing rigs.
-	# if util.bv28() and context.selected_objects:
-	# 	act = context.selected_objects[0] # better for 2.8
-	# elif context.object:
-	# 	act = context.object  # assumption of object after linking
-	env.log("Identified new obj as: {}".format(
-		act), vv_only=True)
+    # util.bAppendLink(os.path.join(path, g_or_c), name, True)
+    # proxy any and all armatures
+    # here should do all that jazz with hacking by copying files, checking
+    # nth number probably consists of checking currently linked libraries,
+    # checking if which have already been linked into existing rigs.
+    # if util.bv28() and context.selected_objects:
+    # 	act = context.selected_objects[0] # better for 2.8
+    # elif context.object:
+    # 	act = context.object  # assumption of object after linking
+    env.log("Identified new obj as: {}".format(act), vv_only=True)
 
-	if not act:
-		self.report({'ERROR'}, "Could not grab linked in object if any.")
-		return
-	if self.relocation == "Origin":
-		act.location = (0, 0, 0)
+    if not act:
+        self.report({"ERROR"}, "Could not grab linked in object if any.")
+        return
+    if self.relocation == "Origin":
+        act.location = (0, 0, 0)
 
-	# find the best armature to proxy, if any
-	prox_obj = None
-	if not act.type == "EMPTY":
-		self.report({'WARNING'}, "Linked object should be type: empty")
-		return
-	elif not util.instance_collection(act):
-		self.report({'WARNING'}, "Linked object has no dupligroup")
-		return
-	else:
-		prox_obj = get_rig_from_objects(
-			util.instance_collection(act).objects)
-	if not prox_obj:
-		self.report({'WARNING'}, "No object found to proxy")
-		return
+    # find the best armature to proxy, if any
+    prox_obj = None
+    if not act.type == "EMPTY":
+        self.report({"WARNING"}, "Linked object should be type: empty")
+        return
+    elif not util.instance_collection(act):
+        self.report({"WARNING"}, "Linked object has no dupligroup")
+        return
+    else:
+        prox_obj = get_rig_from_objects(util.instance_collection(act).objects)
+    if not prox_obj:
+        self.report({"WARNING"}, "No object found to proxy")
+        return
 
-	if "proxy_make" in dir(bpy.ops.object):
-		# The pre 3.0 way.
-		# Can't check using hasattr, as the leftover class is still there
-		# even though the operator no longer is callable.
-		bpy.ops.object.proxy_make(object=prox_obj.name)
-	elif hasattr(bpy.ops.object, "make_override_library"):
-		# Was in some 2.9x versions, but prefer proxy_make for consistency.
-		pre_colls = list(bpy.data.collections)
-		bpy.ops.object.make_override_library()  # Must be active.
-		post_colls = list(bpy.data.collections)
-		new_colls = list(set(post_colls) - set(pre_colls))
-		if len(new_colls) == 1:
-			act = get_rig_from_objects(new_colls[0].all_objects)
-			util.set_active_object(context, act)
-		else:
-			print("Error: failed to get new override collection")
-			raise Exception("Failed to get override collection")
+    if "proxy_make" in dir(bpy.ops.object):
+        # The pre 3.0 way.
+        # Can't check using hasattr, as the leftover class is still there
+        # even though the operator no longer is callable.
+        bpy.ops.object.proxy_make(object=prox_obj.name)
+    elif hasattr(bpy.ops.object, "make_override_library"):
+        # Was in some 2.9x versions, but prefer proxy_make for consistency.
+        pre_colls = list(bpy.data.collections)
+        bpy.ops.object.make_override_library()  # Must be active.
+        post_colls = list(bpy.data.collections)
+        new_colls = list(set(post_colls) - set(pre_colls))
+        if len(new_colls) == 1:
+            act = get_rig_from_objects(new_colls[0].all_objects)
+            util.set_active_object(context, act)
+        else:
+            print("Error: failed to get new override collection")
+            raise Exception("Failed to get override collection")
 
-	coll = util.instance_collection(act)
-	if hasattr(coll, "dupli_offset"):
-		gl = coll.dupli_offset
-	elif hasattr(act, "instance_offset"):
-		gl = coll.instance_offset
-	else:
-		# fallback to ensure gl defined as showed up in user errors,
-		# but not clear how this happens
-		print("WARNING: Assigned fallback gl of (0,0,0)")
-		gl = (0, 0, 0)
-	# cl = util.get_cuser_location(context)
+    coll = util.instance_collection(act)
+    if hasattr(coll, "dupli_offset"):
+        gl = coll.dupli_offset
+    elif hasattr(act, "instance_offset"):
+        gl = coll.instance_offset
+    else:
+        # fallback to ensure gl defined as showed up in user errors,
+        # but not clear how this happens
+        print("WARNING: Assigned fallback gl of (0,0,0)")
+        gl = (0, 0, 0)
+    # cl = util.get_cuser_location(context)
 
-	if self.relocation == "Offset":
-		# do the offset stuff, set active etc
-		bpy.ops.transform.translate(value=(-gl[0], -gl[1], -gl[2]))
+    if self.relocation == "Offset":
+        # do the offset stuff, set active etc
+        bpy.ops.transform.translate(value=(-gl[0], -gl[1], -gl[2]))
 
-	try:
-		bpy.ops.object.mode_set(mode='POSE')
-		act = bpy.context.object
-	except:
-		self.report({'WARNING'}, "Could not enter pose mode on linked character")
-		return
-	if self.clearPose:
-		bpy.ops.pose.select_all(action='SELECT')
-		bpy.ops.pose.rot_clear()
-		bpy.ops.pose.scale_clear()
-		bpy.ops.pose.loc_clear()
-	if self.relocation == "Offset":
-		set_bone = offset_root_bone(context, act)
-		if not set_bone:
-			print(
-				"MCprep mob spawning works better when the root bone's name is 'MAIN'")
-			self.report(
-				{'INFO'}, "This addon works better when the root bone's name is 'MAIN'")
+    try:
+        bpy.ops.object.mode_set(mode="POSE")
+        act = bpy.context.object
+    except:
+        self.report({"WARNING"}, "Could not enter pose mode on linked character")
+        return
+    if self.clearPose:
+        bpy.ops.pose.select_all(action="SELECT")
+        bpy.ops.pose.rot_clear()
+        bpy.ops.pose.scale_clear()
+        bpy.ops.pose.loc_clear()
+    if self.relocation == "Offset":
+        set_bone = offset_root_bone(context, act)
+        if not set_bone:
+            print(
+                "MCprep mob spawning works better when the root bone's name is 'MAIN'"
+            )
+            self.report(
+                {"INFO"}, "This addon works better when the root bone's name is 'MAIN'"
+            )
 
 
 def load_append(self, context, path, name):
-	"""Append an entire collection/group into this blend file and fix armature.
+    """Append an entire collection/group into this blend file and fix armature.
 
-	Used for both mob spawning and entity spawning with appropriate handling
-	of rig objects. Not used by meshswap.
-	"""
-	if path == '//':
-		# This means the group HAS already been appended..
-		# Could try to recopy thsoe elements, or try re-appending with
-		# renaming of the original group
-		self.report({'ERROR'}, "Group name already exists in local file")
-		env.log("Group already appended/is here")
-		return
+    Used for both mob spawning and entity spawning with appropriate handling
+    of rig objects. Not used by meshswap.
+    """
+    if path == "//":
+        # This means the group HAS already been appended..
+        # Could try to recopy thsoe elements, or try re-appending with
+        # renaming of the original group
+        self.report({"ERROR"}, "Group name already exists in local file")
+        env.log("Group already appended/is here")
+        return
 
-	path = bpy.path.abspath(path)
-	# capture state before, technically also copy
-	sel = bpy.context.selected_objects
-	for ob in util.get_objects_conext(context):
-		util.select_set(ob, False)
-	# consider taking pre-exisitng group names and giving them a temp name
-	# to name back at the end
+    path = bpy.path.abspath(path)
+    # capture state before, technically also copy
+    sel = bpy.context.selected_objects
+    for ob in util.get_objects_conext(context):
+        util.select_set(ob, False)
+    # consider taking pre-exisitng group names and giving them a temp name
+    # to name back at the end
 
-	if hasattr(bpy.data, "groups"):
-		subpath = 'Group'
-	elif hasattr(bpy.data, "collections"):
-		subpath = 'Collection'
-	else:
-		raise Exception("No Group or Collection bpy API endpoint")
+    if hasattr(bpy.data, "groups"):
+        subpath = "Group"
+    elif hasattr(bpy.data, "collections"):
+        subpath = "Collection"
+    else:
+        raise Exception("No Group or Collection bpy API endpoint")
 
-	env.log(os.path.join(path, subpath) + ', ' + name)
-	pregroups = list(util.collections())
-	res = util.bAppendLink(os.path.join(path, subpath), name, False)
-	postgroups = list(util.collections())
+    env.log(os.path.join(path, subpath) + ", " + name)
+    pregroups = list(util.collections())
+    res = util.bAppendLink(os.path.join(path, subpath), name, False)
+    postgroups = list(util.collections())
 
-	new_groups = list(set(postgroups) - set(pregroups))
-	if res is False:
-		# Most likely scenario, path was wrong and raised "not a library".
-		# end and automatically reload assets.
-		self.report({'WARNING'}, "Failed to load asset file")
-		bpy.ops.mcprep.prompt_reset_spawners('INVOKE_DEFAULT')
-		return
-	if not new_groups and name in util.collections():
-		# this is more likely to fail but serves as a fallback
-		env.log("Mob spawn: Had to go to fallback group name grab")
-		grp_added = util.collections()[name]
-	elif not new_groups:
-		env.log("Warning, could not detect imported group")
-		self.report({'WARNING'}, "Could not detect imported group")
-		return
-	else:
-		grp_added = new_groups[0]  # Start with first assigned
-		for grp in new_groups:
-			if grp.name.startswith(name):
-				# But then pick the better matching one, in case the first
-				# group is a subcollection of another name.
-				grp_added = grp
+    new_groups = list(set(postgroups) - set(pregroups))
+    if res is False:
+        # Most likely scenario, path was wrong and raised "not a library".
+        # end and automatically reload assets.
+        self.report({"WARNING"}, "Failed to load asset file")
+        bpy.ops.mcprep.prompt_reset_spawners("INVOKE_DEFAULT")
+        return
+    if not new_groups and name in util.collections():
+        # this is more likely to fail but serves as a fallback
+        env.log("Mob spawn: Had to go to fallback group name grab")
+        grp_added = util.collections()[name]
+    elif not new_groups:
+        env.log("Warning, could not detect imported group")
+        self.report({"WARNING"}, "Could not detect imported group")
+        return
+    else:
+        grp_added = new_groups[0]  # Start with first assigned
+        for grp in new_groups:
+            if grp.name.startswith(name):
+                # But then pick the better matching one, in case the first
+                # group is a subcollection of another name.
+                grp_added = grp
 
-	env.log("Identified collection/group {} as the primary imported".format(
-		grp_added), vv_only=True)
+    env.log(
+        "Identified collection/group {} as the primary imported".format(grp_added),
+        vv_only=True,
+    )
 
-	# if rig not centered in original file, assume its group is
-	if hasattr(grp_added, "dupli_offset"):  # 2.7
-		gl = grp_added.dupli_offset
-	elif hasattr(grp_added, "instance_offset"):  # 2.8
-		gl = grp_added.instance_offset
-	else:
-		env.log("Warning, could not set offset for group; null type?")
-		gl = (0, 0, 0)
-	cl = util.get_cuser_location(context)
+    # if rig not centered in original file, assume its group is
+    if hasattr(grp_added, "dupli_offset"):  # 2.7
+        gl = grp_added.dupli_offset
+    elif hasattr(grp_added, "instance_offset"):  # 2.8
+        gl = grp_added.instance_offset
+    else:
+        env.log("Warning, could not set offset for group; null type?")
+        gl = (0, 0, 0)
+    cl = util.get_cuser_location(context)
 
-	# For some reason, adding group objects on its own doesn't work
-	all_objects = context.selected_objects
-	addedObjs = [ob for ob in grp_added.objects]
-	for ob in all_objects:
-		if ob not in addedObjs:
-			env.log("This obj not in group {}: {}".format(
-				grp_added.name, ob.name))
-			# removes things like random bone shapes pulled in,
-			# without deleting them, just unlinking them from the scene
-			util.obj_unlink_remove(ob, False, context)
+    # For some reason, adding group objects on its own doesn't work
+    all_objects = context.selected_objects
+    addedObjs = [ob for ob in grp_added.objects]
+    for ob in all_objects:
+        if ob not in addedObjs:
+            env.log("This obj not in group {}: {}".format(grp_added.name, ob.name))
+            # removes things like random bone shapes pulled in,
+            # without deleting them, just unlinking them from the scene
+            util.obj_unlink_remove(ob, False, context)
 
-	if not util.bv28():
-		grp_added.name = "reload-blend-to-remove-this-empty-group"
-		for obj in grp_added.objects:
-			grp_added.objects.unlink(obj)
-			util.select_set(obj, True)
-		grp_added.user_clear()
-	else:
-		for obj in grp_added.objects:
-			if obj not in context.view_layer.objects[:]:
-				continue
-			util.select_set(obj, True)
+    if not util.bv28():
+        grp_added.name = "reload-blend-to-remove-this-empty-group"
+        for obj in grp_added.objects:
+            grp_added.objects.unlink(obj)
+            util.select_set(obj, True)
+        grp_added.user_clear()
+    else:
+        for obj in grp_added.objects:
+            if obj not in context.view_layer.objects[:]:
+                continue
+            util.select_set(obj, True)
 
-	# try:
-	# 	util.collections().remove(grp_added)
-	# 	This can cause redo last issues
-	# except:
-	# 	pass
-	rig_obj = get_rig_from_objects(addedObjs)
-	if not rig_obj:
-		env.log("Could not get rig object")
-		self.report({'WARNING'}, "No armatures found!")
-	else:
-		env.log("Using object as primary rig: " + rig_obj.name)
-		try:
-			util.set_active_object(context, rig_obj)
-		except RuntimeError:
-			env.log("Failed to set {} as active".format(rig_obj))
-			rig_obj = None
+    # try:
+    # 	util.collections().remove(grp_added)
+    # 	This can cause redo last issues
+    # except:
+    # 	pass
+    rig_obj = get_rig_from_objects(addedObjs)
+    if not rig_obj:
+        env.log("Could not get rig object")
+        self.report({"WARNING"}, "No armatures found!")
+    else:
+        env.log("Using object as primary rig: " + rig_obj.name)
+        try:
+            util.set_active_object(context, rig_obj)
+        except RuntimeError:
+            env.log("Failed to set {} as active".format(rig_obj))
+            rig_obj = None
 
-	if rig_obj and self.clearPose or rig_obj and self.relocation == "Offset":
-		if self.relocation == "Offset":
-			bpy.ops.transform.translate(value=(-gl[0], -gl[1], -gl[2]))
-		try:
-			bpy.ops.object.mode_set(mode='POSE')
-		except Exception as e:
-			self.report({'ERROR'}, "Failed to enter pose mode: " + str(e))
-			print("Failed to enter pose mode, see logs")
-			print("Exception: ", str(e))
-			print(bpy.context.object)
-			print(rig_obj)
-			print("Mode: ", context.mode)
-			print("-- end error context printout --")
+    if rig_obj and self.clearPose or rig_obj and self.relocation == "Offset":
+        if self.relocation == "Offset":
+            bpy.ops.transform.translate(value=(-gl[0], -gl[1], -gl[2]))
+        try:
+            bpy.ops.object.mode_set(mode="POSE")
+        except Exception as e:
+            self.report({"ERROR"}, "Failed to enter pose mode: " + str(e))
+            print("Failed to enter pose mode, see logs")
+            print("Exception: ", str(e))
+            print(bpy.context.object)
+            print(rig_obj)
+            print("Mode: ", context.mode)
+            print("-- end error context printout --")
 
-		posemode = context.mode == 'POSE'
+        posemode = context.mode == "POSE"
 
-		if self.clearPose:
-			if rig_obj.animation_data:
-				rig_obj.animation_data.action = None
-			# transition to clear out pose this way
-			# for b in ob.pose.bones:
-			# old way, with mode set
-			if posemode:
-				bpy.ops.pose.select_all(action='SELECT')
-				bpy.ops.pose.rot_clear()
-				bpy.ops.pose.scale_clear()
-				bpy.ops.pose.loc_clear()
+        if self.clearPose:
+            if rig_obj.animation_data:
+                rig_obj.animation_data.action = None
+            # transition to clear out pose this way
+            # for b in ob.pose.bones:
+            # old way, with mode set
+            if posemode:
+                bpy.ops.pose.select_all(action="SELECT")
+                bpy.ops.pose.rot_clear()
+                bpy.ops.pose.scale_clear()
+                bpy.ops.pose.loc_clear()
 
-		if self.relocation == "Offset" and posemode:
-			set_bone = offset_root_bone(context, rig_obj)
-			if not set_bone:
-				env.log(
-					"This addon works better when the root bone's name is 'MAIN'")
-				self.report(
-					{'INFO'},
-					"Works better if armature has a root bone named 'MAIN' or 'ROOT'")
+        if self.relocation == "Offset" and posemode:
+            set_bone = offset_root_bone(context, rig_obj)
+            if not set_bone:
+                env.log("This addon works better when the root bone's name is 'MAIN'")
+                self.report(
+                    {"INFO"},
+                    "Works better if armature has a root bone named 'MAIN' or 'ROOT'",
+                )
 
-	# now do the extra options, e.g. the object-level offsets
-	if context.mode != 'OBJECT':
-		bpy.ops.object.mode_set(mode='OBJECT')
-	if self.relocation == "Origin":
-		bpy.ops.transform.translate(value=(-gl[0], -gl[1], -gl[2]))
-	elif self.relocation == "Cursor":
-		bpy.ops.transform.translate(value=(
-			cl[0] - gl[0],
-			cl[1] - gl[1],
-			cl[2] - gl[2]))
-	# add the original selection back
-	for objs in sel:
-		util.select_set(objs, True)
+    # now do the extra options, e.g. the object-level offsets
+    if context.mode != "OBJECT":
+        bpy.ops.object.mode_set(mode="OBJECT")
+    if self.relocation == "Origin":
+        bpy.ops.transform.translate(value=(-gl[0], -gl[1], -gl[2]))
+    elif self.relocation == "Cursor":
+        bpy.ops.transform.translate(value=(cl[0] - gl[0], cl[1] - gl[1], cl[2] - gl[2]))
+    # add the original selection back
+    for objs in sel:
+        util.select_set(objs, True)
+
 
 # -----------------------------------------------------------------------------
 # class definitions
@@ -644,66 +646,69 @@ def load_append(self, context, path, name):
 
 
 class MCPREP_OT_reload_spawners(bpy.types.Operator):
-	"""Relaod meshswapping and spawning lists"""
-	bl_idname = "mcprep.reload_spawners"
-	bl_label = "Reload meshswap and mob spawners"
-	bl_options = {'REGISTER', 'UNDO'}
+    """Relaod meshswapping and spawning lists"""
 
-	@tracking.report_error
-	def execute(self, context):
-		_ = util.load_mcprep_json()  # For cases when to prep/make real.
-		bpy.ops.mcprep.reload_meshswap()
-		bpy.ops.mcprep.reload_mobs()
-		bpy.ops.mcprep.reload_items()
-		bpy.ops.mcprep.reload_effects()
-		bpy.ops.mcprep.reload_entities()
-		bpy.ops.mcprep.reload_models()
+    bl_idname = "mcprep.reload_spawners"
+    bl_label = "Reload meshswap and mob spawners"
+    bl_options = {"REGISTER", "UNDO"}
 
-		# to prevent re-drawing "load spawners!" if any one of the above
-		# loaded nothing for any reason.
-		env.loaded_all_spawners = True
+    @tracking.report_error
+    def execute(self, context):
+        _ = util.load_mcprep_json()  # For cases when to prep/make real.
+        bpy.ops.mcprep.reload_meshswap()
+        bpy.ops.mcprep.reload_mobs()
+        bpy.ops.mcprep.reload_items()
+        bpy.ops.mcprep.reload_effects()
+        bpy.ops.mcprep.reload_entities()
+        bpy.ops.mcprep.reload_models()
 
-		return {'FINISHED'}
+        # to prevent re-drawing "load spawners!" if any one of the above
+        # loaded nothing for any reason.
+        env.loaded_all_spawners = True
+
+        return {"FINISHED"}
 
 
 class MCPREP_OT_spawn_path_reset(bpy.types.Operator):
-	"""Reset the spawn path to the default in addon preferences panel"""
-	bl_idname = "mcprep.spawn_path_reset"
-	bl_label = "Reset spawn path"
-	bl_options = {'REGISTER', 'UNDO'}
+    """Reset the spawn path to the default in addon preferences panel"""
 
-	@tracking.report_error
-	def execute(self, context):
-		addon_prefs = util.get_user_preferences(context)
-		context.scene.mcprep_mob_path = addon_prefs.mob_path
-		mobs.update_rig_list(context)
-		return {'FINISHED'}
+    bl_idname = "mcprep.spawn_path_reset"
+    bl_label = "Reset spawn path"
+    bl_options = {"REGISTER", "UNDO"}
+
+    @tracking.report_error
+    def execute(self, context):
+        addon_prefs = util.get_user_preferences(context)
+        context.scene.mcprep_mob_path = addon_prefs.mob_path
+        mobs.update_rig_list(context)
+        return {"FINISHED"}
 
 
 class MCPREP_OT_prompt_reset_spawners(bpy.types.Operator):
-	"""Reset the all spawner paths to the default in addon preferences"""
-	bl_idname = "mcprep.prompt_reset_spawners"
-	bl_label = "Reset spawner & texturepath paths"
-	bl_options = {'REGISTER', 'UNDO'}
+    """Reset the all spawner paths to the default in addon preferences"""
 
-	def invoke(self, context, event):
-		return context.window_manager.invoke_props_dialog(self)
+    bl_idname = "mcprep.prompt_reset_spawners"
+    bl_label = "Reset spawner & texturepath paths"
+    bl_options = {"REGISTER", "UNDO"}
 
-	def draw(self, context):
-		col = self.layout.column(align=True)
-		col.scale_y = 0.8
-		col.label(text="A spawner directory/file is missing.")
-		col.label(text="Reset all spawner paths to default?")
+    def invoke(self, context, event):
+        return context.window_manager.invoke_props_dialog(self)
 
-	@tracking.report_error
-	def execute(self, context):
-		bpy.ops.mcprep.spawn_path_reset()
-		bpy.ops.mcprep.reset_texture_path()
-		bpy.ops.mcprep.effects_path_reset()
-		bpy.ops.mcprep.entity_path_reset()
-		bpy.ops.mcprep.meshswap_path_reset()
+    def draw(self, context):
+        col = self.layout.column(align=True)
+        col.scale_y = 0.8
+        col.label(text="A spawner directory/file is missing.")
+        col.label(text="Reset all spawner paths to default?")
 
-		return {'FINISHED'}
+    @tracking.report_error
+    def execute(self, context):
+        bpy.ops.mcprep.spawn_path_reset()
+        bpy.ops.mcprep.reset_texture_path()
+        bpy.ops.mcprep.effects_path_reset()
+        bpy.ops.mcprep.entity_path_reset()
+        bpy.ops.mcprep.meshswap_path_reset()
+
+        return {"FINISHED"}
 
 
 # -----------------------------------------------------------------------------
@@ -712,208 +717,253 @@ class MCPREP_OT_prompt_reset_spawners(bpy.types.Operator):
 
 
 class MCPREP_UL_mob(bpy.types.UIList):
-	"""For mob asset listing UIList drawing"""
-	def draw_item(self, context, layout, data, set, icon, active_data, active_propname, index):
-		icon = "mob-{}".format(set.index)
-		if self.layout_type in {'DEFAULT', 'COMPACT'}:
-			if not env.use_icons:
-				layout.label(text=set.name)
-			elif env.use_icons and icon in env.preview_collections["mobs"]:
-				layout.label(
-					text=set.name,
-					icon_value=env.preview_collections["mobs"][icon].icon_id)
-			else:
-				layout.label(text=set.name, icon="BLANK1")
+    """For mob asset listing UIList drawing"""
 
-		elif self.layout_type in {'GRID'}:
-			layout.alignment = 'CENTER'
-			if env.use_icons and icon in env.preview_collections["mobs"]:
-				layout.label(
-					text="",
-					icon_value=env.preview_collections["mobs"][icon].icon_id)
-			else:
-				layout.label(text="", icon='QUESTION')
+    def draw_item(
+        self, context, layout, data, set, icon, active_data, active_propname, index
+    ):
+        icon = "mob-{}".format(set.index)
+        if self.layout_type in {"DEFAULT", "COMPACT"}:
+            if not env.use_icons:
+                layout.label(text=set.name)
+            elif env.use_icons and icon in env.preview_collections["mobs"]:
+                layout.label(
+                    text=set.name,
+                    icon_value=env.preview_collections["mobs"][icon].icon_id,
+                )
+            else:
+                layout.label(text=set.name, icon="BLANK1")
+
+        elif self.layout_type in {"GRID"}:
+            layout.alignment = "CENTER"
+            if env.use_icons and icon in env.preview_collections["mobs"]:
+                layout.label(
+                    text="", icon_value=env.preview_collections["mobs"][icon].icon_id
+                )
+            else:
+                layout.label(text="", icon="QUESTION")
 
 
 class MCPREP_UL_meshswap(bpy.types.UIList):
-	"""For meshswap asset listing UIList drawing"""
-	def draw_item(self, context, layout, data, set, icon, active_data, active_propname, index):
-		if self.layout_type in {'DEFAULT', 'COMPACT'}:
-			layout.label(text=set.name)
-		elif self.layout_type in {'GRID'}:
-			layout.alignment = 'CENTER'
-			layout.label(text="", icon='QUESTION')
+    """For meshswap asset listing UIList drawing"""
+
+    def draw_item(
+        self, context, layout, data, set, icon, active_data, active_propname, index
+    ):
+        if self.layout_type in {"DEFAULT", "COMPACT"}:
+            layout.label(text=set.name)
+        elif self.layout_type in {"GRID"}:
+            layout.alignment = "CENTER"
+            layout.label(text="", icon="QUESTION")
 
 
 class MCPREP_UL_entity(bpy.types.UIList):
-	"""For entity asset listing UIList drawing"""
-	def draw_item(self, context, layout, data, set, icon, active_data, active_propname, index):
-		if self.layout_type in {'DEFAULT', 'COMPACT'}:
-			layout.label(text=set.name)
-		elif self.layout_type in {'GRID'}:
-			layout.alignment = 'CENTER'
-			layout.label(text="", icon='QUESTION')
+    """For entity asset listing UIList drawing"""
+
+    def draw_item(
+        self, context, layout, data, set, icon, active_data, active_propname, index
+    ):
+        if self.layout_type in {"DEFAULT", "COMPACT"}:
+            layout.label(text=set.name)
+        elif self.layout_type in {"GRID"}:
+            layout.alignment = "CENTER"
+            layout.label(text="", icon="QUESTION")
 
 
 class MCPREP_UL_model(bpy.types.UIList):
-	"""For model asset listing UIList drawing"""
-	def draw_item(self, context, layout, data, set, icon, active_data, active_propname, index):
-		if self.layout_type in {'DEFAULT', 'COMPACT'}:
-			layout.label(text=set.name)
-		elif self.layout_type in {'GRID'}:
-			layout.alignment = 'CENTER'
-			layout.label(text="", icon='QUESTION')
+    """For model asset listing UIList drawing"""
+
+    def draw_item(
+        self, context, layout, data, set, icon, active_data, active_propname, index
+    ):
+        if self.layout_type in {"DEFAULT", "COMPACT"}:
+            layout.label(text=set.name)
+        elif self.layout_type in {"GRID"}:
+            layout.alignment = "CENTER"
+            layout.label(text="", icon="QUESTION")
 
 
 class MCPREP_UL_item(bpy.types.UIList):
-	"""For item asset listing UIList drawing"""
-	def draw_item(self, context, layout, data, set, icon, active_data, active_propname, index):
-		icon = "item-{}".format(set.index)
-		if self.layout_type in {'DEFAULT', 'COMPACT'}:
-			if not env.use_icons:
-				layout.label(text=set.name)
-			elif env.use_icons and icon in env.preview_collections["items"]:
-				layout.label(
-					text=set.name,
-					icon_value=env.preview_collections["items"][icon].icon_id)
-			else:
-				layout.label(text=set.name, icon="BLANK1")
+    """For item asset listing UIList drawing"""
 
-		elif self.layout_type in {'GRID'}:
-			layout.alignment = 'CENTER'
-			if env.use_icons and icon in env.preview_collections["items"]:
-				layout.label(
-					text="",
-					icon_value=env.preview_collections["items"][icon].icon_id)
-			else:
-				layout.label(text="", icon='QUESTION')
+    def draw_item(
+        self, context, layout, data, set, icon, active_data, active_propname, index
+    ):
+        icon = "item-{}".format(set.index)
+        if self.layout_type in {"DEFAULT", "COMPACT"}:
+            if not env.use_icons:
+                layout.label(text=set.name)
+            elif env.use_icons and icon in env.preview_collections["items"]:
+                layout.label(
+                    text=set.name,
+                    icon_value=env.preview_collections["items"][icon].icon_id,
+                )
+            else:
+                layout.label(text=set.name, icon="BLANK1")
+
+        elif self.layout_type in {"GRID"}:
+            layout.alignment = "CENTER"
+            if env.use_icons and icon in env.preview_collections["items"]:
+                layout.label(
+                    text="", icon_value=env.preview_collections["items"][icon].icon_id
+                )
+            else:
+                layout.label(text="", icon="QUESTION")
 
 
 class MCPREP_UL_effects(bpy.types.UIList):
-	"""For effects asset listing UIList drawing"""
-	def draw_item(self, context, layout, data, set, icon, active_data, active_propname, index):
-		icon = "effects-{}".format(set.index)
-		if self.layout_type in {'DEFAULT', 'COMPACT'}:
+    """For effects asset listing UIList drawing"""
 
-			# Add icons based on the type of effect.
-			if set.effect_type == effects.GEO_AREA:
-				layout.label(text=set.name, icon="NODETREE")
-			elif set.effect_type == effects.PARTICLE_AREA:
-				layout.label(text=set.name, icon="PARTICLES")
-			elif set.effect_type == effects.COLLECTION:
-				layout.label(text=set.name, icon=COLL_ICON)
-			elif set.effect_type == effects.IMG_SEQ:
-				if env.use_icons and icon in env.preview_collections["effects"]:
-					layout.label(
-						text=set.name,
-						icon_value=env.preview_collections["effects"][icon].icon_id)
-				else:
-					layout.label(text=set.name, icon="RENDER_RESULT")
-			else:
-				layout.label(text=set.name, icon="BLANK1")
+    def draw_item(
+        self, context, layout, data, set, icon, active_data, active_propname, index
+    ):
+        icon = "effects-{}".format(set.index)
+        if self.layout_type in {"DEFAULT", "COMPACT"}:
+            # Add icons based on the type of effect.
+            if set.effect_type == effects.GEO_AREA:
+                layout.label(text=set.name, icon="NODETREE")
+            elif set.effect_type == effects.PARTICLE_AREA:
+                layout.label(text=set.name, icon="PARTICLES")
+            elif set.effect_type == effects.COLLECTION:
+                layout.label(text=set.name, icon=COLL_ICON)
+            elif set.effect_type == effects.IMG_SEQ:
+                if env.use_icons and icon in env.preview_collections["effects"]:
+                    layout.label(
+                        text=set.name,
+                        icon_value=env.preview_collections["effects"][icon].icon_id,
+                    )
+                else:
+                    layout.label(text=set.name, icon="RENDER_RESULT")
+            else:
+                layout.label(text=set.name, icon="BLANK1")
 
-		elif self.layout_type in {'GRID'}:
-			layout.alignment = 'CENTER'
-			if env.use_icons and icon in env.preview_collections["effects"]:
-				layout.label(
-					text="",
-					icon_value=env.preview_collections["effects"][icon].icon_id)
-			else:
-				layout.label(text="", icon='QUESTION')
+        elif self.layout_type in {"GRID"}:
+            layout.alignment = "CENTER"
+            if env.use_icons and icon in env.preview_collections["effects"]:
+                layout.label(
+                    text="", icon_value=env.preview_collections["effects"][icon].icon_id
+                )
+            else:
+                layout.label(text="", icon="QUESTION")
 
 
 class MCPREP_UL_material(bpy.types.UIList):
-	"""For material library UIList drawing"""
-	def draw_item(self, context, layout, data, set, icon, active_data, active_propname, index):
-		icon = "material-{}".format(set.index)
-		if self.layout_type in {'DEFAULT', 'COMPACT'}:
-			if not env.use_icons:
-				layout.label(text=set.name)
-			elif env.use_icons and icon in env.preview_collections["materials"]:
-				layout.label(
-					text=set.name,
-					icon_value=env.preview_collections["materials"][icon].icon_id)
-			else:
-				layout.label(text=set.name, icon="BLANK1")
+    """For material library UIList drawing"""
 
-		elif self.layout_type in {'GRID'}:
-			layout.alignment = 'CENTER'
-			if env.use_icons and icon in env.preview_collections["materials"]:
-				layout.label(
-					text="",
-					icon_value=env.preview_collections["materials"][icon].icon_id)
-			else:
-				layout.label(text="", icon='QUESTION')
+    def draw_item(
+        self, context, layout, data, set, icon, active_data, active_propname, index
+    ):
+        icon = "material-{}".format(set.index)
+        if self.layout_type in {"DEFAULT", "COMPACT"}:
+            if not env.use_icons:
+                layout.label(text=set.name)
+            elif env.use_icons and icon in env.preview_collections["materials"]:
+                layout.label(
+                    text=set.name,
+                    icon_value=env.preview_collections["materials"][icon].icon_id,
+                )
+            else:
+                layout.label(text=set.name, icon="BLANK1")
+
+        elif self.layout_type in {"GRID"}:
+            layout.alignment = "CENTER"
+            if env.use_icons and icon in env.preview_collections["materials"]:
+                layout.label(
+                    text="",
+                    icon_value=env.preview_collections["materials"][icon].icon_id,
+                )
+            else:
+                layout.label(text="", icon="QUESTION")
 
 
 class ListMobAssetsAll(bpy.types.PropertyGroup):
-	"""For listing hidden group of all mobs, regardless of category"""
-	description: bpy.props.StringProperty()
-	category: bpy.props.StringProperty()
-	mcmob_type: bpy.props.StringProperty()
-	index: bpy.props.IntProperty(min=0, default=0)  # for icon drawing
+    """For listing hidden group of all mobs, regardless of category"""
+
+    description: bpy.props.StringProperty()
+    category: bpy.props.StringProperty()
+    mcmob_type: bpy.props.StringProperty()
+    index: bpy.props.IntProperty(min=0, default=0)  # for icon drawing
 
 
 class ListMobAssets(bpy.types.PropertyGroup):
-	"""For UI drawing of mob assets and holding data"""
-	description: bpy.props.StringProperty()
-	category: bpy.props.StringProperty()  # category it belongs to
-	mcmob_type: bpy.props.StringProperty()
-	index: bpy.props.IntProperty(min=0, default=0)  # for icon drawing
+    """For UI drawing of mob assets and holding data"""
+
+    description: bpy.props.StringProperty()
+    category: bpy.props.StringProperty()  # category it belongs to
+    mcmob_type: bpy.props.StringProperty()
+    index: bpy.props.IntProperty(min=0, default=0)  # for icon drawing
 
 
 class ListMeshswapAssets(bpy.types.PropertyGroup):
-	"""For UI drawing of meshswap assets and holding data"""
-	block: bpy.props.StringProperty()  # block name only like "fire"
-	method: bpy.props.EnumProperty(
-		name="Import method",
-		# Collection intentionally first to be default for operator calls.
-		items=[
-			("collection", "Collection/group asset", "Collection/group asset"),
-			("object", "Object asset", "Object asset"),
-		]
-	)
-	description: bpy.props.StringProperty()
+    """For UI drawing of meshswap assets and holding data"""
+
+    block: bpy.props.StringProperty()  # block name only like "fire"
+    method: bpy.props.EnumProperty(
+        name="Import method",
+        # Collection intentionally first to be default for operator calls.
+        items=[
+            ("collection", "Collection/group asset", "Collection/group asset"),
+            ("object", "Object asset", "Object asset"),
+        ],
+    )
+    description: bpy.props.StringProperty()
 
 
 class ListEntityAssets(bpy.types.PropertyGroup):
-	"""For UI drawing of meshswap assets and holding data"""
-	entity: bpy.props.StringProperty()  # virtual enum, Group/name
-	description: bpy.props.StringProperty()
+    """For UI drawing of meshswap assets and holding data"""
+
+    entity: bpy.props.StringProperty()  # virtual enum, Group/name
+    description: bpy.props.StringProperty()
 
 
 class ListItemAssets(bpy.types.PropertyGroup):
-	"""For UI drawing of item assets and holding data"""
-	# inherited: name
-	description: bpy.props.StringProperty()
-	path: bpy.props.StringProperty(subtype='FILE_PATH')
-	index: bpy.props.IntProperty(min=0, default=0)  # for icon drawing
+    """For UI drawing of item assets and holding data"""
+
+    # inherited: name
+    description: bpy.props.StringProperty()
+    path: bpy.props.StringProperty(subtype="FILE_PATH")
+    index: bpy.props.IntProperty(min=0, default=0)  # for icon drawing
 
 
 class ListModelAssets(bpy.types.PropertyGroup):
-	"""For UI drawing of mc model assets and holding data"""
-	filepath: bpy.props.StringProperty(subtype="FILE_PATH")
-	description: bpy.props.StringProperty()
-	# index: bpy.props.IntProperty(min=0, default=0)  # icon pulled by name.
+    """For UI drawing of mc model assets and holding data"""
+
+    filepath: bpy.props.StringProperty(subtype="FILE_PATH")
+    description: bpy.props.StringProperty()
+    # index: bpy.props.IntProperty(min=0, default=0)  # icon pulled by name.
 
 
 class ListEffectsAssets(bpy.types.PropertyGroup):
-	"""For UI drawing for different kinds of effects"""
-	# inherited: name
-	filepath: bpy.props.StringProperty(subtype="FILE_PATH")
-	subpath: bpy.props.StringProperty(
-		description="Collection/particle/nodegroup within this file",
-		default="")
-	description: bpy.props.StringProperty()
-	effect_type: bpy.props.EnumProperty(
-		name="Effect type",
-		items=(
-			(effects.GEO_AREA, 'Geonode area', 'Instance wide-area geonodes effect'),
-			(effects.PARTICLE_AREA, 'Particle area', 'Instance wide-area particle effect'),
-			(effects.COLLECTION, 'Collection effect', 'Instance pre-animated collection'),
-			(effects.IMG_SEQ, 'Image sequence', 'Instance an animated image sequence effect'),
-		))
-	index: bpy.props.IntProperty(min=0, default=0)  # for icon drawing
+    """For UI drawing for different kinds of effects"""
+
+    # inherited: name
+    filepath: bpy.props.StringProperty(subtype="FILE_PATH")
+    subpath: bpy.props.StringProperty(
+        description="Collection/particle/nodegroup within this file", default=""
+    )
+    description: bpy.props.StringProperty()
+    effect_type: bpy.props.EnumProperty(
+        name="Effect type",
+        items=(
+            (effects.GEO_AREA, "Geonode area", "Instance wide-area geonodes effect"),
+            (
+                effects.PARTICLE_AREA,
+                "Particle area",
+                "Instance wide-area particle effect",
+            ),
+            (
+                effects.COLLECTION,
+                "Collection effect",
+                "Instance pre-animated collection",
+            ),
+            (
+                effects.IMG_SEQ,
+                "Image sequence",
+                "Instance an animated image sequence effect",
+            ),
+        ),
+    )
+    index: bpy.props.IntProperty(min=0, default=0)  # for icon drawing
 
 
 # -----------------------------------------------------------------------------
@@ -922,31 +972,31 @@ class ListEffectsAssets(bpy.types.PropertyGroup):
 
 
 classes = (
-	ListMobAssetsAll,
-	ListMobAssets,
-	ListMeshswapAssets,
-	ListItemAssets,
-	ListEntityAssets,
-	ListModelAssets,
-	ListEffectsAssets,
-	MCPREP_UL_material,
-	MCPREP_UL_mob,
-	MCPREP_UL_meshswap,
-	MCPREP_UL_entity,
-	MCPREP_UL_model,
-	MCPREP_UL_item,
-	MCPREP_UL_effects,
-	MCPREP_OT_reload_spawners,
-	MCPREP_OT_spawn_path_reset,
-	MCPREP_OT_prompt_reset_spawners,
+    ListMobAssetsAll,
+    ListMobAssets,
+    ListMeshswapAssets,
+    ListItemAssets,
+    ListEntityAssets,
+    ListModelAssets,
+    ListEffectsAssets,
+    MCPREP_UL_material,
+    MCPREP_UL_mob,
+    MCPREP_UL_meshswap,
+    MCPREP_UL_entity,
+    MCPREP_UL_model,
+    MCPREP_UL_item,
+    MCPREP_UL_effects,
+    MCPREP_OT_reload_spawners,
+    MCPREP_OT_spawn_path_reset,
+    MCPREP_OT_prompt_reset_spawners,
 )
 
 
 def register():
-	for cls in classes:
-		bpy.utils.register_class(cls)
+    for cls in classes:
+        bpy.utils.register_class(cls)
 
 
 def unregister():
-	for cls in reversed(classes):
-		bpy.utils.unregister_class(cls)
+    for cls in reversed(classes):
+        bpy.utils.unregister_class(cls)

--- a/MCprep_addon/tracking.py
+++ b/MCprep_addon/tracking.py
@@ -30,24 +30,24 @@ import bpy
 
 # remaining, wrap in safe-importing
 try:
-	from . import conf
-	from . import util
-	from .addon_updater import Updater as updater
-	import re
-	import requests
-	import traceback
-	import json
-	import http.client
-	import platform
-	import threading
-	import textwrap
-	import time
-	from datetime import datetime
-	from .conf import env
+    from . import conf
+    from . import util
+    from .addon_updater import Updater as updater
+    import re
+    import requests
+    import traceback
+    import json
+    import http.client
+    import platform
+    import threading
+    import textwrap
+    import time
+    from datetime import datetime
+    from .conf import env
 except Exception as err:
-	print("[MCPREP Error] Failed tracker module load, invalid import module:")
-	print('\t'+str(err))
-	VALID_IMPORT = False
+    print("[MCPREP Error] Failed tracker module load, invalid import module:")
+    print("\t" + str(err))
+    VALID_IMPORT = False
 
 
 # -----------------------------------------------------------------------------
@@ -58,9 +58,9 @@ IDNAME = "mcprep"
 
 # max data/string lengths to match server-side validation,
 # if exceeded, request will return denied (no data written)
-SHORT_FIELD_MAX = 64-1
-USER_COMMENT_LENGTH = 512-1
-ERROR_STRING_LENGTH = 1024-1
+SHORT_FIELD_MAX = 64 - 1
+USER_COMMENT_LENGTH = 512 - 1
+ERROR_STRING_LENGTH = 1024 - 1
 
 # -----------------------------------------------------------------------------
 # primary class implementation
@@ -68,406 +68,437 @@ ERROR_STRING_LENGTH = 1024-1
 
 
 class Singleton_tracking(object):
+    def __init__(self):
+        self._addon = __package__.lower()
+        self._appurl = ""
+        self._background = False
+        self._bg_thread = []
+        self._blender_version = ""
+        self._dev = False
+        self._failsafe = False
+        self._handling_error = False
+        self._language = ""
+        self._platform = ""
+        self._port = 443
+        self._tracker_idbackup = None
+        self._tracker_json = None
+        self._tracking_enabled = False
+        self._verbose = False
+        self._version = ""
+        self.json = {}
+        self._httpclient_fallback = None  # set to True/False after first req
+        self._last_request = {}  # used to debounce sequential requests
+        self._debounce = 5  # seconds to avoid duplicative requests
+        self._feature_set = 0  # Supported addon features (e.g. experimental)
 
-	def __init__(self):
-		self._addon = __package__.lower()
-		self._appurl = ""
-		self._background = False
-		self._bg_thread = []
-		self._blender_version = ""
-		self._dev = False
-		self._failsafe = False
-		self._handling_error = False
-		self._language = ""
-		self._platform = ""
-		self._port = 443
-		self._tracker_idbackup = None
-		self._tracker_json = None
-		self._tracking_enabled = False
-		self._verbose = False
-		self._version = ""
-		self.json = {}
-		self._httpclient_fallback = None # set to True/False after first req
-		self._last_request = {} # used to debounce sequential requests
-		self._debounce = 5 # seconds to avoid duplicative requests
-		self._feature_set = 0  # Supported addon features (e.g. experimental)
+    # -------------------------------------------------------------------------
+    # Getters and setters
+    # -------------------------------------------------------------------------
 
-	# -------------------------------------------------------------------------
-	# Getters and setters
-	# -------------------------------------------------------------------------
+    @property
+    def blender_version(self):
+        return self._blender_version
 
-	@property
-	def blender_version(self):
-		return self._blender_version
-	@blender_version.setter
-	def blender_version(self, value):
-		if value is None:
-			self._blender_version = "unknown"
-		elif type(value) != type((1,2,3)):
-			raise Exception("blender_version must be a tuple")
-		else:
-			self._blender_version = str(value)
+    @blender_version.setter
+    def blender_version(self, value):
+        if value is None:
+            self._blender_version = "unknown"
+        elif type(value) != type((1, 2, 3)):
+            raise Exception("blender_version must be a tuple")
+        else:
+            self._blender_version = str(value)
 
-	@property
-	def language(self):
-		return self._language
-	@language.setter
-	def language(self, value):
-		if value is None:
-			self._language = "None"
-		elif type(value) != type("string"):
-			raise Exception("language must be a string")
-		else:
-			self._language = self.string_trunc(value)
+    @property
+    def language(self):
+        return self._language
 
-	@property
-	def tracking_enabled(self):
-		return self._tracking_enabled
-	@tracking_enabled.setter
-	def tracking_enabled(self, value):
-		self._tracking_enabled = bool(value)
-		self.enable_tracking(False, value)
+    @language.setter
+    def language(self, value):
+        if value is None:
+            self._language = "None"
+        elif type(value) != type("string"):
+            raise Exception("language must be a string")
+        else:
+            self._language = self.string_trunc(value)
 
-	@property
-	def verbose(self):
-		return self._verbose
-	@verbose.setter
-	def verbose(self, value):
-		try:
-			self._verbose = bool(value)
-		except:
-			raise ValueError("Verbose must be a boolean value")
+    @property
+    def tracking_enabled(self):
+        return self._tracking_enabled
 
-	@property
-	def appurl(self):
-		return self._appurl
-	@appurl.setter
-	def appurl(self, value):
-		if value[-1] == "/":
-			value = value[:-1]
-		self._appurl = value
+    @tracking_enabled.setter
+    def tracking_enabled(self, value):
+        self._tracking_enabled = bool(value)
+        self.enable_tracking(False, value)
 
-	@property
-	def failsafe(self):
-		return self._failsafe
-	@failsafe.setter
-	def failsafe(self, value):
-		try:
-			self._failsafe = bool(value)
-		except:
-			raise ValueError("failsafe must be a boolean value")
+    @property
+    def verbose(self):
+        return self._verbose
 
-	@property
-	def dev(self):
-		return self._dev
-	@dev.setter
-	def dev(self, value):
-		try:
-			self._dev = bool(value)
-		except:
-			raise ValueError("background must be a boolean value")
+    @verbose.setter
+    def verbose(self, value):
+        try:
+            self._verbose = bool(value)
+        except:
+            raise ValueError("Verbose must be a boolean value")
 
-	@property
-	def background(self):
-		return self._background
-	@background.setter
-	def background(self, value):
-		try:
-			self._background = bool(value)
-		except:
-			raise ValueError("background must be a boolean value")
+    @property
+    def appurl(self):
+        return self._appurl
 
-	@property
-	def version(self):
-		return self._version
-	@version.setter
-	def version(self, value):
-		self._version = value
+    @appurl.setter
+    def appurl(self, value):
+        if value[-1] == "/":
+            value = value[:-1]
+        self._appurl = value
 
-	@property
-	def addon(self):
-		return self._addon
-	@addon.setter
-	def addon(self, value):
-		self._addon = value
+    @property
+    def failsafe(self):
+        return self._failsafe
 
-	@property
-	def platform(self):
-		return self._platform
-	@platform.setter
-	def platform(self, value):
-		if value is None:
-			self._platform = "None"
-		elif type(value) != type("string"):
-			raise Exception("platform must be a string")
-		else:
-			self._platform = self.string_trunc(value)
+    @failsafe.setter
+    def failsafe(self, value):
+        try:
+            self._failsafe = bool(value)
+        except:
+            raise ValueError("failsafe must be a boolean value")
 
-	@property
-	def feature_set(self):
-		values = ["", "supported", "experimental"]
-		return values[self._feature_set]
-	@feature_set.setter
-	def feature_set(self, value):
-		if not value:
-			self._feature_set = 0
-		elif value == "supported":
-			self._feature_set = 1
-		elif value == "experimental":
-			self._feature_set = 2
-		else:
-			raise ValueError(
-				"feature_set must be one of supported, experimental, or None")
+    @property
+    def dev(self):
+        return self._dev
 
-	# number/settings for frequency use before ask for enable tracking
+    @dev.setter
+    def dev(self, value):
+        try:
+            self._dev = bool(value)
+        except:
+            raise ValueError("background must be a boolean value")
 
-	# -------------------------------------------------------------------------
-	# Public functions
-	# -------------------------------------------------------------------------
+    @property
+    def background(self):
+        return self._background
 
-	def enable_tracking(self, toggle=True, enable=True):
-		if not VALID_IMPORT:
-			return
-		if toggle:
-			self._tracking_enabled = not self._tracking_enabled
-		else:
-			self._tracking_enabled = enable
+    @background.setter
+    def background(self, value):
+        try:
+            self._background = bool(value)
+        except:
+            raise ValueError("background must be a boolean value")
 
-		# update static json
-		self.json["enable_tracking"] = self._tracking_enabled
-		self.save_tracker_json()
+    @property
+    def version(self):
+        return self._version
 
-	def get_platform_details(self):
-		"""Return OS related information."""
-		try:
-			res = platform.system()+":"+platform.release()
-			if len(res) > SHORT_FIELD_MAX:
-				res = res[:SHORT_FIELD_MAX-1] + "|"
-		except Exception as err:
-			print("Error getting platform info: " + str(err))
-			return "unknown:unknown"
-		return str(res)
+    @version.setter
+    def version(self, value):
+        self._version = value
 
-	def initialize(self, appurl, version, language=None, blender_version=None):
-		"""Load the enable_tracking-preference (in/out), create tracker data."""
-		if not VALID_IMPORT:
-			return
+    @property
+    def addon(self):
+        return self._addon
 
-		self._appurl = appurl
-		self._version = version
-		self.platform = self.get_platform_details()
-		# self.blender_version = blender_version
-		self._blender_version = str(blender_version)
-		self.language = language
+    @addon.setter
+    def addon(self, value):
+        self._addon = value
 
-		self._tracker_idbackup = os.path.join(os.path.dirname(__file__),
-							os.pardir,self._addon+"_trackerid.json")
-		self._tracker_json = os.path.join(os.path.dirname(__file__),
-							self._addon+"_tracker.json")
+    @property
+    def platform(self):
+        return self._platform
 
-		# create the local file
-		# push into BG push update info if true
-		# create local cache file locations
-		# including search for previous
-		self.set_tracker_json()
-		return
+    @platform.setter
+    def platform(self, value):
+        if value is None:
+            self._platform = "None"
+        elif type(value) != type("string"):
+            raise Exception("platform must be a string")
+        else:
+            self._platform = self.string_trunc(value)
 
-	def request(self, method, path, payload, background=False, callback=None):
-		"""Interface request, either launches on main or a background thread."""
-		if not VALID_IMPORT:
-			return
-		if method not in ["POST", "PUT", "GET"]:
-			raise ValueError("Method must be POST, PUT, or GET")
-		if background is False:
-			return self.raw_request(method, path, payload, callback)
-		else:
-			# if self._verbose: print("Starting background thread for track call")
-			bg_thread = threading.Thread(target=self.raw_request, args=(method, path, payload, callback))
-			bg_thread.daemon = True
-			#self._bg_threads.append(bg_thread)
-			bg_thread.start()
-			return "Thread launched"
+    @property
+    def feature_set(self):
+        values = ["", "supported", "experimental"]
+        return values[self._feature_set]
 
+    @feature_set.setter
+    def feature_set(self, value):
+        if not value:
+            self._feature_set = 0
+        elif value == "supported":
+            self._feature_set = 1
+        elif value == "experimental":
+            self._feature_set = 2
+        else:
+            raise ValueError(
+                "feature_set must be one of supported, experimental, or None"
+            )
 
-	def raw_request(self, method, path, payload, callback=None):
-		"""Raw connection request, background or foreground.
+    # number/settings for frequency use before ask for enable tracking
 
-		To support the widest range of installs, try first using the newer
-		requests module, else fall back and keep using http.client
-		"""
-		if not VALID_IMPORT:
-			return
+    # -------------------------------------------------------------------------
+    # Public functions
+    # -------------------------------------------------------------------------
 
-		if self._httpclient_fallback is None:
-			# first time run
-			resp = None
-			try:
-				resp = self._raw_request_mod_requests(method, path, payload)
-				self._httpclient_fallback = False
-			except:
-				resp = self._raw_request_mod_http(method, path, payload)
-				self._httpclient_fallback = True
-		elif self._httpclient_fallback is False:
-			resp = self._raw_request_mod_requests(method, path, payload)
-		else:
-			resp = self._raw_request_mod_http(method, path, payload)
+    def enable_tracking(self, toggle=True, enable=True):
+        if not VALID_IMPORT:
+            return
+        if toggle:
+            self._tracking_enabled = not self._tracking_enabled
+        else:
+            self._tracking_enabled = enable
 
-		if callback is not None:
-			if self._verbose:
-				print(self._addon+": Running callback")
-			callback(resp)
-		return resp
+        # update static json
+        self.json["enable_tracking"] = self._tracking_enabled
+        self.save_tracker_json()
 
-	def _raw_request_mod_requests(self, method, path, payload):
-		"""Method for connection using the requests library.
+    def get_platform_details(self):
+        """Return OS related information."""
+        try:
+            res = platform.system() + ":" + platform.release()
+            if len(res) > SHORT_FIELD_MAX:
+                res = res[: SHORT_FIELD_MAX - 1] + "|"
+        except Exception as err:
+            print("Error getting platform info: " + str(err))
+            return "unknown:unknown"
+        return str(res)
 
-		Intentionally raises when errors occur so that fallback method can
-		be used. This function works in blender 2.8, and at least 2.79.
-		"""
-		url = self._appurl + path
-		if method == "POST":
-			res = requests.post(url, payload, timeout=TIMEOUT)
-		elif method == "GET":
-			res = requests.get(url, timeout=TIMEOUT)
-		elif method == "PUT":
-			res = requests.put(url, payload, timeout=TIMEOUT)
-		else:
-			raise ValueError("raw_request input must be GET, POST, or PUT")
+    def initialize(self, appurl, version, language=None, blender_version=None):
+        """Load the enable_tracking-preference (in/out), create tracker data."""
+        if not VALID_IMPORT:
+            return
 
-		if not res.ok:
-			if self._verbose:
-				print("Error occured in requests req: ", str(res.reason))
-			raise ValueError("Error occured while requesting data (requests lib)")
+        self._appurl = appurl
+        self._version = version
+        self.platform = self.get_platform_details()
+        # self.blender_version = blender_version
+        self._blender_version = str(blender_version)
+        self.language = language
 
-		if res.text:
-			resp = json.loads(res.text)
-		else:
-			resp = {}
-		if self._verbose:
-			print("{} {} response (requests lib) {} at {}".format(
-				self._addon, "dev" if self._dev else "", resp, path))
-		return resp
+        self._tracker_idbackup = os.path.join(
+            os.path.dirname(__file__), os.pardir, self._addon + "_trackerid.json"
+        )
+        self._tracker_json = os.path.join(
+            os.path.dirname(__file__), self._addon + "_tracker.json"
+        )
 
-	def _raw_request_mod_http(self, method, path, payload):
-		"""Method for connection using the http.client library.
+        # create the local file
+        # push into BG push update info if true
+        # create local cache file locations
+        # including search for previous
+        self.set_tracker_json()
+        return
 
-		This method functions consistently up until and not including b3d 2.8
-		"""
+    def request(self, method, path, payload, background=False, callback=None):
+        """Interface request, either launches on main or a background thread."""
+        if not VALID_IMPORT:
+            return
+        if method not in ["POST", "PUT", "GET"]:
+            raise ValueError("Method must be POST, PUT, or GET")
+        if background is False:
+            return self.raw_request(method, path, payload, callback)
+        else:
+            # if self._verbose: print("Starting background thread for track call")
+            bg_thread = threading.Thread(
+                target=self.raw_request, args=(method, path, payload, callback)
+            )
+            bg_thread.daemon = True
+            # self._bg_threads.append(bg_thread)
+            bg_thread.start()
+            return "Thread launched"
 
-		url = self._appurl.split("//")[1]
-		url = url.split("/")[0]
-		connection = http.client.HTTPSConnection(url, self._port)
-		try:
-			connection.connect()
-			if self.verbose:
-				print(self._addon + ": Connection made to "+str(path))
-		except Exception as err:
-			print(self._addon + ": Connection failed, intended report destination: "+str(path))
-			print("Error: "+str(err))
-			return {'status':'NO_CONNECTION'}
+    def raw_request(self, method, path, payload, callback=None):
+        """Raw connection request, background or foreground.
 
-		if method in ("POST", "PUT"):
-			connection.request(method, path, payload)
-		elif method == "GET":
-			connection.request(method, path)
-		else:
-			raise ValueError("raw_request input must be GET, POST, or PUT")
+        To support the widest range of installs, try first using the newer
+        requests module, else fall back and keep using http.client
+        """
+        if not VALID_IMPORT:
+            return
 
-		raw = connection.getresponse().read()
-		resp = json.loads(raw.decode())
-		if self._verbose:
-			print("{} {} response (http lib) {} at {}".format(
-				self._addon, "dev" if self._dev else "", resp, path))
-		return resp
+        if self._httpclient_fallback is None:
+            # first time run
+            resp = None
+            try:
+                resp = self._raw_request_mod_requests(method, path, payload)
+                self._httpclient_fallback = False
+            except:
+                resp = self._raw_request_mod_http(method, path, payload)
+                self._httpclient_fallback = True
+        elif self._httpclient_fallback is False:
+            resp = self._raw_request_mod_requests(method, path, payload)
+        else:
+            resp = self._raw_request_mod_http(method, path, payload)
 
-	def set_tracker_json(self):
-		if not VALID_IMPORT:
-			return
-		if self._tracker_json is None:
-			raise ValueError("tracker_json is not defined")
+        if callback is not None:
+            if self._verbose:
+                print(self._addon + ": Running callback")
+            callback(resp)
+        return resp
 
-		if os.path.isfile(self._tracker_json) is True:
-			with open(self._tracker_json) as data_file:
-				self.json = json.load(data_file)
-				if self._verbose:
-					print(self._addon+": Read in json settings from tracker file")
-		else:
-			# set data structure
-			self.json = {
-				"install_date":None,
-				"install_id":None,
-				"enable_tracking":False,
-				"status":None,
-				"metadata":{}
-			}
+    def _raw_request_mod_requests(self, method, path, payload):
+        """Method for connection using the requests library.
 
-			if os.path.isfile(self._tracker_idbackup):
-				with open(self._tracker_idbackup) as data_file:
-					idbackup = json.load(data_file)
-					if self._verbose:
-						print(self._addon+": Reinstall, getting IDNAME")
-					if "IDNAME" in idbackup:
-						self.json["install_id"] = idbackup["IDNAME"]
-						self.json["status"] = "re-install"
-						self.json["install_date"] = idbackup["date"]
+        Intentionally raises when errors occur so that fallback method can
+        be used. This function works in blender 2.8, and at least 2.79.
+        """
+        url = self._appurl + path
+        if method == "POST":
+            res = requests.post(url, payload, timeout=TIMEOUT)
+        elif method == "GET":
+            res = requests.get(url, timeout=TIMEOUT)
+        elif method == "PUT":
+            res = requests.put(url, payload, timeout=TIMEOUT)
+        else:
+            raise ValueError("raw_request input must be GET, POST, or PUT")
 
-			self.save_tracker_json()
+        if not res.ok:
+            if self._verbose:
+                print("Error occured in requests req: ", str(res.reason))
+            raise ValueError("Error occured while requesting data (requests lib)")
 
-		# update any other properties if necessary from json
-		self._tracking_enabled = self.json["enable_tracking"]
+        if res.text:
+            resp = json.loads(res.text)
+        else:
+            resp = {}
+        if self._verbose:
+            print(
+                "{} {} response (requests lib) {} at {}".format(
+                    self._addon, "dev" if self._dev else "", resp, path
+                )
+            )
+        return resp
 
-	def save_tracker_json(self):
-		"""Save out current state of the tracker json to file."""
-		if not VALID_IMPORT:
-			return
-		jpath = self._tracker_json
-		outf = open(jpath, 'w')
-		data_out = json.dumps(self.json, indent=4)
-		outf.write(data_out)
-		outf.close()
-		if self._verbose:
-			print(self._addon+": Wrote out json settings to file")
+    def _raw_request_mod_http(self, method, path, payload):
+        """Method for connection using the http.client library.
 
-	def save_tracker_idbackup(self):
-		"""Save copy of the ID file to parent folder location, for detecting
-		reinstalls in the future if the folder is deleted"""
-		if not VALID_IMPORT:
-			return
-		jpath = self._tracker_idbackup
+        This method functions consistently up until and not including b3d 2.8
+        """
 
-		if "install_id" in self.json and self.json["install_id"] != None:
-			outf = open(jpath, 'w')
-			idbackup = {"IDNAME":self.json["install_id"],
-						"date":self.json["install_date"]}
-			data_out = json.dumps(idbackup,indent=4)
-			outf.write(data_out)
-			outf.close()
-			if self._verbose:
-				print(self._addon+": Wrote out backup settings to file, with the contents:")
-				print(idbackup)
+        url = self._appurl.split("//")[1]
+        url = url.split("/")[0]
+        connection = http.client.HTTPSConnection(url, self._port)
+        try:
+            connection.connect()
+            if self.verbose:
+                print(self._addon + ": Connection made to " + str(path))
+        except Exception as err:
+            print(
+                self._addon
+                + ": Connection failed, intended report destination: "
+                + str(path)
+            )
+            print("Error: " + str(err))
+            return {"status": "NO_CONNECTION"}
 
-	def remove_indentifiable_information(self, report):
-		"""Remove filepath from report logs, which could have included
-		sensitive information such as usernames or names"""
-		report = report.replace(r'\\', '/').replace(r'\\\\\\', '/')
-		if not VALID_IMPORT:
-			return report
-		try:
-			return re.sub(
-				# case insensitive match: File "C:/path/.." or File "/path/.."
-				r'(?i)File "([a-z]:){0,1}[/\\]{1,2}.*[/\\]{1,2}',
-				'File "<addon_path>/',
-				str(report))
-		except Exception as err:
-			print("Error occured while removing info: {}".format(err))
-			return "[pii] "+str(report)
+        if method in ("POST", "PUT"):
+            connection.request(method, path, payload)
+        elif method == "GET":
+            connection.request(method, path)
+        else:
+            raise ValueError("raw_request input must be GET, POST, or PUT")
 
-	def string_trunc(self, value):
-		"""Function which caps max string length."""
-		ret = str(value)
-		if len(ret)>SHORT_FIELD_MAX:
-			ret = ret[:SHORT_FIELD_MAX]
-		return ret
+        raw = connection.getresponse().read()
+        resp = json.loads(raw.decode())
+        if self._verbose:
+            print(
+                "{} {} response (http lib) {} at {}".format(
+                    self._addon, "dev" if self._dev else "", resp, path
+                )
+            )
+        return resp
+
+    def set_tracker_json(self):
+        if not VALID_IMPORT:
+            return
+        if self._tracker_json is None:
+            raise ValueError("tracker_json is not defined")
+
+        if os.path.isfile(self._tracker_json) is True:
+            with open(self._tracker_json) as data_file:
+                self.json = json.load(data_file)
+                if self._verbose:
+                    print(self._addon + ": Read in json settings from tracker file")
+        else:
+            # set data structure
+            self.json = {
+                "install_date": None,
+                "install_id": None,
+                "enable_tracking": False,
+                "status": None,
+                "metadata": {},
+            }
+
+            if os.path.isfile(self._tracker_idbackup):
+                with open(self._tracker_idbackup) as data_file:
+                    idbackup = json.load(data_file)
+                    if self._verbose:
+                        print(self._addon + ": Reinstall, getting IDNAME")
+                    if "IDNAME" in idbackup:
+                        self.json["install_id"] = idbackup["IDNAME"]
+                        self.json["status"] = "re-install"
+                        self.json["install_date"] = idbackup["date"]
+
+            self.save_tracker_json()
+
+        # update any other properties if necessary from json
+        self._tracking_enabled = self.json["enable_tracking"]
+
+    def save_tracker_json(self):
+        """Save out current state of the tracker json to file."""
+        if not VALID_IMPORT:
+            return
+        jpath = self._tracker_json
+        outf = open(jpath, "w")
+        data_out = json.dumps(self.json, indent=4)
+        outf.write(data_out)
+        outf.close()
+        if self._verbose:
+            print(self._addon + ": Wrote out json settings to file")
+
+    def save_tracker_idbackup(self):
+        """Save copy of the ID file to parent folder location, for detecting
+        reinstalls in the future if the folder is deleted"""
+        if not VALID_IMPORT:
+            return
+        jpath = self._tracker_idbackup
+
+        if "install_id" in self.json and self.json["install_id"] != None:
+            outf = open(jpath, "w")
+            idbackup = {
+                "IDNAME": self.json["install_id"],
+                "date": self.json["install_date"],
+            }
+            data_out = json.dumps(idbackup, indent=4)
+            outf.write(data_out)
+            outf.close()
+            if self._verbose:
+                print(
+                    self._addon
+                    + ": Wrote out backup settings to file, with the contents:"
+                )
+                print(idbackup)
+
+    def remove_indentifiable_information(self, report):
+        """Remove filepath from report logs, which could have included
+        sensitive information such as usernames or names"""
+        report = report.replace(r"\\", "/").replace(r"\\\\\\", "/")
+        if not VALID_IMPORT:
+            return report
+        try:
+            return re.sub(
+                # case insensitive match: File "C:/path/.." or File "/path/.."
+                r'(?i)File "([a-z]:){0,1}[/\\]{1,2}.*[/\\]{1,2}',
+                'File "<addon_path>/',
+                str(report),
+            )
+        except Exception as err:
+            print("Error occured while removing info: {}".format(err))
+            return "[pii] " + str(report)
+
+    def string_trunc(self, value):
+        """Function which caps max string length."""
+        ret = str(value)
+        if len(ret) > SHORT_FIELD_MAX:
+            ret = ret[:SHORT_FIELD_MAX]
+        return ret
 
 
 # -----------------------------------------------------------------------------
@@ -484,157 +515,166 @@ Tracker = Singleton_tracking()
 
 
 class TRACK_OT_toggle_enable_tracking(bpy.types.Operator):
-	"""Enabled or disable usage tracking"""
-	bl_idname = f"{IDNAME}.toggle_enable_tracking"
-	bl_label = "Toggle opt-in for analytics tracking"
-	bl_description = (
-		"Toggle anonymous usage tracking to help the developers. "
-		"The only data tracked is what MCprep functions are used, key blender"
-		"/addon information, and the timestamp of the addon installation")
-	options = {'REGISTER', 'UNDO'}
+    """Enabled or disable usage tracking"""
 
-	tracking: bpy.props.EnumProperty(
-		items=[('toggle', 'Toggle', 'Toggle operator use tracking'),
-				('enable', 'Enable', 'Enable operator use tracking'),
-				('disable', 'Disable', 'Disable operator use tracking (if already on)')],
-		name="tracking")
+    bl_idname = f"{IDNAME}.toggle_enable_tracking"
+    bl_label = "Toggle opt-in for analytics tracking"
+    bl_description = (
+        "Toggle anonymous usage tracking to help the developers. "
+        "The only data tracked is what MCprep functions are used, key blender"
+        "/addon information, and the timestamp of the addon installation"
+    )
+    options = {"REGISTER", "UNDO"}
 
-	def execute(self, context):
-		if not VALID_IMPORT:
-			self.report({"ERROR"}, "Invalid import, all reporting disabled.")
-			return {'CANCELLED'}
-		if self.tracking == "toggle":
-			Tracker.enable_tracking(toggle=True)
-		elif self.tracking == "enable":
-			Tracker.enable_tracking(toggle=False, enable=True)
-		else:
-			Tracker.enable_tracking(toggle=False, enable=False)
-		return {'FINISHED'}
+    tracking: bpy.props.EnumProperty(
+        items=[
+            ("toggle", "Toggle", "Toggle operator use tracking"),
+            ("enable", "Enable", "Enable operator use tracking"),
+            ("disable", "Disable", "Disable operator use tracking (if already on)"),
+        ],
+        name="tracking",
+    )
+
+    def execute(self, context):
+        if not VALID_IMPORT:
+            self.report({"ERROR"}, "Invalid import, all reporting disabled.")
+            return {"CANCELLED"}
+        if self.tracking == "toggle":
+            Tracker.enable_tracking(toggle=True)
+        elif self.tracking == "enable":
+            Tracker.enable_tracking(toggle=False, enable=True)
+        else:
+            Tracker.enable_tracking(toggle=False, enable=False)
+        return {"FINISHED"}
 
 
 class TRACK_OT_popup_feedback(bpy.types.Operator):
-	bl_idname = IDNAME+".popup_feedback"
-	bl_label = "Thanks for using {}!".format(IDNAME)
-	bl_description = "Take a survey to give feedback about the addon"
-	options = {'REGISTER', 'UNDO'}
+    bl_idname = IDNAME + ".popup_feedback"
+    bl_label = "Thanks for using {}!".format(IDNAME)
+    bl_description = "Take a survey to give feedback about the addon"
+    options = {"REGISTER", "UNDO"}
 
-	def invoke(self, context, event):
-		width = 400 * util.ui_scale()
-		return context.window_manager.invoke_props_dialog(self, width=width)
+    def invoke(self, context, event):
+        width = 400 * util.ui_scale()
+        return context.window_manager.invoke_props_dialog(self, width=width)
 
-	def draw(self, context):
+    def draw(self, context):
+        self.layout.split()
+        col = self.layout.column()
+        col.alignment = "CENTER"
+        col.scale_y = 0.7
+        col.label(text="Want to help out even more?")
+        col.label(text="Press OK below to open the MCprep survey")
+        col.label(text="Responding helps direct development time,")
+        col.label(text="and identify those nasty bugs.")
+        col.label(text="You help everyone by responding!")
 
-		self.layout.split()
-		col = self.layout.column()
-		col.alignment='CENTER'
-		col.scale_y = 0.7
-		col.label(text="Want to help out even more?")
-		col.label(text="Press OK below to open the MCprep survey")
-		col.label(text="Responding helps direct development time,")
-		col.label(text="and identify those nasty bugs.")
-		col.label(text="You help everyone by responding!")
+    def execute(self, context):
+        bpy.ops.wm.url_open(url="bit.ly/MCprepSurvey")
 
-	def execute(self, context):
-		bpy.ops.wm.url_open(url="bit.ly/MCprepSurvey")
-
-		return {'FINISHED'}
+        return {"FINISHED"}
 
 
 class TRACK_OT_popup_report_error(bpy.types.Operator):
-	bl_idname = IDNAME+".report_error"
-	bl_label = "MCprep Error, press OK below to send this report to developers"
-	bl_description = "Report error to database, add additional comments for context"
+    bl_idname = IDNAME + ".report_error"
+    bl_label = "MCprep Error, press OK below to send this report to developers"
+    bl_description = "Report error to database, add additional comments for context"
 
-	error_report: bpy.props.StringProperty(default="")
-	comment: bpy.props.StringProperty(
-		default="",
-		maxlen=USER_COMMENT_LENGTH,
-		options={'SKIP_SAVE'})
+    error_report: bpy.props.StringProperty(default="")
+    comment: bpy.props.StringProperty(
+        default="", maxlen=USER_COMMENT_LENGTH, options={"SKIP_SAVE"}
+    )
 
-	action: bpy.props.EnumProperty(
-		items = [('report', 'Send', 'Send the error report to developers, fully anonymous'),
-				('ignore', "Don't send", "Ignore this error report")],
-		)
+    action: bpy.props.EnumProperty(
+        items=[
+            ("report", "Send", "Send the error report to developers, fully anonymous"),
+            ("ignore", "Don't send", "Ignore this error report"),
+        ],
+    )
 
-	def invoke(self, context, event):
-		width = 500 * util.ui_scale()
-		return context.window_manager.invoke_props_dialog(self, width=width)
+    def invoke(self, context, event):
+        width = 500 * util.ui_scale()
+        return context.window_manager.invoke_props_dialog(self, width=width)
 
-	def draw_header(self, context):
-		self.layout.label(text="", icon="ERROR") # doesn't work/add to draw
+    def draw_header(self, context):
+        self.layout.label(text="", icon="ERROR")  # doesn't work/add to draw
 
-	def draw(self, context):
-		layout = self.layout
+    def draw(self, context):
+        layout = self.layout
 
-		col = layout.column()
-		box = col.box()
-		boxcol = box.column()
-		boxcol.scale_y = 0.7
-		if self.error_report=="":
-			box.label(text=" # no error code identified # ")
-		else:
-			width = 500
-			report_lines = self.error_report.split("\n")[:-1]
-			tot_ln = 0
-			max_ln = 10
-			for ln in report_lines:
-				sub_lns = textwrap.fill(ln, width-30)
-				spl = sub_lns.split("\n")
-				for i,s in enumerate(spl):
-					boxcol.label(text=s)
-					tot_ln+=1
-					if tot_ln==max_ln: break
-				if tot_ln==max_ln: break
-		boxcol.label(text="."*500)
-		# boxcol.label(text="System & addon information:")
-		sysinfo="Blender version: {}\nMCprep version: {}\nOS: {}\n MCprep install identifier: {}".format(
-				Tracker.blender_version,
-				Tracker.version,
-				Tracker.platform,
-				Tracker.json["install_id"],
-		)
-		for ln in sysinfo.split("\n"):
-			boxcol.label(text=ln)
+        col = layout.column()
+        box = col.box()
+        boxcol = box.column()
+        boxcol.scale_y = 0.7
+        if self.error_report == "":
+            box.label(text=" # no error code identified # ")
+        else:
+            width = 500
+            report_lines = self.error_report.split("\n")[:-1]
+            tot_ln = 0
+            max_ln = 10
+            for ln in report_lines:
+                sub_lns = textwrap.fill(ln, width - 30)
+                spl = sub_lns.split("\n")
+                for i, s in enumerate(spl):
+                    boxcol.label(text=s)
+                    tot_ln += 1
+                    if tot_ln == max_ln:
+                        break
+                if tot_ln == max_ln:
+                    break
+        boxcol.label(text="." * 500)
+        # boxcol.label(text="System & addon information:")
+        sysinfo = "Blender version: {}\nMCprep version: {}\nOS: {}\n MCprep install identifier: {}".format(
+            Tracker.blender_version,
+            Tracker.version,
+            Tracker.platform,
+            Tracker.json["install_id"],
+        )
+        for ln in sysinfo.split("\n"):
+            boxcol.label(text=ln)
 
-		col.label(text="(Optional) Describe what you were trying to do when the error occured:")
-		col.prop(self,"comment",text="")
+        col.label(
+            text="(Optional) Describe what you were trying to do when the error occured:"
+        )
+        col.prop(self, "comment", text="")
 
-		row = col.row(align=True)
-		split = layout_split(layout, factor=0.6)
-		spcol = split.row()
-		spcol.label(text="Select 'Send' then press OK to share report")
-		split_two = layout_split(split, factor=0.4)
-		spcol_two = split_two.row(align=True)
-		spcol_two.prop(self,"action",text="")
-		spcol_two = split_two.row(align=True)
-		p = spcol_two.operator("wm.url_open", text="How is this used?", icon="QUESTION")
-		p.url = "https://theduckcow.com/dev/blender/mcprep/reporting-errors/"
+        row = col.row(align=True)
+        split = layout_split(layout, factor=0.6)
+        spcol = split.row()
+        spcol.label(text="Select 'Send' then press OK to share report")
+        split_two = layout_split(split, factor=0.4)
+        spcol_two = split_two.row(align=True)
+        spcol_two.prop(self, "action", text="")
+        spcol_two = split_two.row(align=True)
+        p = spcol_two.operator("wm.url_open", text="How is this used?", icon="QUESTION")
+        p.url = "https://theduckcow.com/dev/blender/mcprep/reporting-errors/"
 
-	def execute(self, context):
-		# if in headless mode, skip
-		if bpy.app.background:
-			env.log("Skip Report logging, running headless")
-			env.log("Would have reported:")
-			#env.log(self.error_report)
-			raise Exception(self.error_report)
-			return {'CANCELLED'}
+    def execute(self, context):
+        # if in headless mode, skip
+        if bpy.app.background:
+            env.log("Skip Report logging, running headless")
+            env.log("Would have reported:")
+            # env.log(self.error_report)
+            raise Exception(self.error_report)
+            return {"CANCELLED"}
 
-		if not VALID_IMPORT:
-			self.report({"ERROR"}, "Invalid import, all reporting disabled.")
-			return {'CANCELLED'}
+        if not VALID_IMPORT:
+            self.report({"ERROR"}, "Invalid import, all reporting disabled.")
+            return {"CANCELLED"}
 
-		if self.action=="ignore":
-			return {"FINISHED"}
-		# also do followup callback for hey, check here for issues or support?
-		report = {"error":self.error_report,"user_comment":self.comment}
-		if self.action == 'report':
-			res = logError(report)
-			if Tracker.verbose:
-				print("Logged user report, with server response:")
-				print(res)
-			self.report({"INFO"},"Thanks for sharing the report")
+        if self.action == "ignore":
+            return {"FINISHED"}
+        # also do followup callback for hey, check here for issues or support?
+        report = {"error": self.error_report, "user_comment": self.comment}
+        if self.action == "report":
+            res = logError(report)
+            if Tracker.verbose:
+                print("Logged user report, with server response:")
+                print(res)
+            self.report({"INFO"}, "Thanks for sharing the report")
 
-		return {'FINISHED'}
+        return {"FINISHED"}
 
 
 # -----------------------------------------------------------------------------
@@ -643,277 +683,286 @@ class TRACK_OT_popup_report_error(bpy.types.Operator):
 
 
 def trackInstalled(background=None):
-	"""Send new install event to database."""
-	if not VALID_IMPORT:
-		return
+    """Send new install event to database."""
+    if not VALID_IMPORT:
+        return
 
-	# if already installed, skip
-	if Tracker.json["status"] is None and Tracker.json["install_id"] is not None:
-		return
+    # if already installed, skip
+    if Tracker.json["status"] is None and Tracker.json["install_id"] is not None:
+        return
 
-	if Tracker.verbose:
-		print(Tracker.addon + " install registered")
+    if Tracker.verbose:
+        print(Tracker.addon + " install registered")
 
-	# if no override set, use default
-	if background is None:
-		background = Tracker.background
+    # if no override set, use default
+    if background is None:
+        background = Tracker.background
 
-	def runInstall(background):
+    def runInstall(background):
+        if Tracker.dev is True:
+            location = "/1/track/install_dev.json"
+        else:
+            location = "/1/track/install.json"
 
-		if Tracker.dev is True:
-			location = "/1/track/install_dev.json"
-		else:
-			location = "/1/track/install.json"
+        # capture re-installs/other status events
+        if Tracker.json["status"] is None:
+            status = "New install"
+        else:
+            status = Tracker.json["status"]
+            Tracker.json["status"] = None
+            Tracker.save_tracker_json()
 
-		# capture re-installs/other status events
-		if Tracker.json["status"] is None:
-			status = "New install"
-		else:
-			status = Tracker.json["status"]
-			Tracker.json["status"] = None
-			Tracker.save_tracker_json()
+        Tracker.json["install_date"] = str(datetime.now())
+        payload = json.dumps(
+            {
+                "timestamp": {".sv": "timestamp"},
+                "usertime": Tracker.string_trunc(Tracker.json["install_date"]),
+                "version": Tracker.version,
+                "blender": Tracker.blender_version,
+                "status": Tracker.string_trunc(status),
+                "platform": Tracker.platform,
+                "language": Tracker.language,
+                "ID": str(Tracker.json["install_id"]),
+            }
+        )
 
-		Tracker.json["install_date"] = str(datetime.now())
-		payload = json.dumps({
-			"timestamp": {".sv": "timestamp"},
-			"usertime": Tracker.string_trunc(Tracker.json["install_date"]),
-			"version": Tracker.version,
-			"blender": Tracker.blender_version,
-			"status": Tracker.string_trunc(status),
-			"platform": Tracker.platform,
-			"language": Tracker.language,
-			"ID": str(Tracker.json["install_id"])
-		})
+        _ = Tracker.request("POST", location, payload, background, callback)
 
-		_ = Tracker.request('POST', location, payload, background, callback)
+    def callback(arg):
+        """After call, assumes input is dict server response."""
+        if not isinstance(arg, dict):
+            return
+        elif "name" not in arg:
+            return
 
-	def callback(arg):
-		"""After call, assumes input is dict server response."""
-		if not isinstance(arg, dict):
-			return
-		elif "name" not in arg:
-			return
+        if not Tracker.json["install_id"]:
+            Tracker.json["install_id"] = arg["name"]
+            Tracker.save_tracker_json()
+            Tracker.save_tracker_idbackup()
 
-		if not Tracker.json["install_id"]:
-			Tracker.json["install_id"] = arg["name"]
-			Tracker.save_tracker_json()
-			Tracker.save_tracker_idbackup()
-
-	if Tracker.failsafe is True:
-		try:
-			runInstall(background)
-		except:
-			pass
-	else:
-		runInstall(background)
+    if Tracker.failsafe is True:
+        try:
+            runInstall(background)
+        except:
+            pass
+    else:
+        runInstall(background)
 
 
 def trackUsage(function, param=None, exporter=None, background=None):
-	"""Send usage operator usage + basic metadata to database."""
-	if not VALID_IMPORT:
-		return
-	if Tracker.tracking_enabled is False:
-		return  # skip if not opted in
-	if Tracker.verbose:
-		print("{} usage: {}, param: {}, exporter: {}, mode: {}".format(
-			Tracker.addon, function, param, exporter, Tracker.feature_set))
+    """Send usage operator usage + basic metadata to database."""
+    if not VALID_IMPORT:
+        return
+    if Tracker.tracking_enabled is False:
+        return  # skip if not opted in
+    if Tracker.verbose:
+        print(
+            "{} usage: {}, param: {}, exporter: {}, mode: {}".format(
+                Tracker.addon, function, param, exporter, Tracker.feature_set
+            )
+        )
 
-	# if no override set, use default
-	if background is None:
-		background = Tracker.background
+    # if no override set, use default
+    if background is None:
+        background = Tracker.background
 
-	def runUsage(background):
+    def runUsage(background):
+        if Tracker.dev is True:
+            location = "/1/track/usage_dev.json"
+        else:
+            location = "/1/track/usage.json"
 
-		if Tracker.dev is True:
-			location = "/1/track/usage_dev.json"
-		else:
-			location = "/1/track/usage.json"
+        payload = json.dumps(
+            {
+                "timestamp": {".sv": "timestamp"},
+                "version": Tracker.version,
+                "blender": Tracker.blender_version,
+                "platform": Tracker.platform,
+                "function": Tracker.string_trunc(function),
+                "param": Tracker.string_trunc(param),
+                "exporter": Tracker.string_trunc(exporter),
+                "language": Tracker.language,
+                "ID": Tracker.json["install_id"],
+                "mode": Tracker._feature_set,
+            }
+        )
+        _ = Tracker.request("POST", location, payload, background)
 
-		payload = json.dumps({
-			"timestamp": {".sv": "timestamp"},
-			"version": Tracker.version,
-			"blender": Tracker.blender_version,
-			"platform": Tracker.platform,
-			"function": Tracker.string_trunc(function),
-			"param": Tracker.string_trunc(param),
-			"exporter": Tracker.string_trunc(exporter),
-			"language": Tracker.language,
-			"ID": Tracker.json["install_id"],
-			"mode": Tracker._feature_set
-		})
-		_ = Tracker.request('POST', location, payload, background)
-
-	if Tracker.failsafe is True:
-		try:
-			runUsage(background)
-		except:
-			pass
-	else:
-		runUsage(background)
+    if Tracker.failsafe is True:
+        try:
+            runUsage(background)
+        except:
+            pass
+    else:
+        runUsage(background)
 
 
 def logError(report, background=None):
-	"""Send error report to database."""
-	if not VALID_IMPORT:
-		return
+    """Send error report to database."""
+    if not VALID_IMPORT:
+        return
 
-	# if no override set, use default
-	if background is None:
-		background = Tracker.background
+    # if no override set, use default
+    if background is None:
+        background = Tracker.background
 
-	def runError(background):
-		# ie auto sent in background, must adhere to tracking usage
-		if Tracker.tracking_enabled is False:
-			return  # skip if not opted in
+    def runError(background):
+        # ie auto sent in background, must adhere to tracking usage
+        if Tracker.tracking_enabled is False:
+            return  # skip if not opted in
 
-		if Tracker.dev is True:
-			location = "/1/log/user_report_dev.json"
-		else:
-			location = "/1/log/user_report.json"
+        if Tracker.dev is True:
+            location = "/1/log/user_report_dev.json"
+        else:
+            location = "/1/log/user_report.json"
 
-		# extract details
-		if "user_comment" in report:
-			user_comment = report["user_comment"]
-		else:
-			user_comment = ""
-		if "error" in report:
-			error = report["error"]
-		else:
-			error = ""
-			print("No error passed through")
-			return
+        # extract details
+        if "user_comment" in report:
+            user_comment = report["user_comment"]
+        else:
+            user_comment = ""
+        if "error" in report:
+            error = report["error"]
+        else:
+            error = ""
+            print("No error passed through")
+            return
 
-		# Comply with server-side validation, don't exceed lengths
-		if len(user_comment) > USER_COMMENT_LENGTH:
-			user_comment = user_comment[:USER_COMMENT_LENGTH - 1] + "|"
-		if len(error) > ERROR_STRING_LENGTH:
-			# TODO: make smarter, perhaps grabbing portion of start of error
-			# and portion of end to get all needed info
-			end_bound = len(error) - ERROR_STRING_LENGTH + 1
-			error = "|" + error[end_bound:]
+        # Comply with server-side validation, don't exceed lengths
+        if len(user_comment) > USER_COMMENT_LENGTH:
+            user_comment = user_comment[: USER_COMMENT_LENGTH - 1] + "|"
+        if len(error) > ERROR_STRING_LENGTH:
+            # TODO: make smarter, perhaps grabbing portion of start of error
+            # and portion of end to get all needed info
+            end_bound = len(error) - ERROR_STRING_LENGTH + 1
+            error = "|" + error[end_bound:]
 
-		payload = json.dumps({
-			"timestamp": {".sv": "timestamp"},
-			"version": Tracker.version,
-			"blender": Tracker.blender_version,
-			"platform": Tracker.platform,
-			"error": error,
-			"user_comment": user_comment,
-			"status": "None",  # used later for flagging if fixed or not
-			"ID": Tracker.json["install_id"],
-			"mode": Tracker._feature_set
-		})
-		_ = Tracker.request('POST', location, payload, background)
+        payload = json.dumps(
+            {
+                "timestamp": {".sv": "timestamp"},
+                "version": Tracker.version,
+                "blender": Tracker.blender_version,
+                "platform": Tracker.platform,
+                "error": error,
+                "user_comment": user_comment,
+                "status": "None",  # used later for flagging if fixed or not
+                "ID": Tracker.json["install_id"],
+                "mode": Tracker._feature_set,
+            }
+        )
+        _ = Tracker.request("POST", location, payload, background)
 
-	if Tracker.failsafe is True:
-		try:
-			runError(background)
-		except:
-			pass
-	else:
-		runError(background)
+    if Tracker.failsafe is True:
+        try:
+            runError(background)
+        except:
+            pass
+    else:
+        runError(background)
 
 
 def report_error(function):
-	"""Decorator for the execute(self, context) function of operators.
+    """Decorator for the execute(self, context) function of operators.
 
-	Both captures any errors for user reporting, and runs the usage tracking
-	if/as configured for the operator class. If function returns {'CANCELLED'},
-	has no track_function class attribute, or skipUsage==True, then
-	usage tracking is skipped.
-	"""
+    Both captures any errors for user reporting, and runs the usage tracking
+    if/as configured for the operator class. If function returns {'CANCELLED'},
+    has no track_function class attribute, or skipUsage==True, then
+    usage tracking is skipped.
+    """
 
-	def wrapper(self, context):
-		try:
-			Tracker._handling_error = False
-			res = function(self, context)
-			Tracker._handling_error = False
-		except:
-			err = traceback.format_exc()
-			print(err)  # Always print raw traceback.
+    def wrapper(self, context):
+        try:
+            Tracker._handling_error = False
+            res = function(self, context)
+            Tracker._handling_error = False
+        except:
+            err = traceback.format_exc()
+            print(err)  # Always print raw traceback.
 
-			if updater.json.get("just_updated") is True:
-				print("MCprep was just updated, try restarting blender.")
-				self.report(
-					{"ERROR"},
-					"An error occurred - TRY RESTARTING BLENDER since MCprep just updated")
-				return {'CANCELLED'}
+            if updater.json.get("just_updated") is True:
+                print("MCprep was just updated, try restarting blender.")
+                self.report(
+                    {"ERROR"},
+                    "An error occurred - TRY RESTARTING BLENDER since MCprep just updated",
+                )
+                return {"CANCELLED"}
 
-			err = Tracker.remove_indentifiable_information(err)
+            err = Tracker.remove_indentifiable_information(err)
 
-			# cut off the first three lines of error, which is this wrapper
-			nth_newline = 0
-			for ind in range(len(err)):
-				if err[ind] in ["\n", "\r"]:
-					nth_newline += 1
-				if nth_newline == 3:
-					if len(err) > ind+1:
-						err = err[ind+1:]
-					break
+            # cut off the first three lines of error, which is this wrapper
+            nth_newline = 0
+            for ind in range(len(err)):
+                if err[ind] in ["\n", "\r"]:
+                    nth_newline += 1
+                if nth_newline == 3:
+                    if len(err) > ind + 1:
+                        err = err[ind + 1 :]
+                    break
 
-			# Prevent recusrive popups for errors if operators call other
-			# operators, only show the inner-most errors
-			if Tracker._handling_error is False:
-				Tracker._handling_error = True
-				bpy.ops.mcprep.report_error('INVOKE_DEFAULT', error_report=err)
-			return {'CANCELLED'}
+            # Prevent recusrive popups for errors if operators call other
+            # operators, only show the inner-most errors
+            if Tracker._handling_error is False:
+                Tracker._handling_error = True
+                bpy.ops.mcprep.report_error("INVOKE_DEFAULT", error_report=err)
+            return {"CANCELLED"}
 
-		if res=={'CANCELLED'}:
-			return res  # cancelled, so skip running usage
-		elif hasattr(self, "skipUsage") and self.skipUsage is True:
-			return res  # skip running usage
-		elif VALID_IMPORT is False:
-			env.log("Skipping usage, VALID_IMPORT is False")
-			return
+        if res == {"CANCELLED"}:
+            return res  # cancelled, so skip running usage
+        elif hasattr(self, "skipUsage") and self.skipUsage is True:
+            return res  # skip running usage
+        elif VALID_IMPORT is False:
+            env.log("Skipping usage, VALID_IMPORT is False")
+            return
 
-		try:
-			wrapper_safe_handler(self)
-		except:
-			err = traceback.format_exc()
-			print("Error while reporting usage for "+str(self.track_function))
-			print(err)
+        try:
+            wrapper_safe_handler(self)
+        except:
+            err = traceback.format_exc()
+            print("Error while reporting usage for " + str(self.track_function))
+            print(err)
 
-		return res
+        return res
 
-	def wrapper_safe_handler(self):
-		"""Safely report usage, while debouncing multiple of requests.
+    def wrapper_safe_handler(self):
+        """Safely report usage, while debouncing multiple of requests.
 
-		Wrapped at this level as time module could have failed to import, used
-		during the run check
-		"""
-		run_track = hasattr(self, "track_function") and self.track_function
-		if (run_track
-			and Tracker._last_request.get("function") == self.track_function
-			and Tracker._last_request.get("time") + Tracker._debounce > time.time()
-			):
-			env.log("Skipping usage due to debounce")
-			run_track = False
+        Wrapped at this level as time module could have failed to import, used
+        during the run check
+        """
+        run_track = hasattr(self, "track_function") and self.track_function
+        if (
+            run_track
+            and Tracker._last_request.get("function") == self.track_function
+            and Tracker._last_request.get("time") + Tracker._debounce > time.time()
+        ):
+            env.log("Skipping usage due to debounce")
+            run_track = False
 
-		# If successful completion, run analytics function if relevant
-		if bpy.app.background and run_track:
-			env.log("Background mode, would have tracked usage: " + self.track_function)
-		elif run_track:
-			param = None
-			exporter = None
-			if hasattr(self, "track_param"):
-				param = self.track_param
-			if hasattr(self, "track_exporter"):
-				exporter = self.track_exporter
+        # If successful completion, run analytics function if relevant
+        if bpy.app.background and run_track:
+            env.log("Background mode, would have tracked usage: " + self.track_function)
+        elif run_track:
+            param = None
+            exporter = None
+            if hasattr(self, "track_param"):
+                param = self.track_param
+            if hasattr(self, "track_exporter"):
+                exporter = self.track_exporter
 
-			try:
-				trackUsage(self.track_function, param=param, exporter=exporter)
-			except:
-				err = traceback.format_exc()
-				print("Error while reporting usage for "+str(self.track_function))
-				print(err)
+            try:
+                trackUsage(self.track_function, param=param, exporter=exporter)
+            except:
+                err = traceback.format_exc()
+                print("Error while reporting usage for " + str(self.track_function))
+                print(err)
 
-			# always update the last request gone through
-			Tracker._last_request = {
-				"time": time.time(),
-				"function": self.track_function
-			}
+            # always update the last request gone through
+            Tracker._last_request = {
+                "time": time.time(),
+                "function": self.track_function,
+            }
 
-	return wrapper
+    return wrapper
 
 
 # -----------------------------------------------------------------------------
@@ -922,86 +971,87 @@ def report_error(function):
 
 
 def layout_split(layout, factor=0.0, align=False):
-	"""Intermediate method for pre and post blender 2.8 split UI function"""
-	if not hasattr(bpy.app, "version") or bpy.app.version < (2, 80):
-		return layout.split(percentage=factor, align=align)
-	return layout.split(factor=factor, align=align)
+    """Intermediate method for pre and post blender 2.8 split UI function"""
+    if not hasattr(bpy.app, "version") or bpy.app.version < (2, 80):
+        return layout.split(percentage=factor, align=align)
+    return layout.split(factor=factor, align=align)
 
 
 classes = (
-	TRACK_OT_toggle_enable_tracking,
-	TRACK_OT_popup_feedback,
-	TRACK_OT_popup_report_error
+    TRACK_OT_toggle_enable_tracking,
+    TRACK_OT_popup_feedback,
+    TRACK_OT_popup_report_error,
 )
 
 
 def register(bl_info):
-	"""Setup the tracker and register install."""
-	global VALID_IMPORT
+    """Setup the tracker and register install."""
+    global VALID_IMPORT
 
-	bversion = None
-	# for compatibility to prior blender (2.75?)
-	try:
-		bversion = bpy.app.version
-	except Exception as err:
-		err = traceback.format_exc()
-		print("Could not get blender version:")
-		print(err)
+    bversion = None
+    # for compatibility to prior blender (2.75?)
+    try:
+        bversion = bpy.app.version
+    except Exception as err:
+        err = traceback.format_exc()
+        print("Could not get blender version:")
+        print(err)
 
-	language = None
+    language = None
 
-	if hasattr(bpy.app, "version") and bpy.app.version >= (2, 80):
-		if hasattr(bpy.context, "preferences"):
-			system = bpy.context.preferences.view
-		elif hasattr(bpy.context, "user_preferences"):
-			system = bpy.context.user_preferences.view
-		else:
-			system = None
+    if hasattr(bpy.app, "version") and bpy.app.version >= (2, 80):
+        if hasattr(bpy.context, "preferences"):
+            system = bpy.context.preferences.view
+        elif hasattr(bpy.context, "user_preferences"):
+            system = bpy.context.user_preferences.view
+        else:
+            system = None
 
-		if not system:
-			pass
-		elif hasattr(system, "language"):
-			language = system.language
-	else:
-		system = bpy.context.user_preferences.system
-		if system.use_international_fonts:
-			language = system.language
+        if not system:
+            pass
+        elif hasattr(system, "language"):
+            language = system.language
+    else:
+        system = bpy.context.user_preferences.system
+        if system.use_international_fonts:
+            language = system.language
 
-	try:
-		Tracker.initialize(
-			appurl = "https://mcprep-1aa04.firebaseio.com/",
-			version = str(bl_info["version"]),
-			language = language,
-			blender_version = bversion)
-	except Exception as err:
-		err = traceback.format_exc()
-		print(err)
-		VALID_IMPORT = False
+    try:
+        Tracker.initialize(
+            appurl="https://mcprep-1aa04.firebaseio.com/",
+            version=str(bl_info["version"]),
+            language=language,
+            blender_version=bversion,
+        )
+    except Exception as err:
+        err = traceback.format_exc()
+        print(err)
+        VALID_IMPORT = False
 
-	# used to define which server source, not just if's below
-	if VALID_IMPORT:
-		Tracker.dev = env.dev_build # True or False
-	else:
-		Tracker.dev = False
+    # used to define which server source, not just if's below
+    if VALID_IMPORT:
+        Tracker.dev = env.dev_build  # True or False
+    else:
+        Tracker.dev = False
 
-	if Tracker.dev is True:
-		Tracker.verbose = True
-		Tracker.background = True # test either way
-		Tracker.failsafe = False # test either way
-		Tracker.tracking_enabled = True # enabled automatically for testing
-	else:
-		Tracker.verbose = False
-		Tracker.background = True
-		Tracker.failsafe = True
-		Tracker.tracking_enabled = True # User accepted on download
+    if Tracker.dev is True:
+        Tracker.verbose = True
+        Tracker.background = True  # test either way
+        Tracker.failsafe = False  # test either way
+        Tracker.tracking_enabled = True  # enabled automatically for testing
+    else:
+        Tracker.verbose = False
+        Tracker.background = True
+        Tracker.failsafe = True
+        Tracker.tracking_enabled = True  # User accepted on download
 
-	for cls in classes:
-		bpy.utils.register_class(cls)
+    for cls in classes:
+        bpy.utils.register_class(cls)
 
-	# register install
-	trackInstalled()
+    # register install
+    trackInstalled()
 
 
 def unregister():
-	for cls in reversed(classes):
-		bpy.utils.unregister_class(cls)
+    for cls in reversed(classes):
+        bpy.utils.unregister_class(cls)

--- a/MCprep_addon/util.py
+++ b/MCprep_addon/util.py
@@ -40,524 +40,522 @@ SPAWNER_EXCLUDE = "Spawner Exclude"
 
 
 def apply_colorspace(node, color_enum):
-	"""Apply color space in a cross compatible way, for version and language.
+    """Apply color space in a cross compatible way, for version and language.
 
-	Use enum nomeclature matching Blender 2.8x Default, not 2.7 or other lang
-	"""
-	global noncolor_override
-	noncolor_override = None
+    Use enum nomeclature matching Blender 2.8x Default, not 2.7 or other lang
+    """
+    global noncolor_override
+    noncolor_override = None
 
-	if not node.image:
-		env.log("Node has no image applied yet, cannot change colorspace")
+    if not node.image:
+        env.log("Node has no image applied yet, cannot change colorspace")
 
-	# For later 2.8, fix images color space user
-	if hasattr(node, "color_space"):  # 2.7 and earlier 2.8 versions
-		node.color_space = 'NONE'  # for better interpretation of specmaps
-	elif hasattr(node.image, "colorspace_settings"):  # later 2.8 versions
-		# try default 'Non-color', fall back to best guess 'Non-Colour Data'
-		if color_enum == 'Non-color' and noncolor_override is not None:
-			node.image.colorspace_settings.name = noncolor_override
-		else:
-			try:
-				node.image.colorspace_settings.name = 'Non-Color'
-			except TypeError:
-				node.image.colorspace_settings.name = 'Non-Colour Data'
-				noncolor_override = 'Non-Colour Data'
+    # For later 2.8, fix images color space user
+    if hasattr(node, "color_space"):  # 2.7 and earlier 2.8 versions
+        node.color_space = "NONE"  # for better interpretation of specmaps
+    elif hasattr(node.image, "colorspace_settings"):  # later 2.8 versions
+        # try default 'Non-color', fall back to best guess 'Non-Colour Data'
+        if color_enum == "Non-color" and noncolor_override is not None:
+            node.image.colorspace_settings.name = noncolor_override
+        else:
+            try:
+                node.image.colorspace_settings.name = "Non-Color"
+            except TypeError:
+                node.image.colorspace_settings.name = "Non-Colour Data"
+                noncolor_override = "Non-Colour Data"
 
 
 def nameGeneralize(name):
-	"""Get base name from datablock, accounts for duplicates and animated tex."""
-	if duplicatedDatablock(name) is True:
-		name = name[:-4]  # removes .001
-	if name.endswith(".png"):
-		name = name[:-4]
+    """Get base name from datablock, accounts for duplicates and animated tex."""
+    if duplicatedDatablock(name) is True:
+        name = name[:-4]  # removes .001
+    if name.endswith(".png"):
+        name = name[:-4]
 
-	# if name ends in _####, drop those numbers (for animated sequences)
-	# noting it is specifically 4 numbers
-	# could use regex, but some historical issues within including this lib
-	# in certain blender builds
-	nums = '0123456789'
-	if len(name) < 5:
-		return name
-	any_nonnumbs = [1 if ltr in nums else 0 for ltr in name[-4:]]
-	if sum(any_nonnumbs) == 4:  # all leters are numbers
-		if name[-5] in ["-", "_", " "]:
-			name = name[:-5]
-		else:
-			name = name[:-4]
-	return name
+    # if name ends in _####, drop those numbers (for animated sequences)
+    # noting it is specifically 4 numbers
+    # could use regex, but some historical issues within including this lib
+    # in certain blender builds
+    nums = "0123456789"
+    if len(name) < 5:
+        return name
+    any_nonnumbs = [1 if ltr in nums else 0 for ltr in name[-4:]]
+    if sum(any_nonnumbs) == 4:  # all leters are numbers
+        if name[-5] in ["-", "_", " "]:
+            name = name[:-5]
+        else:
+            name = name[:-4]
+    return name
 
 
 def materialsFromObj(obj_list):
-	"""Gets all materials on input list of objects.
+    """Gets all materials on input list of objects.
 
-	Loop over every object, adding each material if not already added
-	"""
-	mat_list = []
-	for obj in obj_list:
-		# also capture obj materials from dupliverts/instances on e.g. empties
-		if hasattr(obj, "dupli_group") and obj.dupli_group:  # 2.7
-			for dup_obj in obj.dupli_group.objects:
-				if dup_obj not in obj_list:
-					obj_list.append(dup_obj)
-		elif hasattr(obj, "instance_collection") and obj.instance_collection:  # 2.8
-			for dup_obj in obj.instance_collection.objects:
-				if dup_obj not in obj_list:
-					obj_list.append(dup_obj)
-		if obj.type != 'MESH':
-			continue
-		for slot in obj.material_slots:
-			if slot.material is not None and slot.material not in mat_list:
-				mat_list.append(slot.material)
-	return mat_list
+    Loop over every object, adding each material if not already added
+    """
+    mat_list = []
+    for obj in obj_list:
+        # also capture obj materials from dupliverts/instances on e.g. empties
+        if hasattr(obj, "dupli_group") and obj.dupli_group:  # 2.7
+            for dup_obj in obj.dupli_group.objects:
+                if dup_obj not in obj_list:
+                    obj_list.append(dup_obj)
+        elif hasattr(obj, "instance_collection") and obj.instance_collection:  # 2.8
+            for dup_obj in obj.instance_collection.objects:
+                if dup_obj not in obj_list:
+                    obj_list.append(dup_obj)
+        if obj.type != "MESH":
+            continue
+        for slot in obj.material_slots:
+            if slot.material is not None and slot.material not in mat_list:
+                mat_list.append(slot.material)
+    return mat_list
 
 
 def bAppendLink(directory, name, toLink, active_layer=True):
-	"""For multiple version compatibility, this function generalized
-	appending/linking blender post 2.71 changed to new append/link methods
+    """For multiple version compatibility, this function generalized
+    appending/linking blender post 2.71 changed to new append/link methods
 
-	Note that for 2.8 compatibility, the directory passed in should
-	already be correctly identified (eg Group or Collection)
+    Note that for 2.8 compatibility, the directory passed in should
+    already be correctly identified (eg Group or Collection)
 
-	Arguments:
-		directory: xyz.blend/Type, where Type is: Collection, Group, Material...
-		name: asset name
-		toLink: bool
+    Arguments:
+            directory: xyz.blend/Type, where Type is: Collection, Group, Material...
+            name: asset name
+            toLink: bool
 
-	Returns: true if successful, false if not.
-	"""
+    Returns: true if successful, false if not.
+    """
 
-	env.log("Appending " + directory + " : " + name, vv_only=True)
+    env.log("Appending " + directory + " : " + name, vv_only=True)
 
-	# for compatibility, add ending character
-	if directory[-1] != "/" and directory[-1] != os.path.sep:
-		directory += os.path.sep
+    # for compatibility, add ending character
+    if directory[-1] != "/" and directory[-1] != os.path.sep:
+        directory += os.path.sep
 
-	if "link_append" in dir(bpy.ops.wm):
-		# OLD method of importing, e.g. in blender 2.70
-		env.log("Using old method of append/link, 2.72 <=", vv_only=True)
-		try:
-			bpy.ops.wm.link_append(directory=directory, filename=name, link=toLink)
-			return True
-		except RuntimeError as e:
-			print("bAppendLink", e)
-			return False
-	elif "link" in dir(bpy.ops.wm) and "append" in dir(bpy.ops.wm):
-		env.log("Using post-2.72 method of append/link", vv_only=True)
-		if toLink:
-			bpy.ops.wm.link(directory=directory, filename=name)
-		elif bv28():
-			try:
-				bpy.ops.wm.append(
-					directory=directory,
-					filename=name)
-				return True
-			except RuntimeError as e:
-				print("bAppendLink", e)
-				return False
-		else:
-			env.log("{} {} {}".format(directory, name, active_layer))
-			try:
-				bpy.ops.wm.append(
-					directory=directory,
-					filename=name,
-					active_layer=active_layer)
-				return True
-			except RuntimeError as e:
-				print("bAppendLink", e)
-				return False
+    if "link_append" in dir(bpy.ops.wm):
+        # OLD method of importing, e.g. in blender 2.70
+        env.log("Using old method of append/link, 2.72 <=", vv_only=True)
+        try:
+            bpy.ops.wm.link_append(directory=directory, filename=name, link=toLink)
+            return True
+        except RuntimeError as e:
+            print("bAppendLink", e)
+            return False
+    elif "link" in dir(bpy.ops.wm) and "append" in dir(bpy.ops.wm):
+        env.log("Using post-2.72 method of append/link", vv_only=True)
+        if toLink:
+            bpy.ops.wm.link(directory=directory, filename=name)
+        elif bv28():
+            try:
+                bpy.ops.wm.append(directory=directory, filename=name)
+                return True
+            except RuntimeError as e:
+                print("bAppendLink", e)
+                return False
+        else:
+            env.log("{} {} {}".format(directory, name, active_layer))
+            try:
+                bpy.ops.wm.append(
+                    directory=directory, filename=name, active_layer=active_layer
+                )
+                return True
+            except RuntimeError as e:
+                print("bAppendLink", e)
+                return False
 
 
 def obj_copy(base, context=None, vertex_groups=True, modifiers=True):
-	"""Copy an object's data, vertex groups, and modifiers without operators.
+    """Copy an object's data, vertex groups, and modifiers without operators.
 
-	Input must be a valid object in bpy.data.objects
-	"""
-	if not base or base.name not in bpy.data.objects:
-		raise Exception("Invalid object passed")
-	if not context:
-		context = bpy.context
+    Input must be a valid object in bpy.data.objects
+    """
+    if not base or base.name not in bpy.data.objects:
+        raise Exception("Invalid object passed")
+    if not context:
+        context = bpy.context
 
-	new_ob = bpy.data.objects.new(base.name, base.data.copy())
-	obj_link_scene(new_ob, context)
+    new_ob = bpy.data.objects.new(base.name, base.data.copy())
+    obj_link_scene(new_ob, context)
 
-	if vertex_groups:
-		verts = len(base.data.vertices)
-		for vgroup in base.vertex_groups:
-			print("Running vertex group: ", vgroup.name)
-			new_g = new_ob.vertex_groups.new(name=vgroup.name)
-			for i in range(0, verts):
-				try:
-					new_g.add([i], vgroup.weight(i), "REPLACE")
-				except:
-					pass  # no way to check if a given vertex is part of src group
+    if vertex_groups:
+        verts = len(base.data.vertices)
+        for vgroup in base.vertex_groups:
+            print("Running vertex group: ", vgroup.name)
+            new_g = new_ob.vertex_groups.new(name=vgroup.name)
+            for i in range(0, verts):
+                try:
+                    new_g.add([i], vgroup.weight(i), "REPLACE")
+                except:
+                    pass  # no way to check if a given vertex is part of src group
 
-	if modifiers:
-		for mod_src in base.modifiers:
-			dest = new_ob.modifiers.get(mod_src.name, None)
-			if not dest:
-				dest = new_ob.modifiers.new(mod_src.name, mod_src.type)
-			properties = [
-				p.identifier for p in mod_src.bl_rna.properties
-				if not p.is_readonly]
-			for prop in properties:
-				setattr(dest, prop, getattr(mod_src, prop))
-	return new_ob
+    if modifiers:
+        for mod_src in base.modifiers:
+            dest = new_ob.modifiers.get(mod_src.name, None)
+            if not dest:
+                dest = new_ob.modifiers.new(mod_src.name, mod_src.type)
+            properties = [
+                p.identifier for p in mod_src.bl_rna.properties if not p.is_readonly
+            ]
+            for prop in properties:
+                setattr(dest, prop, getattr(mod_src, prop))
+    return new_ob
+
 
 def min_bv(version, *, inclusive=True):
-	if hasattr(bpy.app, "version"):
-		if inclusive is False:
-			return bpy.app.version > version
-		return bpy.app.version >= version
+    if hasattr(bpy.app, "version"):
+        if inclusive is False:
+            return bpy.app.version > version
+        return bpy.app.version >= version
 
 
 def bv28():
-	"""Check if blender 2.8, for layouts, UI, and properties. """
-	env.deprecation_warning()
-	return min_bv((2, 80))
+    """Check if blender 2.8, for layouts, UI, and properties."""
+    env.deprecation_warning()
+    return min_bv((2, 80))
 
 
 def bv30():
-	"""Check if we're dealing with Blender 3.0"""
-	return min_bv((3, 00))
+    """Check if we're dealing with Blender 3.0"""
+    return min_bv((3, 00))
 
 
 def is_atlas_export(context):
-	"""Check if the selected objects are textureswap/animate tex compatible.
+    """Check if the selected objects are textureswap/animate tex compatible.
 
-	Atlas textures are ones where all textures are combined into a single file,
-	while individual textures is where there is one image file per block type.
+    Atlas textures are ones where all textures are combined into a single file,
+    while individual textures is where there is one image file per block type.
 
-	Returns a bool. If false, the UI will show a warning and link to doc
-	about using the right settings.
-	"""
-	if not context.selected_objects:
-		# Don't trigger the UI warning just because nothing is selected
-		return True
+    Returns a bool. If false, the UI will show a warning and link to doc
+    about using the right settings.
+    """
+    if not context.selected_objects:
+        # Don't trigger the UI warning just because nothing is selected
+        return True
 
-	file_types = {
-		"ATLAS": 0,
-		"INDIVIDUAL": 0
-	}
-	for obj in context.selected_objects:
-		# If the header exists then we should be fine
-		if "MCPREP_OBJ_HEADER" in obj:
-			if obj["MCPREP_OBJ_FILE_TYPE"] == "ATLAS":
-				file_types["ATLAS"] += 1
-			else:
-				file_types["INDIVIDUAL"] += 1
-		else:
-			continue
+    file_types = {"ATLAS": 0, "INDIVIDUAL": 0}
+    for obj in context.selected_objects:
+        # If the header exists then we should be fine
+        if "MCPREP_OBJ_HEADER" in obj:
+            if obj["MCPREP_OBJ_FILE_TYPE"] == "ATLAS":
+                file_types["ATLAS"] += 1
+            else:
+                file_types["INDIVIDUAL"] += 1
+        else:
+            continue
 
-	return file_types["ATLAS"] == 0
+    return file_types["ATLAS"] == 0
 
 
 def face_on_edge(faceLoc):
-	"""Check if a face is on the boundary between two blocks (local coordinates)."""
-	face_decimals = [loc - loc // 1 for loc in faceLoc]
-	if face_decimals[0] > 0.4999 and face_decimals[0] < 0.501:
-		return True
-	elif face_decimals[1] > 0.499 and face_decimals[1] < 0.501:
-		return True
-	elif face_decimals[2] > 0.499 and face_decimals[2] < 0.501:
-		return True
-	return False
+    """Check if a face is on the boundary between two blocks (local coordinates)."""
+    face_decimals = [loc - loc // 1 for loc in faceLoc]
+    if face_decimals[0] > 0.4999 and face_decimals[0] < 0.501:
+        return True
+    elif face_decimals[1] > 0.499 and face_decimals[1] < 0.501:
+        return True
+    elif face_decimals[2] > 0.499 and face_decimals[2] < 0.501:
+        return True
+    return False
 
 
 def randomizeMeshSawp(swap, variations):
-	"""Randomization for model imports, add extra statements for exta cases."""
-	randi = ''
-	if swap == 'torch':
-		randomized = random.randint(0, variations - 1)
-		if randomized != 0:
-			randi = ".{x}".format(x=randomized)
-	elif swap == 'Torch':
-		randomized = random.randint(0, variations - 1)
-		if randomized != 0:
-			randi = ".{x}".format(x=randomized)
-	return swap + randi
+    """Randomization for model imports, add extra statements for exta cases."""
+    randi = ""
+    if swap == "torch":
+        randomized = random.randint(0, variations - 1)
+        if randomized != 0:
+            randi = ".{x}".format(x=randomized)
+    elif swap == "Torch":
+        randomized = random.randint(0, variations - 1)
+        if randomized != 0:
+            randi = ".{x}".format(x=randomized)
+    return swap + randi
 
 
 def duplicatedDatablock(name):
-	"""Check if datablock is a duplicate or not, e.g. ending in .00# """
-	try:
-		if name[-4] != ".":
-			return False
-		int(name[-3:])  # Will force ValueError if not a number.
-		return True
-	except IndexError:
-		return False
-	except ValueError:
-		return False
+    """Check if datablock is a duplicate or not, e.g. ending in .00#"""
+    try:
+        if name[-4] != ".":
+            return False
+        int(name[-3:])  # Will force ValueError if not a number.
+        return True
+    except IndexError:
+        return False
+    except ValueError:
+        return False
 
 
 def loadTexture(texture):
-	"""Load texture once, reusing existing texture if present."""
-	base = nameGeneralize(bpy.path.basename(texture))
-	if base in bpy.data.images:
-		base_filepath = bpy.path.abspath(bpy.data.images[base].filepath)
-		if base_filepath == bpy.path.abspath(texture):
-			data_img = bpy.data.images[base]
-			data_img.reload()
-			env.log("Using already loaded texture", vv_only=True)
-		else:
-			data_img = bpy.data.images.load(texture, check_existing=True)
-			env.log("Loading new texture image", vv_only=True)
-	else:
-		data_img = bpy.data.images.load(texture, check_existing=True)
-		env.log("Loading new texture image", vv_only=True)
-	return data_img
+    """Load texture once, reusing existing texture if present."""
+    base = nameGeneralize(bpy.path.basename(texture))
+    if base in bpy.data.images:
+        base_filepath = bpy.path.abspath(bpy.data.images[base].filepath)
+        if base_filepath == bpy.path.abspath(texture):
+            data_img = bpy.data.images[base]
+            data_img.reload()
+            env.log("Using already loaded texture", vv_only=True)
+        else:
+            data_img = bpy.data.images.load(texture, check_existing=True)
+            env.log("Loading new texture image", vv_only=True)
+    else:
+        data_img = bpy.data.images.load(texture, check_existing=True)
+        env.log("Loading new texture image", vv_only=True)
+    return data_img
 
 
 def remap_users(old, new):
-	"""Consistent, general way to remap datablock users."""
-	# Todo: write equivalent function of user_remap for older blender versions
-	try:
-		old.user_remap(new)
-		return 0
-	except:
-		return "not available prior to blender 2.78"
+    """Consistent, general way to remap datablock users."""
+    # Todo: write equivalent function of user_remap for older blender versions
+    try:
+        old.user_remap(new)
+        return 0
+    except:
+        return "not available prior to blender 2.78"
 
 
 def get_objects_conext(context):
-	"""Returns list of objects, either from view layer if 2.8 or scene if 2.8"""
-	if bv28():
-		return context.view_layer.objects
-	return context.scene.objects
+    """Returns list of objects, either from view layer if 2.8 or scene if 2.8"""
+    if bv28():
+        return context.view_layer.objects
+    return context.scene.objects
 
 
 def link_selected_objects_to_scene():
-	"""Quick script for linking all objects back into a scene.
+    """Quick script for linking all objects back into a scene.
 
-	Not used by addon, but shortcut useful in one-off cases to copy/run code
-	"""
-	for ob in bpy.data.objects:
-		if ob not in list(bpy.context.scene.objects):
-			obj_link_scene(ob)
+    Not used by addon, but shortcut useful in one-off cases to copy/run code
+    """
+    for ob in bpy.data.objects:
+        if ob not in list(bpy.context.scene.objects):
+            obj_link_scene(ob)
 
 
 def open_program(executable):
-	# Open an external program from filepath/executbale
-	executable = bpy.path.abspath(executable)
-	env.log("Open program request: " + executable)
+    # Open an external program from filepath/executbale
+    executable = bpy.path.abspath(executable)
+    env.log("Open program request: " + executable)
 
-	# input could be .app file, which appears as if a folder
-	if not os.path.isfile(executable):
-		env.log("File not executable")
-		if not os.path.isdir(executable):
-			return -1
-		elif not executable.lower().endswith(".app"):
-			return -1
+    # input could be .app file, which appears as if a folder
+    if not os.path.isfile(executable):
+        env.log("File not executable")
+        if not os.path.isdir(executable):
+            return -1
+        elif not executable.lower().endswith(".app"):
+            return -1
 
-	# try to open with wine, if available
-	osx_or_linux = platform.system() == "Darwin"
-	osx_or_linux = osx_or_linux or 'linux' in platform.system().lower()
-	if executable.lower().endswith('.exe') and osx_or_linux:
-		env.log("Opening program via wine")
-		p = Popen(['which', 'wine'], stdin=PIPE, stdout=PIPE, stderr=PIPE)
-		stdout, err = p.communicate(b"")
-		has_wine = stdout and not err
+    # try to open with wine, if available
+    osx_or_linux = platform.system() == "Darwin"
+    osx_or_linux = osx_or_linux or "linux" in platform.system().lower()
+    if executable.lower().endswith(".exe") and osx_or_linux:
+        env.log("Opening program via wine")
+        p = Popen(["which", "wine"], stdin=PIPE, stdout=PIPE, stderr=PIPE)
+        stdout, err = p.communicate(b"")
+        has_wine = stdout and not err
 
-		if has_wine:
-			# wine is installed; this will hang blender until mineways closes.
-			p = Popen(['wine', executable], stdin=PIPE, stdout=PIPE, stderr=PIPE)
-			env.log(
-				"Opening via wine + direct executable, will hang blender till closed")
+        if has_wine:
+            # wine is installed; this will hang blender until mineways closes.
+            p = Popen(["wine", executable], stdin=PIPE, stdout=PIPE, stderr=PIPE)
+            env.log(
+                "Opening via wine + direct executable, will hang blender till closed"
+            )
 
-			# communicating with process makes it hang, so trust it works
-			# stdout, err = p.communicate(b"")
-			# for line in iter(p.stdout.readline, ''):
-			# 	# will print lines as they come, instead of just at end
-			# 	print(stdout)
-			return 0
+            # communicating with process makes it hang, so trust it works
+            # stdout, err = p.communicate(b"")
+            # for line in iter(p.stdout.readline, ''):
+            # 	# will print lines as they come, instead of just at end
+            # 	print(stdout)
+            return 0
 
-	try:  # attempt to use blender's built-in method
-		res = bpy.ops.wm.path_open(filepath=executable)
-		if res == {"FINISHED"}:
-			env.log("Opened using built in path opener")
-			return 0
-		else:
-			env.log("Did not get finished response: ", str(res))
-	except:
-		env.log("failed to open using builtin mehtod")
-		pass
+    try:  # attempt to use blender's built-in method
+        res = bpy.ops.wm.path_open(filepath=executable)
+        if res == {"FINISHED"}:
+            env.log("Opened using built in path opener")
+            return 0
+        else:
+            env.log("Did not get finished response: ", str(res))
+    except:
+        env.log("failed to open using builtin mehtod")
+        pass
 
-	if platform.system() == "Darwin" and executable.lower().endswith(".app"):
-		# for mac, if folder, check that it has .app otherwise throw -1
-		# (right now says will open even if just folder!!)
-		env.log("Attempting to open .app via system Open")
-		p = Popen(['open', executable], stdin=PIPE, stdout=PIPE, stderr=PIPE)
-		stdout, err = p.communicate(b"")
-		if err != b"":
-			return "Error occured while trying to open executable: " + str(err)
-	return "Failed to open executable"
+    if platform.system() == "Darwin" and executable.lower().endswith(".app"):
+        # for mac, if folder, check that it has .app otherwise throw -1
+        # (right now says will open even if just folder!!)
+        env.log("Attempting to open .app via system Open")
+        p = Popen(["open", executable], stdin=PIPE, stdout=PIPE, stderr=PIPE)
+        stdout, err = p.communicate(b"")
+        if err != b"":
+            return "Error occured while trying to open executable: " + str(err)
+    return "Failed to open executable"
 
 
 def open_folder_crossplatform(folder):
-	"""Cross platform way to open folder in host operating system."""
-	folder = bpy.path.abspath(folder)
-	if not os.path.isdir(folder):
-		return False
+    """Cross platform way to open folder in host operating system."""
+    folder = bpy.path.abspath(folder)
+    if not os.path.isdir(folder):
+        return False
 
-	try:  # first attempt to use blender's built-in method
-		res = bpy.ops.wm.path_open(filepath=folder)
-		if res == {"FINISHED"}:
-			return True
-	except:
-		pass
+    try:  # first attempt to use blender's built-in method
+        res = bpy.ops.wm.path_open(filepath=folder)
+        if res == {"FINISHED"}:
+            return True
+    except:
+        pass
 
-	try:
-		# windows... untested
-		subprocess.Popen('explorer "{x}"'.format(x=folder))
-		return True
-	except:
-		pass
-	try:
-		# mac... works on Yosemite minimally
-		subprocess.call(["open", folder])
-		return True
-	except:
-		pass
-	try:
-		# linux
-		subprocess.call(["xdg-open", folder])
-		return True
-	except:
-		return False
+    try:
+        # windows... untested
+        subprocess.Popen('explorer "{x}"'.format(x=folder))
+        return True
+    except:
+        pass
+    try:
+        # mac... works on Yosemite minimally
+        subprocess.call(["open", folder])
+        return True
+    except:
+        pass
+    try:
+        # linux
+        subprocess.call(["xdg-open", folder])
+        return True
+    except:
+        return False
 
 
 def addGroupInstance(group_name, loc, select=True):
-	"""Add object instance not working, so workaround function."""
-	# The built in method fails, bpy.ops.object.group_instance_add(...)
-	# UPDATE: I reported the bug, and they fixed it nearly instantly =D
-	# but it was recommended to do the below anyways.
+    """Add object instance not working, so workaround function."""
+    # The built in method fails, bpy.ops.object.group_instance_add(...)
+    # UPDATE: I reported the bug, and they fixed it nearly instantly =D
+    # but it was recommended to do the below anyways.
 
-	scene = bpy.context.scene
-	ob = bpy.data.objects.new(group_name, None)
-	if bv28():
-		ob.instance_type = 'COLLECTION'
-		ob.instance_collection = collections().get(group_name)
-		scene.collection.objects.link(ob)  # links to scene collection
-	else:
-		ob.dupli_type = 'GROUP'
-		ob.dupli_group = collections().get(group_name)
-		scene.objects.link(ob)
-	ob.location = loc
-	select_set(ob, select)
-	return ob
+    scene = bpy.context.scene
+    ob = bpy.data.objects.new(group_name, None)
+    if bv28():
+        ob.instance_type = "COLLECTION"
+        ob.instance_collection = collections().get(group_name)
+        scene.collection.objects.link(ob)  # links to scene collection
+    else:
+        ob.dupli_type = "GROUP"
+        ob.dupli_group = collections().get(group_name)
+        scene.objects.link(ob)
+    ob.location = loc
+    select_set(ob, select)
+    return ob
 
 
 def load_mcprep_json():
-	"""Load in the json file, defered so not at addon enable time."""
-	path = env.json_path
-	default = {
-		"blocks": {
-			"reflective": [],
-			"water": [],
-			"solid": [],
-			"emit": [],
-			"desaturated": [],
-			"animated": [],
-			"block_mapping_mc": {},
-			"block_mapping_jmc": {},
-			"block_mapping_mineways": {},
-			"canon_mapping_block": {}
-		},
-		"mob_skip_prep": [],
-		"make_real": []
-	}
-	if not os.path.isfile(path):
-		env.log("Error, json file does not exist: " + path)
-		env.json_data = default
-		return False
-	with open(path) as data_file:
-		try:
-			env.json_data = json.load(data_file)
-			env.log("Successfully read the JSON file")
-			return True
-		except Exception as err:
-			print("Failed to load json file:")
-			print('\t', err)
-			env.json_data = default
+    """Load in the json file, defered so not at addon enable time."""
+    path = env.json_path
+    default = {
+        "blocks": {
+            "reflective": [],
+            "water": [],
+            "solid": [],
+            "emit": [],
+            "desaturated": [],
+            "animated": [],
+            "block_mapping_mc": {},
+            "block_mapping_jmc": {},
+            "block_mapping_mineways": {},
+            "canon_mapping_block": {},
+        },
+        "mob_skip_prep": [],
+        "make_real": [],
+    }
+    if not os.path.isfile(path):
+        env.log("Error, json file does not exist: " + path)
+        env.json_data = default
+        return False
+    with open(path) as data_file:
+        try:
+            env.json_data = json.load(data_file)
+            env.log("Successfully read the JSON file")
+            return True
+        except Exception as err:
+            print("Failed to load json file:")
+            print("\t", err)
+            env.json_data = default
 
 
 def ui_scale():
-	"""Returns scale of UI, for width drawing. Compatible down to blender 2.72"""
-	prefs = get_preferences()
-	if not hasattr(prefs, "view"):
-		return 1
-	elif hasattr(prefs.view, "ui_scale") and hasattr(prefs.view, "pixel_size"):
-		return prefs.view.ui_scale * prefs.system.pixel_size
-	elif hasattr(prefs.system, "dpi"):
-		return prefs.system.dpi / 72
-	else:
-		return 1
+    """Returns scale of UI, for width drawing. Compatible down to blender 2.72"""
+    prefs = get_preferences()
+    if not hasattr(prefs, "view"):
+        return 1
+    elif hasattr(prefs.view, "ui_scale") and hasattr(prefs.view, "pixel_size"):
+        return prefs.view.ui_scale * prefs.system.pixel_size
+    elif hasattr(prefs.system, "dpi"):
+        return prefs.system.dpi / 72
+    else:
+        return 1
 
 
-def uv_select(obj, action='TOGGLE'):
-	"""Direct way to select all UV verts of an object, assumings 1 uv layer.
+def uv_select(obj, action="TOGGLE"):
+    """Direct way to select all UV verts of an object, assumings 1 uv layer.
 
-	Actions are: SELECT, DESELECT, TOGGLE.
-	"""
-	if not obj.data.uv_layers.active:
-		return  # consider raising error
-	if action == 'TOGGLE':
-		for face in obj.data.polygons:
-			face.select = not face.select
-	elif action == 'SELECT':
-		for face in obj.data.polygons:
-			# if len(face.loop_indices) < 3:
-			# 	continue
-			face.select = True
-	elif action == 'DESELECT':
-		for face in obj.data.polygons:
-			# if len(face.loop_indices) < 3:
-			# 	continue
-			face.select = False
+    Actions are: SELECT, DESELECT, TOGGLE.
+    """
+    if not obj.data.uv_layers.active:
+        return  # consider raising error
+    if action == "TOGGLE":
+        for face in obj.data.polygons:
+            face.select = not face.select
+    elif action == "SELECT":
+        for face in obj.data.polygons:
+            # if len(face.loop_indices) < 3:
+            # 	continue
+            face.select = True
+    elif action == "DESELECT":
+        for face in obj.data.polygons:
+            # if len(face.loop_indices) < 3:
+            # 	continue
+            face.select = False
 
 
 def move_to_collection(obj, collection):
-	"""Move out of all collections and into this specified one. 2.8 only"""
-	for col in obj.users_collection:
-		col.objects.unlink(obj)
-	collection.objects.link(obj)
+    """Move out of all collections and into this specified one. 2.8 only"""
+    for col in obj.users_collection:
+        col.objects.unlink(obj)
+    collection.objects.link(obj)
 
 
 def get_or_create_viewlayer(context, collection_name):
-	"""Returns or creates the view layer for a given name. 2.8 only.
+    """Returns or creates the view layer for a given name. 2.8 only.
 
-	Only searches within same viewlayer; not exact match but a non-case
-	sensitive contains-text of collection_name check. If the collection exists
-	elsewhere by name, ignore (could be used for something else) and generate
-	a new one; maye cause any existing collection to be renamed, but is still
-	left unaffected in whatever view layer it exists.
-	"""
-	master_vl = context.view_layer.layer_collection
-	response_vl = None
-	for child in master_vl.children:
-		if collection_name.lower() not in child.name.lower():
-			continue
-		response_vl = child
-		break
-	if response_vl is None:
-		new_coll = bpy.data.collections.new(collection_name)
-		context.scene.collection.children.link(new_coll)
+    Only searches within same viewlayer; not exact match but a non-case
+    sensitive contains-text of collection_name check. If the collection exists
+    elsewhere by name, ignore (could be used for something else) and generate
+    a new one; maye cause any existing collection to be renamed, but is still
+    left unaffected in whatever view layer it exists.
+    """
+    master_vl = context.view_layer.layer_collection
+    response_vl = None
+    for child in master_vl.children:
+        if collection_name.lower() not in child.name.lower():
+            continue
+        response_vl = child
+        break
+    if response_vl is None:
+        new_coll = bpy.data.collections.new(collection_name)
+        context.scene.collection.children.link(new_coll)
 
-		# assumes added to scene's active view layer root via link above
-		response_vl = master_vl.children[new_coll.name]
-	return response_vl
+        # assumes added to scene's active view layer root via link above
+        response_vl = master_vl.children[new_coll.name]
+    return response_vl
 
 
 def natural_sort(elements):
-	"""Use human or natural sorting for subnumbers within string list."""
-	def convert(text):
-		return int(text) if text.isdigit() else text.lower()
+    """Use human or natural sorting for subnumbers within string list."""
 
-	def alphanum_key(key):
-		return [convert(c) for c in re.split('([0-9]+)', key)]
-		# or return [ convert(c) for c in re.split(r'(\d+)', text) ]
+    def convert(text):
+        return int(text) if text.isdigit() else text.lower()
 
-	return sorted(elements, key=alphanum_key)
+    def alphanum_key(key):
+        return [convert(c) for c in re.split("([0-9]+)", key)]
+        # or return [ convert(c) for c in re.split(r'(\d+)', text) ]
+
+    return sorted(elements, key=alphanum_key)
+
 
 # -----------------------------------------------------------------------------
 # Cross blender 2.7 and 2.8 functions
@@ -565,221 +563,223 @@ def natural_sort(elements):
 
 
 def make_annotations(cls):
-	"""Add annotation attribute to class fields to avoid Blender 2.8 warnings"""
-	env.deprecation_warning()
-	if not hasattr(bpy.app, "version") or bpy.app.version < (2, 80):
-		return cls
-	if bpy.app.version < (2, 93, 0):
-		bl_props = {
-			k: v for k, v in cls.__dict__.items() if isinstance(v, tuple)}
-	else:
-		bl_props = {
-			k: v for k, v in cls.__dict__.items()
-			if isinstance(v, bpy.props._PropertyDeferred)}
-	if bl_props:
-		if '__annotations__' not in cls.__dict__:
-			setattr(cls, '__annotations__', {})
-		annotations = cls.__dict__['__annotations__']
-		for k, v in bl_props.items():
-			annotations[k] = v
-			delattr(cls, k)
-	return cls
+    """Add annotation attribute to class fields to avoid Blender 2.8 warnings"""
+    env.deprecation_warning()
+    if not hasattr(bpy.app, "version") or bpy.app.version < (2, 80):
+        return cls
+    if bpy.app.version < (2, 93, 0):
+        bl_props = {k: v for k, v in cls.__dict__.items() if isinstance(v, tuple)}
+    else:
+        bl_props = {
+            k: v
+            for k, v in cls.__dict__.items()
+            if isinstance(v, bpy.props._PropertyDeferred)
+        }
+    if bl_props:
+        if "__annotations__" not in cls.__dict__:
+            setattr(cls, "__annotations__", {})
+        annotations = cls.__dict__["__annotations__"]
+        for k, v in bl_props.items():
+            annotations[k] = v
+            delattr(cls, k)
+    return cls
 
 
 def layout_split(layout, factor=0.0, align=False):
-	"""Intermediate method for pre and post blender 2.8 split UI function"""
-	if not hasattr(bpy.app, "version") or bpy.app.version < (2, 80):
-		return layout.split(percentage=factor, align=align)
-	return layout.split(factor=factor, align=align)
+    """Intermediate method for pre and post blender 2.8 split UI function"""
+    if not hasattr(bpy.app, "version") or bpy.app.version < (2, 80):
+        return layout.split(percentage=factor, align=align)
+    return layout.split(factor=factor, align=align)
 
 
 def get_user_preferences(context=None):
-	"""Intermediate method for pre and post blender 2.8 grabbing preferences"""
-	if not context:
-		context = bpy.context
-	prefs = None
-	if hasattr(context, "user_preferences"):
-		prefs = context.user_preferences.addons.get(__package__, None)
-	elif hasattr(context, "preferences"):
-		prefs = context.preferences.addons.get(__package__, None)
-	if prefs:
-		return prefs.preferences
-	# To make the addon stable and non-exception prone, return None
-	# raise Exception("Could not fetch user preferences")
-	return None
+    """Intermediate method for pre and post blender 2.8 grabbing preferences"""
+    if not context:
+        context = bpy.context
+    prefs = None
+    if hasattr(context, "user_preferences"):
+        prefs = context.user_preferences.addons.get(__package__, None)
+    elif hasattr(context, "preferences"):
+        prefs = context.preferences.addons.get(__package__, None)
+    if prefs:
+        return prefs.preferences
+    # To make the addon stable and non-exception prone, return None
+    # raise Exception("Could not fetch user preferences")
+    return None
 
 
 def get_preferences(context=None):
-	"""Function to easily get general user prefs in 2.7 and 2.8 friendly way"""
-	if hasattr(context, "user_preferences"):
-		return context.user_preferences
-	elif hasattr(context, "preferences"):
-		return context.preferences
-	return None
+    """Function to easily get general user prefs in 2.7 and 2.8 friendly way"""
+    if hasattr(context, "user_preferences"):
+        return context.user_preferences
+    elif hasattr(context, "preferences"):
+        return context.preferences
+    return None
 
 
 def set_active_object(context, obj):
-	"""Get the active object in a 2.7 and 2.8 compatible way"""
-	if hasattr(context, "view_layer"):
-		context.view_layer.objects.active = obj  # the 2.8 way
-	else:
-		context.scene.objects.active = obj  # the 2.7 way
+    """Get the active object in a 2.7 and 2.8 compatible way"""
+    if hasattr(context, "view_layer"):
+        context.view_layer.objects.active = obj  # the 2.8 way
+    else:
+        context.scene.objects.active = obj  # the 2.7 way
 
 
 def select_get(obj):
-	"""Multi version compatibility for getting object selection"""
-	if hasattr(obj, "select_get"):
-		return obj.select_get()
-	else:
-		return obj.select
+    """Multi version compatibility for getting object selection"""
+    if hasattr(obj, "select_get"):
+        return obj.select_get()
+    else:
+        return obj.select
 
 
 def select_set(obj, state):
-	"""Multi version compatibility for setting object selection"""
-	if hasattr(obj, "select_set"):
-		obj.select_set(state)
-	else:
-		obj.select = state
+    """Multi version compatibility for setting object selection"""
+    if hasattr(obj, "select_set"):
+        obj.select_set(state)
+    else:
+        obj.select = state
 
 
 def hide_viewport(obj, state):
-	"""Multi version compatibility for setting the viewport hide state"""
-	if hasattr(obj, "hide_viewport"):
-		obj.hide_viewport = state  # where state is a boolean True or False
-	else:
-		obj.hide = state
+    """Multi version compatibility for setting the viewport hide state"""
+    if hasattr(obj, "hide_viewport"):
+        obj.hide_viewport = state  # where state is a boolean True or False
+    else:
+        obj.hide = state
 
 
 def collections():
-	"""Returns group or collection object for 2.7 and 2.8"""
-	if hasattr(bpy.data, "collections"):
-		return bpy.data.collections
-	else:
-		return bpy.data.groups
+    """Returns group or collection object for 2.7 and 2.8"""
+    if hasattr(bpy.data, "collections"):
+        return bpy.data.collections
+    else:
+        return bpy.data.groups
 
 
 def viewport_textured(context=None):
-	"""Returns state of viewport solid being textured or not"""
-	if not context:
-		context = bpy.context
+    """Returns state of viewport solid being textured or not"""
+    if not context:
+        context = bpy.context
 
-	if hasattr(context.space_data, "show_textured_solid"):  # 2.7
-		return context.space_data.show_textured_solid
-	elif hasattr(context.scene, "display"):  # 2.8
-		# makes textured if any
-		return context.scene.display.shading.color_type == "TEXTURE"
-	return None  # unsure
+    if hasattr(context.space_data, "show_textured_solid"):  # 2.7
+        return context.space_data.show_textured_solid
+    elif hasattr(context.scene, "display"):  # 2.8
+        # makes textured if any
+        return context.scene.display.shading.color_type == "TEXTURE"
+    return None  # unsure
 
 
 def get_cuser_location(context=None):
-	"""Returns the location vector of the 3D cursor"""
-	if not context:
-		context = bpy.context
-	if hasattr(context.scene, "cursor_location"):
-		return context.scene.cursor_location
-	elif hasattr(context.scene, "cursor") and hasattr(context.scene.cursor, "location"):
-		return context.scene.cursor.location  # later 2.8 builds
-	elif hasattr(context.space_data, "cursor_location"):
-		return context.space_data.cursor_location
-	elif hasattr(context.space_data, "cursor") and hasattr(context.space_data.cursor, "location"):
-		return context.space_data.cursor.location
-	print("MCPREP WARNING! Unable to get cursor location, using (0,0,0)")
-	return (0, 0, 0)
+    """Returns the location vector of the 3D cursor"""
+    if not context:
+        context = bpy.context
+    if hasattr(context.scene, "cursor_location"):
+        return context.scene.cursor_location
+    elif hasattr(context.scene, "cursor") and hasattr(context.scene.cursor, "location"):
+        return context.scene.cursor.location  # later 2.8 builds
+    elif hasattr(context.space_data, "cursor_location"):
+        return context.space_data.cursor_location
+    elif hasattr(context.space_data, "cursor") and hasattr(
+        context.space_data.cursor, "location"
+    ):
+        return context.space_data.cursor.location
+    print("MCPREP WARNING! Unable to get cursor location, using (0,0,0)")
+    return (0, 0, 0)
 
 
 def set_cuser_location(loc, context=None):
-	"""Returns the location vector of the 3D cursor"""
-	if not context:
-		context = bpy.context
-	if hasattr(context.scene, "cursor_location"):  # 2.7
-		context.scene.cursor_location = loc
-	else:
-		context.scene.cursor.location = loc
+    """Returns the location vector of the 3D cursor"""
+    if not context:
+        context = bpy.context
+    if hasattr(context.scene, "cursor_location"):  # 2.7
+        context.scene.cursor_location = loc
+    else:
+        context.scene.cursor.location = loc
 
 
 def instance_collection(obj):
-	"""Cross compatible way to get an objects dupligroup or collection"""
-	if hasattr(obj, "dupli_group"):
-		return obj.dupli_group
-	elif hasattr(obj, "instance_collection"):
-		return obj.instance_collection
+    """Cross compatible way to get an objects dupligroup or collection"""
+    if hasattr(obj, "dupli_group"):
+        return obj.dupli_group
+    elif hasattr(obj, "instance_collection"):
+        return obj.instance_collection
 
 
 def obj_link_scene(obj, context=None):
-	"""Links object to scene, or for 2.8, the scene master collection"""
-	if not context:
-		context = bpy.context
-	if hasattr(context.scene.objects, "link"):
-		context.scene.objects.link(obj)
-	elif hasattr(context.scene, "collection"):
-		context.scene.collection.objects.link(obj)
-	# context.scene.update() # needed?
+    """Links object to scene, or for 2.8, the scene master collection"""
+    if not context:
+        context = bpy.context
+    if hasattr(context.scene.objects, "link"):
+        context.scene.objects.link(obj)
+    elif hasattr(context.scene, "collection"):
+        context.scene.collection.objects.link(obj)
+    # context.scene.update() # needed?
 
 
 def obj_unlink_remove(obj, remove, context=None):
-	"""Unlink an object from the scene, and remove from data if specified"""
-	if not context:
-		context = bpy.context
-	if hasattr(context.scene.objects, "unlink"):  # 2.7
-		context.scene.objects.unlink(obj)
-	elif hasattr(context.scene, "collection"):  # 2.8
-		try:
-			context.scene.collection.objects.unlink(obj)
-		except RuntimeError:
-			pass  # if not in master collection
-		colls = list(obj.users_collection)
-		for coll in colls:
-			coll.objects.unlink(obj)
-	if remove is True:
-		obj.user_clear()
-		bpy.data.objects.remove(obj)
+    """Unlink an object from the scene, and remove from data if specified"""
+    if not context:
+        context = bpy.context
+    if hasattr(context.scene.objects, "unlink"):  # 2.7
+        context.scene.objects.unlink(obj)
+    elif hasattr(context.scene, "collection"):  # 2.8
+        try:
+            context.scene.collection.objects.unlink(obj)
+        except RuntimeError:
+            pass  # if not in master collection
+        colls = list(obj.users_collection)
+        for coll in colls:
+            coll.objects.unlink(obj)
+    if remove is True:
+        obj.user_clear()
+        bpy.data.objects.remove(obj)
 
 
 def users_collection(obj):
-	"""Returns the collections/group of an object"""
-	if hasattr(obj, "users_collection"):
-		return obj.users_collection
-	elif hasattr(obj, "users_group"):
-		return obj.users_group
+    """Returns the collections/group of an object"""
+    if hasattr(obj, "users_collection"):
+        return obj.users_collection
+    elif hasattr(obj, "users_group"):
+        return obj.users_group
 
 
 def matmul(v1, v2, v3=None):
-	"""Multiplciation of matrix and/or vectors in cross compatible way.
+    """Multiplciation of matrix and/or vectors in cross compatible way.
 
-	This is a workaround for the syntax that otherwise could be used a @ b.
-	"""
-	if bv28():
-		# does not exist pre 2.7<#?>, syntax error
-		mtm = getattr(operator, "matmul")
-		if v3:
-			return mtm(v1, mtm(v2, v3))
-		return mtm(v1, v2)
-	if v3:
-		return v1 * v2 * v3
-	return v1 * v2
+    This is a workaround for the syntax that otherwise could be used a @ b.
+    """
+    if bv28():
+        # does not exist pre 2.7<#?>, syntax error
+        mtm = getattr(operator, "matmul")
+        if v3:
+            return mtm(v1, mtm(v2, v3))
+        return mtm(v1, v2)
+    if v3:
+        return v1 * v2 * v3
+    return v1 * v2
 
 
 def scene_update(context=None):
-	"""Update scene in cross compatible way, to update desp graph"""
-	if not context:
-		context = bpy.context
-	if hasattr(context.scene, "update"):  # 2.7
-		context.scene.update()
-	elif hasattr(context, "view_layer"):  # 2.8
-		context.view_layer.update()
+    """Update scene in cross compatible way, to update desp graph"""
+    if not context:
+        context = bpy.context
+    if hasattr(context.scene, "update"):  # 2.7
+        context.scene.update()
+    elif hasattr(context, "view_layer"):  # 2.8
+        context.view_layer.update()
 
 
 def move_assets_to_excluded_layer(context, collections):
-	"""Utility to move source collections to excluded layer to not be rendered"""
-	initial_view_coll = context.view_layer.active_layer_collection
+    """Utility to move source collections to excluded layer to not be rendered"""
+    initial_view_coll = context.view_layer.active_layer_collection
 
-	# Then, setup the exclude view layer
-	spawner_exclude_vl = get_or_create_viewlayer(
-		context, SPAWNER_EXCLUDE)
-	spawner_exclude_vl.exclude = True
+    # Then, setup the exclude view layer
+    spawner_exclude_vl = get_or_create_viewlayer(context, SPAWNER_EXCLUDE)
+    spawner_exclude_vl.exclude = True
 
-	for grp in collections:
-		if grp.name not in initial_view_coll.collection.children:
-			continue  # not linked, likely a sub-group not added to scn
-		spawner_exclude_vl.collection.children.link(grp)
-		initial_view_coll.collection.children.unlink(grp)
+    for grp in collections:
+        if grp.name not in initial_view_coll.collection.children:
+            continue  # not linked, likely a sub-group not added to scn
+        spawner_exclude_vl.collection.children.link(grp)
+        initial_view_coll.collection.children.unlink(grp)

--- a/MCprep_addon/util_operators.py
+++ b/MCprep_addon/util_operators.py
@@ -30,193 +30,210 @@ from . import tracking
 
 
 class MCPREP_OT_improve_ui(bpy.types.Operator):
-	"""Improve UI for minecraft textures: disable mipmaps, set texture solid
-	in viewport, and set rendermode to at least solid view"""
-	bl_idname = "mcprep.improve_ui"
-	bl_label = "Improve UI"
-	bl_options = {'REGISTER', 'UNDO'}
+    """Improve UI for minecraft textures: disable mipmaps, set texture solid
+    in viewport, and set rendermode to at least solid view"""
 
-	@tracking.report_error
-	def execute(self, context):
-		# Disable mipmaps (not saved, but avoids on screen blurry textures)
-		prefs = util.get_preferences(context)
-		if hasattr(prefs.system, "use_mipmaps"):
-			prefs.system.use_mipmaps = False
+    bl_idname = "mcprep.improve_ui"
+    bl_label = "Improve UI"
+    bl_options = {"REGISTER", "UNDO"}
 
-		# Check api availability
-		scn_disp = hasattr(context.scene, "display")
-		scn_disp_shade = scn_disp and hasattr(context.scene.display, "shading")
+    @tracking.report_error
+    def execute(self, context):
+        # Disable mipmaps (not saved, but avoids on screen blurry textures)
+        prefs = util.get_preferences(context)
+        if hasattr(prefs.system, "use_mipmaps"):
+            prefs.system.use_mipmaps = False
 
-		# show textures in solid mode
-		view = context.space_data
-		if bpy.app.background:
-			return {'CANCELLED'}  # headless mode, no visual to improve anyways
-		if not view:
-			self.report({'ERROR'}, "Cannot improve display, no view context")
-			return {'CANCELLED'}  # should not occur
-		elif hasattr(view, "show_textured_solid"):  # 2.7
-			context.space_data.show_textured_solid = True
-		elif view.type == 'VIEW_3D' and hasattr(context.scene, "display"):
-			try:  # can fail e.g. in workbench view
-				view.shading.color_type = "TEXTURE"
-			except:
-				pass
-		elif hasattr(context.screen, "shading"):  # 2.8 non shaded view
-			try:  # can fail e.g. in workbench view
-				context.scene.display.shading.color_type = "TEXTURE"
-			except:
-				pass
+        # Check api availability
+        scn_disp = hasattr(context.scene, "display")
+        scn_disp_shade = scn_disp and hasattr(context.scene.display, "shading")
 
-		# now change the active drawing level to a minimum of solid mode
-		view27 = ['TEXTURED', 'MATEIRAL', 'RENDERED']
-		view28 = ['SOLID', 'MATERIAL', 'RENDERED']
-		engine = bpy.context.scene.render.engine
-		if not util.bv28() and view.viewport_shade not in view27:
-			if not hasattr(context.space_data, "viewport_shade"):
-				self.report({"WARNING"}, "Improve UI is meant for the 3D view")
-				return {'FINISHED'}
-			if engine == 'CYCLES':
-				view.viewport_shade = 'TEXTURED'
-			else:
-				view.viewport_shade = 'SOLID'
-		elif util.bv28() and context.scene.display.shading.type not in view28:
-			if not scn_disp or not scn_disp_shade:
-				self.report({"WARNING"}, "Improve UI is meant for the 3D view")
-				return {'FINISHED'}
+        # show textures in solid mode
+        view = context.space_data
+        if bpy.app.background:
+            return {"CANCELLED"}  # headless mode, no visual to improve anyways
+        if not view:
+            self.report({"ERROR"}, "Cannot improve display, no view context")
+            return {"CANCELLED"}  # should not occur
+        elif hasattr(view, "show_textured_solid"):  # 2.7
+            context.space_data.show_textured_solid = True
+        elif view.type == "VIEW_3D" and hasattr(context.scene, "display"):
+            try:  # can fail e.g. in workbench view
+                view.shading.color_type = "TEXTURE"
+            except:
+                pass
+        elif hasattr(context.screen, "shading"):  # 2.8 non shaded view
+            try:  # can fail e.g. in workbench view
+                context.scene.display.shading.color_type = "TEXTURE"
+            except:
+                pass
 
-			# make it solid mode, regardless of cycles or eevee
-			context.scene.display.shading.type = 'SOLID'
-		return {'FINISHED'}
+        # now change the active drawing level to a minimum of solid mode
+        view27 = ["TEXTURED", "MATEIRAL", "RENDERED"]
+        view28 = ["SOLID", "MATERIAL", "RENDERED"]
+        engine = bpy.context.scene.render.engine
+        if not util.bv28() and view.viewport_shade not in view27:
+            if not hasattr(context.space_data, "viewport_shade"):
+                self.report({"WARNING"}, "Improve UI is meant for the 3D view")
+                return {"FINISHED"}
+            if engine == "CYCLES":
+                view.viewport_shade = "TEXTURED"
+            else:
+                view.viewport_shade = "SOLID"
+        elif util.bv28() and context.scene.display.shading.type not in view28:
+            if not scn_disp or not scn_disp_shade:
+                self.report({"WARNING"}, "Improve UI is meant for the 3D view")
+                return {"FINISHED"}
+
+            # make it solid mode, regardless of cycles or eevee
+            context.scene.display.shading.type = "SOLID"
+        return {"FINISHED"}
 
 
 class MCPREP_OT_show_preferences(bpy.types.Operator):
-	"""Open user preferences and display MCprep settings"""
-	bl_idname = "mcprep.open_preferences"
-	bl_label = "Show MCprep preferences"
+    """Open user preferences and display MCprep settings"""
 
-	tab: bpy.props.EnumProperty(
-		items=[
-			('settings', 'Open settings', 'Open MCprep preferences settings'),
-			('tutorials', 'Open tutorials', 'View MCprep tutorials'),
-			('tracker_updater', 'Open tracker/updater settings',
-				'Open user tracking & addon updating settings')],
-		name="Section")
+    bl_idname = "mcprep.open_preferences"
+    bl_label = "Show MCprep preferences"
 
-	@tracking.report_error
-	def execute(self, context):
-		bpy.ops.screen.userpref_show('INVOKE_AREA')
-		util.get_preferences(context).active_section = "ADDONS"
-		bpy.data.window_managers["WinMan"].addon_search = "MCprep"
+    tab: bpy.props.EnumProperty(
+        items=[
+            ("settings", "Open settings", "Open MCprep preferences settings"),
+            ("tutorials", "Open tutorials", "View MCprep tutorials"),
+            (
+                "tracker_updater",
+                "Open tracker/updater settings",
+                "Open user tracking & addon updating settings",
+            ),
+        ],
+        name="Section",
+    )
 
-		addons_ids = [
-			mod for mod in addon_utils.modules(refresh=False)
-			if mod.__name__ == __package__]
-		if not addons_ids:
-			print("Failed to directly load and open MCprep preferences")
-			return {'FINISHED'}
+    @tracking.report_error
+    def execute(self, context):
+        bpy.ops.screen.userpref_show("INVOKE_AREA")
+        util.get_preferences(context).active_section = "ADDONS"
+        bpy.data.window_managers["WinMan"].addon_search = "MCprep"
 
-		addon_blinfo = addon_utils.module_bl_info(addons_ids[0])
-		if not addon_blinfo["show_expanded"]:
-			has_prefs = hasattr(bpy.ops, "preferences")
-			has_prefs = has_prefs and hasattr(bpy.ops.preferences, "addon_expand")
-			has_prefs = has_prefs and util.bv28()
+        addons_ids = [
+            mod
+            for mod in addon_utils.modules(refresh=False)
+            if mod.__name__ == __package__
+        ]
+        if not addons_ids:
+            print("Failed to directly load and open MCprep preferences")
+            return {"FINISHED"}
 
-			has_exp = hasattr(bpy.ops, "wm")
-			has_exp = has_exp and hasattr(bpy.ops.wm, "addon_expand")
+        addon_blinfo = addon_utils.module_bl_info(addons_ids[0])
+        if not addon_blinfo["show_expanded"]:
+            has_prefs = hasattr(bpy.ops, "preferences")
+            has_prefs = has_prefs and hasattr(bpy.ops.preferences, "addon_expand")
+            has_prefs = has_prefs and util.bv28()
 
-			if has_prefs:  # later 2.8 buids
-				bpy.ops.preferences.addon_expand(module=__package__)
-			elif has_exp:  # old 2.8 and 2.7
-				bpy.ops.wm.addon_expand(module=__package__)
-			else:
-				self.report(
-					{"INFO"}, "Search for and expand the MCprep addon in preferences")
+            has_exp = hasattr(bpy.ops, "wm")
+            has_exp = has_exp and hasattr(bpy.ops.wm, "addon_expand")
 
-		addon_prefs = util.get_user_preferences(context)
-		addon_prefs.preferences_tab = self.tab
-		return {'FINISHED'}
+            if has_prefs:  # later 2.8 buids
+                bpy.ops.preferences.addon_expand(module=__package__)
+            elif has_exp:  # old 2.8 and 2.7
+                bpy.ops.wm.addon_expand(module=__package__)
+            else:
+                self.report(
+                    {"INFO"}, "Search for and expand the MCprep addon in preferences"
+                )
+
+        addon_prefs = util.get_user_preferences(context)
+        addon_prefs.preferences_tab = self.tab
+        return {"FINISHED"}
 
 
 class MCPREP_OT_open_folder(bpy.types.Operator):
-	"""Open a folder in the host operating system"""
-	bl_idname = "mcprep.openfolder"
-	bl_label = "Open folder"
+    """Open a folder in the host operating system"""
 
-	folder: bpy.props.StringProperty(
-		name="Folderpath",
-		default="//")
+    bl_idname = "mcprep.openfolder"
+    bl_label = "Open folder"
 
-	@tracking.report_error
-	def execute(self, context):
-		if not os.path.isdir(bpy.path.abspath(self.folder)):
-			self.report(
-				{'ERROR'},
-				"Invalid folder path: {x}".format(x=self.folder))
-			return {'CANCELLED'}
+    folder: bpy.props.StringProperty(name="Folderpath", default="//")
 
-		res = util.open_folder_crossplatform(self.folder)
-		if res is False:
-			msg = "Didn't open folder, navigate to it manually: {x}".format(
-				x=self.folder)
-			print(msg)
-			self.report({'ERROR'}, msg)
-			return {'CANCELLED'}
-		return {'FINISHED'}
+    @tracking.report_error
+    def execute(self, context):
+        if not os.path.isdir(bpy.path.abspath(self.folder)):
+            self.report({"ERROR"}, "Invalid folder path: {x}".format(x=self.folder))
+            return {"CANCELLED"}
+
+        res = util.open_folder_crossplatform(self.folder)
+        if res is False:
+            msg = "Didn't open folder, navigate to it manually: {x}".format(
+                x=self.folder
+            )
+            print(msg)
+            self.report({"ERROR"}, msg)
+            return {"CANCELLED"}
+        return {"FINISHED"}
 
 
 class MCPREP_OT_open_help(bpy.types.Operator):
-	"""Support operator for opening url in UI, but indicating through popup
-	text that it is a supporting/help button"""
-	bl_idname = "mcprep.open_help"
-	bl_label = "Open help page"
-	bl_description = "Need help? Click to open a reference page"
+    """Support operator for opening url in UI, but indicating through popup
+    text that it is a supporting/help button"""
 
-	url: bpy.props.StringProperty(
-		name="Url",
-		default="")
+    bl_idname = "mcprep.open_help"
+    bl_label = "Open help page"
+    bl_description = "Need help? Click to open a reference page"
 
-	@tracking.report_error
-	def execute(self, context):
-		if self.url == "":
-			return {'CANCELLED'}
-		else:
-			bpy.ops.wm.url_open(url=self.url)
-		return {'FINISHED'}
+    url: bpy.props.StringProperty(name="Url", default="")
+
+    @tracking.report_error
+    def execute(self, context):
+        if self.url == "":
+            return {"CANCELLED"}
+        else:
+            bpy.ops.wm.url_open(url=self.url)
+        return {"FINISHED"}
 
 
 class MCPREP_OT_prep_material_legacy(bpy.types.Operator):
-	"""Legacy operator which calls new operator, use mcprep.prep_material"""
-	bl_idname = "mcprep.mat_change"
-	bl_label = "MCprep Materials"
-	bl_options = {'REGISTER', 'UNDO'}
+    """Legacy operator which calls new operator, use mcprep.prep_material"""
 
-	useReflections: bpy.props.BoolProperty(
-		name="Use reflections",
-		description="Allow appropriate materials to be rendered reflective",
-		default=True)
-	combineMaterials: bpy.props.BoolProperty(
-		name="Combine materials",
-		description="Consolidate duplciate materials & textures",
-		default=False)
+    bl_idname = "mcprep.mat_change"
+    bl_label = "MCprep Materials"
+    bl_options = {"REGISTER", "UNDO"}
 
-	track_function = "materials_legacy"
-	@tracking.report_error
-	def execute(self, context):
-		print((
-			"Using legacy operator call for MCprep materials, move to "
-			"use bpy.ops.mcprep.prep_materials"))
-		try:
-			bpy.ops.mcprep.prep_materials(
-				useReflections=self.useReflections,
-				combineMaterials=self.combineMaterials
-			)
-		except:
-			self.report({"ERROR"}, (
-				"Legacy Prep Materials failed; use new operator name "
-				"'mcprep.prep_materials' going forward and to get more info"
-			))
-			return {'CANCELLED'}
-		return {'FINISHED'}
+    useReflections: bpy.props.BoolProperty(
+        name="Use reflections",
+        description="Allow appropriate materials to be rendered reflective",
+        default=True,
+    )
+    combineMaterials: bpy.props.BoolProperty(
+        name="Combine materials",
+        description="Consolidate duplciate materials & textures",
+        default=False,
+    )
+
+    track_function = "materials_legacy"
+
+    @tracking.report_error
+    def execute(self, context):
+        print(
+            (
+                "Using legacy operator call for MCprep materials, move to "
+                "use bpy.ops.mcprep.prep_materials"
+            )
+        )
+        try:
+            bpy.ops.mcprep.prep_materials(
+                useReflections=self.useReflections,
+                combineMaterials=self.combineMaterials,
+            )
+        except:
+            self.report(
+                {"ERROR"},
+                (
+                    "Legacy Prep Materials failed; use new operator name "
+                    "'mcprep.prep_materials' going forward and to get more info"
+                ),
+            )
+            return {"CANCELLED"}
+        return {"FINISHED"}
 
 
 # -----------------------------------------------------------------------------
@@ -225,19 +242,19 @@ class MCPREP_OT_prep_material_legacy(bpy.types.Operator):
 
 
 classes = (
-	MCPREP_OT_improve_ui,
-	MCPREP_OT_show_preferences,
-	MCPREP_OT_open_folder,
-	MCPREP_OT_open_help,
-	MCPREP_OT_prep_material_legacy
+    MCPREP_OT_improve_ui,
+    MCPREP_OT_show_preferences,
+    MCPREP_OT_open_folder,
+    MCPREP_OT_open_help,
+    MCPREP_OT_prep_material_legacy,
 )
 
 
 def register():
-	for cls in classes:
-		bpy.utils.register_class(cls)
+    for cls in classes:
+        bpy.utils.register_class(cls)
 
 
 def unregister():
-	for cls in reversed(classes):
-		bpy.utils.unregister_class(cls)
+    for cls in reversed(classes):
+        bpy.utils.unregister_class(cls)

--- a/MCprep_addon/world_tools.py
+++ b/MCprep_addon/world_tools.py
@@ -35,213 +35,211 @@ from .materials import generate
 # supporting functions
 # -----------------------------------------------------------------------------
 
-BUILTIN_SPACES = (
-	"Standard",
-	"Filmic",
-	"Filmic Log",
-	"Raw",
-	"False Color"
-)
+BUILTIN_SPACES = ("Standard", "Filmic", "Filmic Log", "Raw", "False Color")
 
 
 time_obj_cache = None
 
 
 def get_time_object():
-	"""Returns the time object if present in the file"""
-	global time_obj_cache  # to avoid re parsing every time
+    """Returns the time object if present in the file"""
+    global time_obj_cache  # to avoid re parsing every time
 
-	if time_obj_cache is not None:
-		try:
-			if "MCprepHour" not in time_obj_cache:
-				time_obj_cache = None
-		except ReferenceError:
-			time_obj_cache = None  # e.g. if item was deleted
+    if time_obj_cache is not None:
+        try:
+            if "MCprepHour" not in time_obj_cache:
+                time_obj_cache = None
+        except ReferenceError:
+            time_obj_cache = None  # e.g. if item was deleted
 
-	cached = time_obj_cache is not None
-	obj_gone = cached and time_obj_cache not in bpy.data.objects[:]
-	key_missing = cached and "MCprepHour" not in time_obj_cache
-	if obj_gone or key_missing:
-		time_obj_cache = None
+    cached = time_obj_cache is not None
+    obj_gone = cached and time_obj_cache not in bpy.data.objects[:]
+    key_missing = cached and "MCprepHour" not in time_obj_cache
+    if obj_gone or key_missing:
+        time_obj_cache = None
 
-	if time_obj_cache is None:
-		time_objs = [obj for obj in bpy.data.objects if "MCprepHour" in obj]
-		if time_objs:
-			# If multiple contain this key, fetch the most recent.
-			time_objs.sort(key=lambda x: x.name)
-			time_obj_cache = time_objs[-1]
+    if time_obj_cache is None:
+        time_objs = [obj for obj in bpy.data.objects if "MCprepHour" in obj]
+        if time_objs:
+            # If multiple contain this key, fetch the most recent.
+            time_objs.sort(key=lambda x: x.name)
+            time_obj_cache = time_objs[-1]
 
-	return time_obj_cache
+    return time_obj_cache
 
 
 class ObjHeaderOptions:
-	"""Wrapper functions to avoid typos causing issues."""
+    """Wrapper functions to avoid typos causing issues."""
 
-	def __init__(self):
-		self._exporter = None
-		self._file_type = None
+    def __init__(self):
+        self._exporter = None
+        self._file_type = None
 
-	def set_mineways(self):
-		self._exporter = "Mineways"
+    def set_mineways(self):
+        self._exporter = "Mineways"
 
-	def set_jmc2obj(self):
-		self._exporter = "jmc2obj"
+    def set_jmc2obj(self):
+        self._exporter = "jmc2obj"
 
-	def set_atlas(self):
-		self._file_type = "ATLAS"
+    def set_atlas(self):
+        self._file_type = "ATLAS"
 
-	def set_seperated(self):
-		self._file_type = "INDIVIDUAL_TILES"
+    def set_seperated(self):
+        self._file_type = "INDIVIDUAL_TILES"
 
-	"""
+    """
 	Returns the exporter used
 	"""
-	def exporter(self):
-		return self._exporter if self._exporter is not None else "(choose)"
 
-	"""
+    def exporter(self):
+        return self._exporter if self._exporter is not None else "(choose)"
+
+    """
 	Returns the type of textures
 	"""
-	def texture_type(self):
-		return self._file_type if self._file_type is not None else "NONE"
+
+    def texture_type(self):
+        return self._file_type if self._file_type is not None else "NONE"
 
 
 obj_header = ObjHeaderOptions()
 
 
 def detect_world_exporter(filepath):
-	"""Detect whether Mineways or jmc2obj was used, based on prefix info.
+    """Detect whether Mineways or jmc2obj was used, based on prefix info.
 
-	Primary heruistic: if detect Mineways header, assert Mineways, else
-	assume jmc2obj. All Mineways exports for a long time have prefix info
-	set in the obj file as comments.
-	"""
-	with open(filepath, 'r') as obj_fd:
-		try:
-			header = obj_fd.readline()
-			if 'mineways' in header.lower():
-				obj_header.set_mineways()
-				# form of: # Wavefront OBJ file made by Mineways version 5.10...
-				for line in obj_fd:
-					if line.startswith("# File type:"):
-						header = line.rstrip()  # Remove trailing newline
+    Primary heruistic: if detect Mineways header, assert Mineways, else
+    assume jmc2obj. All Mineways exports for a long time have prefix info
+    set in the obj file as comments.
+    """
+    with open(filepath, "r") as obj_fd:
+        try:
+            header = obj_fd.readline()
+            if "mineways" in header.lower():
+                obj_header.set_mineways()
+                # form of: # Wavefront OBJ file made by Mineways version 5.10...
+                for line in obj_fd:
+                    if line.startswith("# File type:"):
+                        header = line.rstrip()  # Remove trailing newline
 
-				# The issue here is that Mineways has changed how the header is generated.
-				# As such, we're limited with only a couple of OBJs, some from
-				# 2020 and some from 2023, so we'll assume people are using
-				# an up to date version.
-				atlas = (
-					"# File type: Export all textures to three large images",
-					"# File type: Export full color texture patterns"
-				)
-				tiles = (
-					"# File type: Export tiles for textures to directory textures",
-					"# File type: Export individual textures to directory tex"
-				)
-				print('"{}"'.format(header))
-				if header in atlas:  # If a texture atlas is used
-					obj_header.set_atlas()
-				elif header in tiles:  # If the OBJ uses individual textures
-					obj_header.set_seperated()
-				return
-		except UnicodeDecodeError:
-			print("failed to read first line of obj: " + filepath)
-			return
-		obj_header.set_jmc2obj()
-		# Since this is the default for Jmc2Obj,
-		# we'll assume this is what the OBJ is using
-		obj_header.set_seperated()
+                # The issue here is that Mineways has changed how the header is generated.
+                # As such, we're limited with only a couple of OBJs, some from
+                # 2020 and some from 2023, so we'll assume people are using
+                # an up to date version.
+                atlas = (
+                    "# File type: Export all textures to three large images",
+                    "# File type: Export full color texture patterns",
+                )
+                tiles = (
+                    "# File type: Export tiles for textures to directory textures",
+                    "# File type: Export individual textures to directory tex",
+                )
+                print('"{}"'.format(header))
+                if header in atlas:  # If a texture atlas is used
+                    obj_header.set_atlas()
+                elif header in tiles:  # If the OBJ uses individual textures
+                    obj_header.set_seperated()
+                return
+        except UnicodeDecodeError:
+            print("failed to read first line of obj: " + filepath)
+            return
+        obj_header.set_jmc2obj()
+        # Since this is the default for Jmc2Obj,
+        # we'll assume this is what the OBJ is using
+        obj_header.set_seperated()
 
 
 def convert_mtl(filepath):
-	"""Convert the MTL file if we're not using one of Blender's built in
-	colorspaces
+    """Convert the MTL file if we're not using one of Blender's built in
+    colorspaces
 
-	Without this, Blender's OBJ importer will attempt to set non-color data to
-	alpha maps and what not, which causes issues in ACES and whatnot where
-	non-color data is not an option.
+    Without this, Blender's OBJ importer will attempt to set non-color data to
+    alpha maps and what not, which causes issues in ACES and whatnot where
+    non-color data is not an option.
 
-	This MTL conversion simply does the following:
-	- Comment out lines that begin with map_d
-	- Add a header at the end
+    This MTL conversion simply does the following:
+    - Comment out lines that begin with map_d
+    - Add a header at the end
 
-	Returns:
-		True if success or skipped, False if failed, or None if skipped
-	"""
-	# Check if the MTL exists. If not, then check if it
-	# uses underscores. If still not, then return False
-	mtl = Path(filepath.rsplit(".", 1)[0] + '.mtl')
-	if not mtl.exists():
-		mtl_underscores = Path(mtl.parent.absolute()) / mtl.name.replace(" ", "_")
-		if mtl_underscores.exists():
-			mtl = mtl_underscores
-		else:
-			return False
+    Returns:
+            True if success or skipped, False if failed, or None if skipped
+    """
+    # Check if the MTL exists. If not, then check if it
+    # uses underscores. If still not, then return False
+    mtl = Path(filepath.rsplit(".", 1)[0] + ".mtl")
+    if not mtl.exists():
+        mtl_underscores = Path(mtl.parent.absolute()) / mtl.name.replace(" ", "_")
+        if mtl_underscores.exists():
+            mtl = mtl_underscores
+        else:
+            return False
 
-	lines = None
-	copied_file = None
+    lines = None
+    copied_file = None
 
-	try:
-		with open(mtl, 'r') as mtl_file:
-			lines = mtl_file.readlines()
-	except Exception as e:
-		print(e)
-		return False
-	
-	# This checks to see if the user is using a built-in colorspace or if none of the lines have map_d. If so
-	# then ignore this file and return None
-	if bpy.context.scene.view_settings.view_transform in BUILTIN_SPACES or not any("map_d" in s for s in lines):
-		return None
+    try:
+        with open(mtl, "r") as mtl_file:
+            lines = mtl_file.readlines()
+    except Exception as e:
+        print(e)
+        return False
 
-	# This represents a new folder that'll backup the MTL filepath
-	original_mtl_path = Path(filepath).parent.absolute() / "ORIGINAL_MTLS"
-	original_mtl_path.mkdir(parents=True, exist_ok=True)
+    # This checks to see if the user is using a built-in colorspace or if none of the lines have map_d. If so
+    # then ignore this file and return None
+    if bpy.context.scene.view_settings.view_transform in BUILTIN_SPACES or not any(
+        "map_d" in s for s in lines
+    ):
+        return None
 
-	mcprep_header = (
-		"# This section was created by MCprep's MTL conversion script\n",
-		"# Please do not remove\n",
-		"# Thanks c:\n"
-	)
+    # This represents a new folder that'll backup the MTL filepath
+    original_mtl_path = Path(filepath).parent.absolute() / "ORIGINAL_MTLS"
+    original_mtl_path.mkdir(parents=True, exist_ok=True)
 
-	try:
-		header = tuple(lines[-3:])  # Get the last 3 lines
-		# Check if MTL has already been converted. If so, return True
-		if header != mcprep_header:
-			# Copy the MTL with metadata
-			print("Header " + str(header))
-			copied_file = shutil.copy2(mtl, original_mtl_path.absolute())
-		else:
-			return True
-	except Exception as e:
-		print(e)
-		return False
+    mcprep_header = (
+        "# This section was created by MCprep's MTL conversion script\n",
+        "# Please do not remove\n",
+        "# Thanks c:\n",
+    )
 
-	# In this section, we go over each line
-	# and check to see if it begins with map_d. If
-	# it does, then we simply comment it out. Otherwise,
-	# we can safely ignore it.
-	try:
-		with open(mtl, 'r') as mtl_file:
-			for index, line in enumerate(lines):
-				if line.startswith("map_d "):
-					lines[index] = "# " + line
-	except Exception as e:
-		print(e)
-		return False
+    try:
+        header = tuple(lines[-3:])  # Get the last 3 lines
+        # Check if MTL has already been converted. If so, return True
+        if header != mcprep_header:
+            # Copy the MTL with metadata
+            print("Header " + str(header))
+            copied_file = shutil.copy2(mtl, original_mtl_path.absolute())
+        else:
+            return True
+    except Exception as e:
+        print(e)
+        return False
 
-	# This needs to be seperate since it involves writing
-	try:
-		with open(mtl, 'w') as mtl_file:
-			mtl_file.writelines(lines)
-			mtl_file.writelines(mcprep_header)
+    # In this section, we go over each line
+    # and check to see if it begins with map_d. If
+    # it does, then we simply comment it out. Otherwise,
+    # we can safely ignore it.
+    try:
+        with open(mtl, "r") as mtl_file:
+            for index, line in enumerate(lines):
+                if line.startswith("map_d "):
+                    lines[index] = "# " + line
+    except Exception as e:
+        print(e)
+        return False
 
-	# Recover the original file
-	except Exception as e:
-		print(e)
-		shutil.copy2(copied_file, mtl)
-		return False
+    # This needs to be seperate since it involves writing
+    try:
+        with open(mtl, "w") as mtl_file:
+            mtl_file.writelines(lines)
+            mtl_file.writelines(mcprep_header)
 
-	return True
+    # Recover the original file
+    except Exception as e:
+        print(e)
+        shutil.copy2(copied_file, mtl)
+        return False
+
+    return True
 
 
 # -----------------------------------------------------------------------------
@@ -250,1123 +248,1189 @@ def convert_mtl(filepath):
 
 
 class MCPREP_OT_open_jmc2obj(bpy.types.Operator):
-	"""Open the jmc2obj executbale"""
-	bl_idname = "mcprep.open_jmc2obj"
-	bl_label = "Open jmc2obj"
-	bl_description = "Open the jmc2obj executbale"
+    """Open the jmc2obj executbale"""
 
-	# poll, and prompt to download if not present w/ tutorial link
-	skipUsage: bpy.props.BoolProperty(
-		default=False,
-		options={'HIDDEN'})
+    bl_idname = "mcprep.open_jmc2obj"
+    bl_label = "Open jmc2obj"
+    bl_description = "Open the jmc2obj executbale"
 
-	track_function = "open_program"
-	track_param = "jmc2obj"
-	@tracking.report_error
-	def execute(self, context):
-		addon_prefs = util.get_user_preferences(context)
-		res = util.open_program(addon_prefs.open_jmc2obj_path)
+    # poll, and prompt to download if not present w/ tutorial link
+    skipUsage: bpy.props.BoolProperty(default=False, options={"HIDDEN"})
 
-		if res == -1:
-			bpy.ops.mcprep.install_jmc2obj('INVOKE_DEFAULT')
-			return {'CANCELLED'}
-		elif res != 0:
-			self.report({'ERROR'}, str(res))
-			return {'CANCELLED'}
-		else:
-			self.report({'INFO'}, "jmc2obj should open soon")
-		return {'FINISHED'}
+    track_function = "open_program"
+    track_param = "jmc2obj"
+
+    @tracking.report_error
+    def execute(self, context):
+        addon_prefs = util.get_user_preferences(context)
+        res = util.open_program(addon_prefs.open_jmc2obj_path)
+
+        if res == -1:
+            bpy.ops.mcprep.install_jmc2obj("INVOKE_DEFAULT")
+            return {"CANCELLED"}
+        elif res != 0:
+            self.report({"ERROR"}, str(res))
+            return {"CANCELLED"}
+        else:
+            self.report({"INFO"}, "jmc2obj should open soon")
+        return {"FINISHED"}
 
 
 class MCPREP_OT_install_jmc2obj(bpy.types.Operator):
-	"""Utility class to prompt jmc2obj installing"""
-	bl_idname = "mcprep.install_jmc2obj"
-	bl_label = "Install jmc2obj"
-	bl_description = "Prompt to install the jmc2obj world exporter"
+    """Utility class to prompt jmc2obj installing"""
 
-	# error message
+    bl_idname = "mcprep.install_jmc2obj"
+    bl_label = "Install jmc2obj"
+    bl_description = "Prompt to install the jmc2obj world exporter"
 
-	def invoke(self, context, event):
-		wm = context.window_manager
-		return wm.invoke_popup(self, width=400 * util.ui_scale())
+    # error message
 
-	def draw(self, context):
-		self.layout.label(text="Valid program path not found!")
-		self.layout.separator()
-		self.layout.label(text="Need to install jmc2obj?")
-		self.layout.operator(
-			"wm.url_open", text="Click to download"
-		).url = "http://www.jmc2obj.net/"
-		_ = self.layout.split()
-		col = self.layout.column()
-		col.scale_y = 0.7
-		col.label(text="Then, go to MCprep's user preferences and set the jmc2obj")
-		col.label(text=" path to jmc2obj_ver#.jar, for example")
-		row = self.layout.row(align=True)
+    def invoke(self, context, event):
+        wm = context.window_manager
+        return wm.invoke_popup(self, width=400 * util.ui_scale())
 
-		if bpy.app.version < (2, 81):
-			# Due to crash-prone bug in 2.81 through 2.83 (beta), if this
-			# operator's draw popup is still present behind the newly opened
-			# preferences window, and the user then opens a filebrowser e.g.
-			# by pressing a folder icon, blender will instant-crash.
-			# Thus, don't offer to open preferences for these blender versions
-			row.operator(
-				"mcprep.open_preferences",
-				text="Open MCprep preferences",
-				icon="PREFERENCES").tab = "settings"
+    def draw(self, context):
+        self.layout.label(text="Valid program path not found!")
+        self.layout.separator()
+        self.layout.label(text="Need to install jmc2obj?")
+        self.layout.operator(
+            "wm.url_open", text="Click to download"
+        ).url = "http://www.jmc2obj.net/"
+        _ = self.layout.split()
+        col = self.layout.column()
+        col.scale_y = 0.7
+        col.label(text="Then, go to MCprep's user preferences and set the jmc2obj")
+        col.label(text=" path to jmc2obj_ver#.jar, for example")
+        row = self.layout.row(align=True)
 
-		row.operator(
-			"wm.url_open", text="Open tutorial"
-		).url = "https://theduckcow.com/dev/blender/mcprep/setup-world-exporters/"
-		return
+        if bpy.app.version < (2, 81):
+            # Due to crash-prone bug in 2.81 through 2.83 (beta), if this
+            # operator's draw popup is still present behind the newly opened
+            # preferences window, and the user then opens a filebrowser e.g.
+            # by pressing a folder icon, blender will instant-crash.
+            # Thus, don't offer to open preferences for these blender versions
+            row.operator(
+                "mcprep.open_preferences",
+                text="Open MCprep preferences",
+                icon="PREFERENCES",
+            ).tab = "settings"
 
-	def execute(self, context):
-		self.report({'INFO'}, self.message)
-		print(self.message)
+        row.operator(
+            "wm.url_open", text="Open tutorial"
+        ).url = "https://theduckcow.com/dev/blender/mcprep/setup-world-exporters/"
+        return
 
-		return {'FINISHED'}
+    def execute(self, context):
+        self.report({"INFO"}, self.message)
+        print(self.message)
+
+        return {"FINISHED"}
 
 
 class MCPREP_OT_open_mineways(bpy.types.Operator):
-	"""Open the Mineways executbale"""
-	bl_idname = "mcprep.open_mineways"
-	bl_label = "Open Mineways"
-	bl_description = "Open the Mineways executbale"
+    """Open the Mineways executbale"""
 
-	# poll, and prompt to download if not present w/ tutorial link
-	skipUsage: bpy.props.BoolProperty(
-		default=False,
-		options={'HIDDEN'})
+    bl_idname = "mcprep.open_mineways"
+    bl_label = "Open Mineways"
+    bl_description = "Open the Mineways executbale"
 
-	track_function = "open_program"
-	track_param = "mineways"
-	@tracking.report_error
-	def execute(self, context):
-		addon_prefs = util.get_user_preferences(context)
-		if os.path.isfile(addon_prefs.open_mineways_path):
-			res = util.open_program(addon_prefs.open_mineways_path)
-		else:
-			res = -1
+    # poll, and prompt to download if not present w/ tutorial link
+    skipUsage: bpy.props.BoolProperty(default=False, options={"HIDDEN"})
 
-		if res == -1:
-			bpy.ops.mcprep.install_mineways('INVOKE_DEFAULT')
-			return {'CANCELLED'}
-		elif res != 0:
-			self.report({'ERROR'}, str(res))
-			return {'CANCELLED'}
-		else:
-			self.report({'INFO'}, "Mineways should open soon")
-		return {'FINISHED'}
+    track_function = "open_program"
+    track_param = "mineways"
+
+    @tracking.report_error
+    def execute(self, context):
+        addon_prefs = util.get_user_preferences(context)
+        if os.path.isfile(addon_prefs.open_mineways_path):
+            res = util.open_program(addon_prefs.open_mineways_path)
+        else:
+            res = -1
+
+        if res == -1:
+            bpy.ops.mcprep.install_mineways("INVOKE_DEFAULT")
+            return {"CANCELLED"}
+        elif res != 0:
+            self.report({"ERROR"}, str(res))
+            return {"CANCELLED"}
+        else:
+            self.report({"INFO"}, "Mineways should open soon")
+        return {"FINISHED"}
 
 
 class MCPREP_OT_install_mineways(bpy.types.Operator):
-	"""Utility class to prompt Mineways installing"""
-	bl_idname = "mcprep.install_mineways"
-	bl_label = "Install Mineways"
-	bl_description = "Prompt to install the Mineways world exporter"
+    """Utility class to prompt Mineways installing"""
 
-	# error message
+    bl_idname = "mcprep.install_mineways"
+    bl_label = "Install Mineways"
+    bl_description = "Prompt to install the Mineways world exporter"
 
-	def invoke(self, context, event):
-		wm = context.window_manager
-		return wm.invoke_popup(self, width=400 * util.ui_scale())
+    # error message
 
-	def draw(self, context):
-		self.layout.label(text="Valid program path not found!")
-		self.layout.separator()
-		self.layout.label(text="Need to install Mineways?")
-		self.layout.operator(
-			"wm.url_open", text="Click to download"
-		).url = "http://www.realtimerendering.com/erich/minecraft/public/mineways/"
-		_ = self.layout.split()
-		col = self.layout.column()
-		col.scale_y = 0.7
-		col.label(text="Then, go to MCprep's user preferences and set the")
-		col.label(text=" Mineways path to Mineways.exe or Mineways.app, for example")
-		row = self.layout.row(align=True)
-		if bpy.app.version < (2, 81):
-			# Due to crash-prone bug in 2.81 through 2.83 (beta), if this
-			# operator's draw popup is still present behind the newly opened
-			# preferences window, and the user then opens a filebrowser e.g.
-			# by pressing a folder icon, blender will instant-crash.
-			# Thus, don't offer to open preferences for these blender versions
-			row.operator(
-				"mcprep.open_preferences",
-				text="Open MCprep preferences",
-				icon="PREFERENCES").tab = "settings"
+    def invoke(self, context, event):
+        wm = context.window_manager
+        return wm.invoke_popup(self, width=400 * util.ui_scale())
 
-		row.operator(
-			"wm.url_open", text="Open tutorial"
-		).url = "https://theduckcow.com/dev/blender/mcprep/setup-world-exporters/"
-		return
+    def draw(self, context):
+        self.layout.label(text="Valid program path not found!")
+        self.layout.separator()
+        self.layout.label(text="Need to install Mineways?")
+        self.layout.operator(
+            "wm.url_open", text="Click to download"
+        ).url = "http://www.realtimerendering.com/erich/minecraft/public/mineways/"
+        _ = self.layout.split()
+        col = self.layout.column()
+        col.scale_y = 0.7
+        col.label(text="Then, go to MCprep's user preferences and set the")
+        col.label(text=" Mineways path to Mineways.exe or Mineways.app, for example")
+        row = self.layout.row(align=True)
+        if bpy.app.version < (2, 81):
+            # Due to crash-prone bug in 2.81 through 2.83 (beta), if this
+            # operator's draw popup is still present behind the newly opened
+            # preferences window, and the user then opens a filebrowser e.g.
+            # by pressing a folder icon, blender will instant-crash.
+            # Thus, don't offer to open preferences for these blender versions
+            row.operator(
+                "mcprep.open_preferences",
+                text="Open MCprep preferences",
+                icon="PREFERENCES",
+            ).tab = "settings"
 
-	def execute(self, context):
-		self.report({'INFO'}, self.message)
-		print(self.message)
+        row.operator(
+            "wm.url_open", text="Open tutorial"
+        ).url = "https://theduckcow.com/dev/blender/mcprep/setup-world-exporters/"
+        return
 
-		return {'FINISHED'}
+    def execute(self, context):
+        self.report({"INFO"}, self.message)
+        print(self.message)
+
+        return {"FINISHED"}
 
 
 # -----------------------------------------------------------------------------
 # Additional world tools
 # -----------------------------------------------------------------------------
 
+
 class MCPREP_OT_import_world_split(bpy.types.Operator, ImportHelper):
-	"""Imports an obj file, and auto splits it by material"""
-	bl_idname = "mcprep.import_world_split"
-	bl_label = "Import World"
-	bl_options = {'REGISTER', 'UNDO'}
+    """Imports an obj file, and auto splits it by material"""
 
-	filter_glob: bpy.props.StringProperty(
-		default="*.obj;*.mtl",
-		options={'HIDDEN'})
-	fileselectparams = "use_filter_blender"
-	skipUsage: bpy.props.BoolProperty(
-		default=False,
-		options={'HIDDEN'})
+    bl_idname = "mcprep.import_world_split"
+    bl_label = "Import World"
+    bl_options = {"REGISTER", "UNDO"}
 
-	track_function = "import_split"
-	track_exporter = None
-	@tracking.report_error
-	def execute(self, context):
-		# for consistency with the built in one, only import the active path
-		if self.filepath.lower().endswith(".mtl"):
-			filename = Path(self.filepath)
-			new_filename = filename.with_suffix(".obj")
-			# Auto change from MTL to OBJ, latet if's will check if existing.
-			self.filepath = str(new_filename)
-		if not self.filepath:
-			self.report({"ERROR"}, "File not found, could not import obj")
-			return {'CANCELLED'}
-		if not os.path.isfile(self.filepath):
-			self.report({"ERROR"}, "File not found, could not import obj")
-			return {'CANCELLED'}
-		if not self.filepath.lower().endswith(".obj"):
-			self.report({"ERROR"}, "You must select a .obj file to import")
-			return {'CANCELLED'}
+    filter_glob: bpy.props.StringProperty(default="*.obj;*.mtl", options={"HIDDEN"})
+    fileselectparams = "use_filter_blender"
+    skipUsage: bpy.props.BoolProperty(default=False, options={"HIDDEN"})
 
-		if "obj" not in dir(bpy.ops.import_scene):
-			try:
-				bpy.ops.preferences.addon_enable(module="io_scene_obj")
-				self.report(
-					{"INFO"},
-					"FYI: had to enable OBJ imports in user preferences")
-			except RuntimeError:
-				self.report({"ERROR"}, "Built-in OBJ importer could not be enabled")
-				return {'CANCELLED'}
+    track_function = "import_split"
+    track_exporter = None
 
-		# There are a number of bug reports that come from the generic call
-		# of obj importing. If this fails, should notify the user to try again
-		# or try exporting again.
-		#
-		# In order to not overly supress error messages, below we only capture
-		# very tight specific errors possible, so that other errors still get
-		# reported so it may be passed off to blender devs. It is understood the
-		# below errors are not internationalized, so someone with another lang
-		# set will get the raw bubbled up traceback.
-		obj_import_err_msg = (
-			"Blender's OBJ importer error, try re-exporting your world and "
-			"import again.")
-		obj_import_mem_msg = (
-			"Memory error during OBJ import, try exporting a smaller world")
+    @tracking.report_error
+    def execute(self, context):
+        # for consistency with the built in one, only import the active path
+        if self.filepath.lower().endswith(".mtl"):
+            filename = Path(self.filepath)
+            new_filename = filename.with_suffix(".obj")
+            # Auto change from MTL to OBJ, latet if's will check if existing.
+            self.filepath = str(new_filename)
+        if not self.filepath:
+            self.report({"ERROR"}, "File not found, could not import obj")
+            return {"CANCELLED"}
+        if not os.path.isfile(self.filepath):
+            self.report({"ERROR"}, "File not found, could not import obj")
+            return {"CANCELLED"}
+        if not self.filepath.lower().endswith(".obj"):
+            self.report({"ERROR"}, "You must select a .obj file to import")
+            return {"CANCELLED"}
 
-		# First let's convert the MTL if needed
-		conv_res = convert_mtl(self.filepath)
-		try:
-			if conv_res is None:
-				pass  # skipped, no issue anyways.
-			elif conv_res is False:
-				self.report({"WARNING"}, "MTL conversion failed!")
+        if "obj" not in dir(bpy.ops.import_scene):
+            try:
+                bpy.ops.preferences.addon_enable(module="io_scene_obj")
+                self.report(
+                    {"INFO"}, "FYI: had to enable OBJ imports in user preferences"
+                )
+            except RuntimeError:
+                self.report({"ERROR"}, "Built-in OBJ importer could not be enabled")
+                return {"CANCELLED"}
 
-			res = None
-			if util.min_bv((3, 5)):
-				res = bpy.ops.wm.obj_import(
-					filepath=self.filepath, use_split_groups=True)
-			else:
-				res = bpy.ops.import_scene.obj(
-					filepath=self.filepath, use_split_groups=True)
+        # There are a number of bug reports that come from the generic call
+        # of obj importing. If this fails, should notify the user to try again
+        # or try exporting again.
+        #
+        # In order to not overly supress error messages, below we only capture
+        # very tight specific errors possible, so that other errors still get
+        # reported so it may be passed off to blender devs. It is understood the
+        # below errors are not internationalized, so someone with another lang
+        # set will get the raw bubbled up traceback.
+        obj_import_err_msg = (
+            "Blender's OBJ importer error, try re-exporting your world and "
+            "import again."
+        )
+        obj_import_mem_msg = (
+            "Memory error during OBJ import, try exporting a smaller world"
+        )
 
-		except MemoryError as err:
-			print("Memory error during import OBJ:")
-			print(err)
-			self.report({"ERROR"}, obj_import_mem_msg)
-			return {'CANCELLED'}
-		except ValueError as err:
-			if "could not convert string" in str(err):
-				# Error such as:
-				#   vec[:] = [float_func(v) for v in line_split[1:]]
-				#   ValueError: could not convert string to float: b'6848/28'
-				print(err)
-				self.report({"ERROR"}, obj_import_err_msg)
-				return {'CANCELLED'}
-			elif "invalid literal for int() with base" in str(err):
-				# Error such as:
-				#   idx = int(obj_vert[0])
-				#   ValueError: invalid literal for int() with base 10: b'4semtl'
-				print(err)
-				self.report({"ERROR"}, obj_import_err_msg)
-				return {'CANCELLED'}
-			else:
-				raise err
-		except IndexError as err:
-			if "list index out of range" in str(err):
-				# Error such as:
-				#   verts_split.append(verts_loc[vert_idx])
-				#   IndexError: list index out of range
-				print(err)
-				self.report({"ERROR"}, obj_import_err_msg)
-				return {'CANCELLED'}
-			else:
-				raise err
-		except UnicodeDecodeError as err:
-			if "codec can't decode byte" in str(err):
-				# Error such as:
-				#   keywords["relpath"] = os.path.dirname(bpy.data.filepath)
-				#   UnicodeDecodeError: 'utf-8' codec can't decode byte 0xc4 in
-				#     position 24: invalid continuation byte
-				print(err)
-				self.report({"ERROR"}, obj_import_err_msg)
-				return {'CANCELLED'}
-			else:
-				raise err
-		except TypeError as err:
-			if "enum" in str(err) and "not found in" in str(err):
-				# Error such as:
-				#   enum "Non-Color" not found in ('AppleP3 Filmic Log Encoding',
-				#  'AppleP3 sRGB OETF', ...
-				print(err)
-				self.report({"ERROR"}, obj_import_err_msg)
-				return {'CANCELLED'}
-			else:
-				raise err
-		except AttributeError as err:
-			if "object has no attribute 'image'" in str(err):
-				# Error such as:
-				#   nodetex.image = image
-				#   AttributeError: 'NoneType' object has no attribute 'image'
-				print(err)
-				self.report({"ERROR"}, obj_import_err_msg)
-				return {'CANCELLED'}
-			else:
-				raise err
-		except RuntimeError as err:
-			# Possible this is the more broad error that even the abvoe
-			# items are wrapped under. Generally just prompt user to re-export.
-			print(err)
-			self.report({"ERROR"}, obj_import_err_msg)
-			return {'CANCELLED'}
+        # First let's convert the MTL if needed
+        conv_res = convert_mtl(self.filepath)
+        try:
+            if conv_res is None:
+                pass  # skipped, no issue anyways.
+            elif conv_res is False:
+                self.report({"WARNING"}, "MTL conversion failed!")
 
-		if res != {'FINISHED'}:
-			self.report({"ERROR"}, "Issue encountered while importing world")
-			return {'CANCELLED'}
+            res = None
+            if util.min_bv((3, 5)):
+                res = bpy.ops.wm.obj_import(
+                    filepath=self.filepath, use_split_groups=True
+                )
+            else:
+                res = bpy.ops.import_scene.obj(
+                    filepath=self.filepath, use_split_groups=True
+                )
 
-		prefs = util.get_user_preferences(context)
-		detect_world_exporter(self.filepath)
-		prefs.MCprep_exporter_type = obj_header.exporter()
+        except MemoryError as err:
+            print("Memory error during import OBJ:")
+            print(err)
+            self.report({"ERROR"}, obj_import_mem_msg)
+            return {"CANCELLED"}
+        except ValueError as err:
+            if "could not convert string" in str(err):
+                # Error such as:
+                #   vec[:] = [float_func(v) for v in line_split[1:]]
+                #   ValueError: could not convert string to float: b'6848/28'
+                print(err)
+                self.report({"ERROR"}, obj_import_err_msg)
+                return {"CANCELLED"}
+            elif "invalid literal for int() with base" in str(err):
+                # Error such as:
+                #   idx = int(obj_vert[0])
+                #   ValueError: invalid literal for int() with base 10: b'4semtl'
+                print(err)
+                self.report({"ERROR"}, obj_import_err_msg)
+                return {"CANCELLED"}
+            else:
+                raise err
+        except IndexError as err:
+            if "list index out of range" in str(err):
+                # Error such as:
+                #   verts_split.append(verts_loc[vert_idx])
+                #   IndexError: list index out of range
+                print(err)
+                self.report({"ERROR"}, obj_import_err_msg)
+                return {"CANCELLED"}
+            else:
+                raise err
+        except UnicodeDecodeError as err:
+            if "codec can't decode byte" in str(err):
+                # Error such as:
+                #   keywords["relpath"] = os.path.dirname(bpy.data.filepath)
+                #   UnicodeDecodeError: 'utf-8' codec can't decode byte 0xc4 in
+                #     position 24: invalid continuation byte
+                print(err)
+                self.report({"ERROR"}, obj_import_err_msg)
+                return {"CANCELLED"}
+            else:
+                raise err
+        except TypeError as err:
+            if "enum" in str(err) and "not found in" in str(err):
+                # Error such as:
+                #   enum "Non-Color" not found in ('AppleP3 Filmic Log Encoding',
+                #  'AppleP3 sRGB OETF', ...
+                print(err)
+                self.report({"ERROR"}, obj_import_err_msg)
+                return {"CANCELLED"}
+            else:
+                raise err
+        except AttributeError as err:
+            if "object has no attribute 'image'" in str(err):
+                # Error such as:
+                #   nodetex.image = image
+                #   AttributeError: 'NoneType' object has no attribute 'image'
+                print(err)
+                self.report({"ERROR"}, obj_import_err_msg)
+                return {"CANCELLED"}
+            else:
+                raise err
+        except RuntimeError as err:
+            # Possible this is the more broad error that even the abvoe
+            # items are wrapped under. Generally just prompt user to re-export.
+            print(err)
+            self.report({"ERROR"}, obj_import_err_msg)
+            return {"CANCELLED"}
 
-		for obj in context.selected_objects:
-			obj["MCPREP_OBJ_HEADER"] = True
-			obj["MCPREP_OBJ_FILE_TYPE"] = obj_header.texture_type()
+        if res != {"FINISHED"}:
+            self.report({"ERROR"}, "Issue encountered while importing world")
+            return {"CANCELLED"}
 
-		if util.bv28():
-			self.split_world_by_material(context)
+        prefs = util.get_user_preferences(context)
+        detect_world_exporter(self.filepath)
+        prefs.MCprep_exporter_type = obj_header.exporter()
 
-		addon_prefs = util.get_user_preferences(context)
-		self.track_exporter = addon_prefs.MCprep_exporter_type  # Soft detect.
-		return {'FINISHED'}
+        for obj in context.selected_objects:
+            obj["MCPREP_OBJ_HEADER"] = True
+            obj["MCPREP_OBJ_FILE_TYPE"] = obj_header.texture_type()
 
-	def obj_name_to_material(self, obj):
-		"""Update an objects name based on its first material"""
-		if not obj:
-			return
-		mat = obj.active_material
-		if not mat and not obj.material_slots:
-			return
-		else:
-			mat = obj.material_slots[0].material
-		if not mat:
-			return
-		obj.name = util.nameGeneralize(mat.name)
+        if util.bv28():
+            self.split_world_by_material(context)
 
-	def split_world_by_material(self, context):
-		"""2.8-only function, split combined object into parts by material"""
-		world_name = os.path.basename(self.filepath)
-		world_name = os.path.splitext(world_name)[0]
+        addon_prefs = util.get_user_preferences(context)
+        self.track_exporter = addon_prefs.MCprep_exporter_type  # Soft detect.
+        return {"FINISHED"}
 
-		# Create the new world collection
-		prefs = util.get_user_preferences(context)
-		if prefs is not None and prefs.MCprep_exporter_type != '(choose)':
-			name = "{} world: {}".format(
-				prefs.MCprep_exporter_type,
-				world_name)
-		else:
-			name = "minecraft_world: " + world_name
-		worldg = util.collections().new(name=name)
-		context.scene.collection.children.link(worldg)  # Add to outliner.
+    def obj_name_to_material(self, obj):
+        """Update an objects name based on its first material"""
+        if not obj:
+            return
+        mat = obj.active_material
+        if not mat and not obj.material_slots:
+            return
+        else:
+            mat = obj.material_slots[0].material
+        if not mat:
+            return
+        obj.name = util.nameGeneralize(mat.name)
 
-		for obj in context.selected_objects:
-			util.move_to_collection(obj, worldg)
+    def split_world_by_material(self, context):
+        """2.8-only function, split combined object into parts by material"""
+        world_name = os.path.basename(self.filepath)
+        world_name = os.path.splitext(world_name)[0]
 
-		# Force renames based on material, as default names are not useful.
-		for obj in worldg.objects:
-			self.obj_name_to_material(obj)
+        # Create the new world collection
+        prefs = util.get_user_preferences(context)
+        if prefs is not None and prefs.MCprep_exporter_type != "(choose)":
+            name = "{} world: {}".format(prefs.MCprep_exporter_type, world_name)
+        else:
+            name = "minecraft_world: " + world_name
+        worldg = util.collections().new(name=name)
+        context.scene.collection.children.link(worldg)  # Add to outliner.
+
+        for obj in context.selected_objects:
+            util.move_to_collection(obj, worldg)
+
+        # Force renames based on material, as default names are not useful.
+        for obj in worldg.objects:
+            self.obj_name_to_material(obj)
 
 
 class MCPREP_OT_prep_world(bpy.types.Operator):
-	"""Class to prep world settings to appropriate default"""
-	bl_idname = "mcprep.world"
-	bl_label = "Prep World"
-	bl_description = "Prep world render settings to something generally useful"
-	bl_options = {'REGISTER', 'UNDO'}
+    """Class to prep world settings to appropriate default"""
 
-	skipUsage: bpy.props.BoolProperty(
-		default=False,
-		options={'HIDDEN'})
+    bl_idname = "mcprep.world"
+    bl_label = "Prep World"
+    bl_description = "Prep world render settings to something generally useful"
+    bl_options = {"REGISTER", "UNDO"}
 
-	track_function = "prep_world"
-	track_param = None
-	@tracking.report_error
-	def execute(self, context):
-		engine = bpy.context.scene.render.engine
-		self.track_param = engine
-		if not context.scene.world:
-			context.scene.world = bpy.data.worlds.new("MCprep world")
-		if engine == 'CYCLES':
-			self.prep_world_cycles(context)
-		elif engine == 'BLENDER_EEVEE':
-			self.prep_world_eevee(context)
-		elif engine == 'BLENDER_RENDER' or engine == 'BLENDER_GAME':
-			self.prep_world_internal(context)
-		else:
-			self.report({'ERROR'}, "Must be cycles, eevee, or blender internal")
-		return {'FINISHED'}
+    skipUsage: bpy.props.BoolProperty(default=False, options={"HIDDEN"})
 
-	def prep_world_cycles(self, context):
-		if not context.scene.world or not context.scene.world.use_nodes:
-			context.scene.world.use_nodes = True
+    track_function = "prep_world"
+    track_param = None
 
-		world_nodes = context.scene.world.node_tree.nodes
-		world_links = context.scene.world.node_tree.links
+    @tracking.report_error
+    def execute(self, context):
+        engine = bpy.context.scene.render.engine
+        self.track_param = engine
+        if not context.scene.world:
+            context.scene.world = bpy.data.worlds.new("MCprep world")
+        if engine == "CYCLES":
+            self.prep_world_cycles(context)
+        elif engine == "BLENDER_EEVEE":
+            self.prep_world_eevee(context)
+        elif engine == "BLENDER_RENDER" or engine == "BLENDER_GAME":
+            self.prep_world_internal(context)
+        else:
+            self.report({"ERROR"}, "Must be cycles, eevee, or blender internal")
+        return {"FINISHED"}
 
-		if "mcprep_world" not in context.scene.world:
-			world_nodes.clear()
-			skynode = generate.create_node(
-				world_nodes, "ShaderNodeTexSky", location=(-280, 300))
-			background = generate.create_node(
-				world_nodes, "ShaderNodeBackground", location=(10, 300))
-			output = generate.create_node(
-				world_nodes, "ShaderNodeOutputWorld", location=(300, 300))
-			world_links.new(skynode.outputs["Color"], background.inputs[0])
-			world_links.new(background.outputs["Background"], output.inputs[0])
+    def prep_world_cycles(self, context):
+        if not context.scene.world or not context.scene.world.use_nodes:
+            context.scene.world.use_nodes = True
 
-		context.scene.world.light_settings.use_ambient_occlusion = False
+        world_nodes = context.scene.world.node_tree.nodes
+        world_links = context.scene.world.node_tree.links
 
-		if hasattr(context.scene, "cycles"):
-			context.scene.cycles.caustics_reflective = False
-			context.scene.cycles.caustics_refractive = False
+        if "mcprep_world" not in context.scene.world:
+            world_nodes.clear()
+            skynode = generate.create_node(
+                world_nodes, "ShaderNodeTexSky", location=(-280, 300)
+            )
+            background = generate.create_node(
+                world_nodes, "ShaderNodeBackground", location=(10, 300)
+            )
+            output = generate.create_node(
+                world_nodes, "ShaderNodeOutputWorld", location=(300, 300)
+            )
+            world_links.new(skynode.outputs["Color"], background.inputs[0])
+            world_links.new(background.outputs["Background"], output.inputs[0])
 
-			# higher = faster, though potentially noisier; this is a good balance
-			context.scene.cycles.light_sampling_threshold = 0.1
-			context.scene.cycles.max_bounces = 8
+        context.scene.world.light_settings.use_ambient_occlusion = False
 
-			# Renders faster at a (minor?) cost of the image output
-			# TODO: given the output change, consider adding a bool toggle
-			context.scene.render.use_simplify = True
-			context.scene.cycles.ao_bounces = 2
-			context.scene.cycles.ao_bounces_render = 2
+        if hasattr(context.scene, "cycles"):
+            context.scene.cycles.caustics_reflective = False
+            context.scene.cycles.caustics_refractive = False
 
-	def prep_world_eevee(self, context):
-		"""Default world settings for Eevee rendering"""
-		if not context.scene.world or not context.scene.world.use_nodes:
-			context.scene.world.use_nodes = True
+            # higher = faster, though potentially noisier; this is a good balance
+            context.scene.cycles.light_sampling_threshold = 0.1
+            context.scene.cycles.max_bounces = 8
 
-		world_nodes = context.scene.world.node_tree.nodes
-		world_links = context.scene.world.node_tree.links
+            # Renders faster at a (minor?) cost of the image output
+            # TODO: given the output change, consider adding a bool toggle
+            context.scene.render.use_simplify = True
+            context.scene.cycles.ao_bounces = 2
+            context.scene.cycles.ao_bounces_render = 2
 
-		if "mcprep_world" not in context.scene.world:
-			world_nodes.clear()
-			light_paths = generate.create_node(
-				world_nodes, "ShaderNodeLightPath", location=(-150, 400))
-			background_camera = generate.create_node(
-				world_nodes, "ShaderNodeBackground", location=(10, 150))
-			background_others = generate.create_node(
-				world_nodes, "ShaderNodeBackground", location=(10, 300))
-			mix_shader = generate.create_node(
-				world_nodes, "ShaderNodeMixShader", location=(300, 300))
-			output = generate.create_node(
-				world_nodes, "ShaderNodeOutputWorld", location=(500, 300))
-			background_others.inputs["Color"].default_value = (0.14965, 0.425823, 1, 1)
-			background_others.inputs["Strength"].default_value = 0.1
-			background_camera.inputs["Color"].default_value = (0.14965, 0.425823, 1, 1)
-			background_camera.inputs["Strength"].default_value = 1
-			world_links.new(light_paths.outputs[0], mix_shader.inputs[0])
-			world_links.new(
-				background_others.outputs["Background"], mix_shader.inputs[1])
-			world_links.new(
-				background_camera.outputs["Background"], mix_shader.inputs[2])
-			world_links.new(mix_shader.outputs["Shader"], output.inputs[0])
+    def prep_world_eevee(self, context):
+        """Default world settings for Eevee rendering"""
+        if not context.scene.world or not context.scene.world.use_nodes:
+            context.scene.world.use_nodes = True
 
-		# is not great
-		context.scene.world.light_settings.use_ambient_occlusion = False
-		if hasattr(context.scene, "cycles"):
-			context.scene.cycles.caustics_reflective = False
-			context.scene.cycles.caustics_refractive = False
+        world_nodes = context.scene.world.node_tree.nodes
+        world_links = context.scene.world.node_tree.links
 
-			# higher = faster, though potentially noisier; this is a good balance
-			context.scene.cycles.light_sampling_threshold = 0.1
-			context.scene.cycles.max_bounces = 8
-			context.scene.cycles.ao_bounces = 2
-			context.scene.cycles.ao_bounces_render = 2
+        if "mcprep_world" not in context.scene.world:
+            world_nodes.clear()
+            light_paths = generate.create_node(
+                world_nodes, "ShaderNodeLightPath", location=(-150, 400)
+            )
+            background_camera = generate.create_node(
+                world_nodes, "ShaderNodeBackground", location=(10, 150)
+            )
+            background_others = generate.create_node(
+                world_nodes, "ShaderNodeBackground", location=(10, 300)
+            )
+            mix_shader = generate.create_node(
+                world_nodes, "ShaderNodeMixShader", location=(300, 300)
+            )
+            output = generate.create_node(
+                world_nodes, "ShaderNodeOutputWorld", location=(500, 300)
+            )
+            background_others.inputs["Color"].default_value = (0.14965, 0.425823, 1, 1)
+            background_others.inputs["Strength"].default_value = 0.1
+            background_camera.inputs["Color"].default_value = (0.14965, 0.425823, 1, 1)
+            background_camera.inputs["Strength"].default_value = 1
+            world_links.new(light_paths.outputs[0], mix_shader.inputs[0])
+            world_links.new(
+                background_others.outputs["Background"], mix_shader.inputs[1]
+            )
+            world_links.new(
+                background_camera.outputs["Background"], mix_shader.inputs[2]
+            )
+            world_links.new(mix_shader.outputs["Shader"], output.inputs[0])
 
-		# Renders faster at a (minor?) cost of the image output
-		# TODO: given the output change, consider make a bool toggle for this
-		bpy.context.scene.render.use_simplify = True
+        # is not great
+        context.scene.world.light_settings.use_ambient_occlusion = False
+        if hasattr(context.scene, "cycles"):
+            context.scene.cycles.caustics_reflective = False
+            context.scene.cycles.caustics_refractive = False
 
-	def prep_world_internal(self, context):
-		# check for any suns with the sky setting on;
-		if not context.scene.world:
-			return
-		context.scene.world.use_nodes = False
-		context.scene.world.horizon_color = (0.00938029, 0.0125943, 0.0140572)
-		context.scene.world.light_settings.use_ambient_occlusion = True
-		context.scene.world.light_settings.ao_blend_type = 'MULTIPLY'
-		context.scene.world.light_settings.ao_factor = 0.1
-		context.scene.world.light_settings.use_environment_light = True
-		context.scene.world.light_settings.environment_energy = 0.05
-		context.scene.render.use_shadows = True
-		context.scene.render.use_raytrace = True
-		context.scene.render.use_textures = True
+            # higher = faster, though potentially noisier; this is a good balance
+            context.scene.cycles.light_sampling_threshold = 0.1
+            context.scene.cycles.max_bounces = 8
+            context.scene.cycles.ao_bounces = 2
+            context.scene.cycles.ao_bounces_render = 2
 
-		# check for any sunlamps with sky setting
-		sky_used = False
-		for lamp in context.scene.objects:
-			if lamp.type not in ("LAMP", "LIGHT") or lamp.data.type != "SUN":
-				continue
-			if lamp.data.sky.use_sky:
-				sky_used = True
-				break
-		if sky_used:
-			env.log("MCprep sky being used with atmosphere")
-			context.scene.world.use_sky_blend = False
-			context.scene.world.horizon_color = (0.00938029, 0.0125943, 0.0140572)
-		else:
-			env.log("No MCprep sky with atmosphere")
-			context.scene.world.use_sky_blend = True
-			context.scene.world.horizon_color = (0.647705, 0.859927, 0.940392)
-			context.scene.world.zenith_color = (0.0954261, 0.546859, 1)
+        # Renders faster at a (minor?) cost of the image output
+        # TODO: given the output change, consider make a bool toggle for this
+        bpy.context.scene.render.use_simplify = True
+
+    def prep_world_internal(self, context):
+        # check for any suns with the sky setting on;
+        if not context.scene.world:
+            return
+        context.scene.world.use_nodes = False
+        context.scene.world.horizon_color = (0.00938029, 0.0125943, 0.0140572)
+        context.scene.world.light_settings.use_ambient_occlusion = True
+        context.scene.world.light_settings.ao_blend_type = "MULTIPLY"
+        context.scene.world.light_settings.ao_factor = 0.1
+        context.scene.world.light_settings.use_environment_light = True
+        context.scene.world.light_settings.environment_energy = 0.05
+        context.scene.render.use_shadows = True
+        context.scene.render.use_raytrace = True
+        context.scene.render.use_textures = True
+
+        # check for any sunlamps with sky setting
+        sky_used = False
+        for lamp in context.scene.objects:
+            if lamp.type not in ("LAMP", "LIGHT") or lamp.data.type != "SUN":
+                continue
+            if lamp.data.sky.use_sky:
+                sky_used = True
+                break
+        if sky_used:
+            env.log("MCprep sky being used with atmosphere")
+            context.scene.world.use_sky_blend = False
+            context.scene.world.horizon_color = (0.00938029, 0.0125943, 0.0140572)
+        else:
+            env.log("No MCprep sky with atmosphere")
+            context.scene.world.use_sky_blend = True
+            context.scene.world.horizon_color = (0.647705, 0.859927, 0.940392)
+            context.scene.world.zenith_color = (0.0954261, 0.546859, 1)
 
 
 class MCPREP_OT_add_mc_world(bpy.types.Operator):
-	"""Please used the new operator, mcprep.add_mc_sky"""
-	bl_idname = "mcprep.add_mc_world"
-	bl_label = "Create MC World"
-	bl_options = {'REGISTER', 'UNDO'}
+    """Please used the new operator, mcprep.add_mc_sky"""
 
-	track_function = "world_time"
-	track_param = "Deprecated"
-	@tracking.report_error
-	def execute(self, context):
-		self.report({"ERROR"}, "Use the new operator, mcprep.add_mc_sky")
-		return {'CANCELLED'}
+    bl_idname = "mcprep.add_mc_world"
+    bl_label = "Create MC World"
+    bl_options = {"REGISTER", "UNDO"}
+
+    track_function = "world_time"
+    track_param = "Deprecated"
+
+    @tracking.report_error
+    def execute(self, context):
+        self.report({"ERROR"}, "Use the new operator, mcprep.add_mc_sky")
+        return {"CANCELLED"}
 
 
 class MCPREP_OT_add_mc_sky(bpy.types.Operator):
-	"""Add sun lamp and time of day (dynamic) driver, setup sky with sun and moon"""
-	bl_idname = "mcprep.add_mc_sky"
-	bl_label = "Create MC Sky"
-	bl_options = {'REGISTER', 'UNDO'}
+    """Add sun lamp and time of day (dynamic) driver, setup sky with sun and moon"""
 
-	def enum_options(self, context):
-		"""Dynamic set of enums to show based on engine"""
-		engine = bpy.context.scene.render.engine
-		enums = []
-		if bpy.app.version >= (2, 77) and engine in ("CYCLES", "BLENDER_EEVEE"):
-			enums.append((
-				"world_shader",
-				"Dynamic sky + shader sun/moon",
-				"Import dynamic sky and shader-based sun and moon"))
-		enums.append((
-			"world_mesh",
-			"Dynamic sky + mesh sun/moon",
-			"Import dynamic sky and mesh sun and moon"))
-		enums.append((
-			"world_only",
-			"Dynamic sky only",
-			"Import dynamic sky, with no sun or moon"))
-		enums.append((
-			"world_static_mesh",
-			"Static sky + mesh sun/moon",
-			"Create static sky with mesh sun and moon"))
-		enums.append((
-			"world_static_only",
-			"Static sky only",
-			"Create static sky, with no sun or moon"))
-		return enums
+    bl_idname = "mcprep.add_mc_sky"
+    bl_label = "Create MC Sky"
+    bl_options = {"REGISTER", "UNDO"}
 
-	world_type: bpy.props.EnumProperty(
-		name="Sky type",
-		description=(
-			"Decide to improt dynamic (time/hour-controlled) vs static sky "
-			"(daytime only), and the type of sun/moon (if any) to use"),
-		items=enum_options)
-	initial_time: bpy.props.EnumProperty(
-		name="Set time (dynamic only)",
-		description="Set initial time of day, only supported for dynamic sky types",
-		items=(
-			("8", "Morning", "Set initial time to 9am"),
-			("12", "Noon", "Set initial time to 12pm"),
-			("18", "Sunset", "Set initial time to 6pm"),
-			("0", "Midnight", "Set initial time to 12am"),
-			("6", "Sunrise", "Set initial time to 6am"))
-	)
-	add_clouds: bpy.props.BoolProperty(
-		name="Add clouds",
-		description="Add in a cloud mesh",
-		default=True)
-	remove_existing_suns: bpy.props.BoolProperty(
-		name="Remove initial suns",
-		description="Remove any existing sunlamps",
-		default=True)
+    def enum_options(self, context):
+        """Dynamic set of enums to show based on engine"""
+        engine = bpy.context.scene.render.engine
+        enums = []
+        if bpy.app.version >= (2, 77) and engine in ("CYCLES", "BLENDER_EEVEE"):
+            enums.append(
+                (
+                    "world_shader",
+                    "Dynamic sky + shader sun/moon",
+                    "Import dynamic sky and shader-based sun and moon",
+                )
+            )
+        enums.append(
+            (
+                "world_mesh",
+                "Dynamic sky + mesh sun/moon",
+                "Import dynamic sky and mesh sun and moon",
+            )
+        )
+        enums.append(
+            (
+                "world_only",
+                "Dynamic sky only",
+                "Import dynamic sky, with no sun or moon",
+            )
+        )
+        enums.append(
+            (
+                "world_static_mesh",
+                "Static sky + mesh sun/moon",
+                "Create static sky with mesh sun and moon",
+            )
+        )
+        enums.append(
+            (
+                "world_static_only",
+                "Static sky only",
+                "Create static sky, with no sun or moon",
+            )
+        )
+        return enums
 
-	def invoke(self, context, event):
-		return context.window_manager.invoke_props_dialog(
-			self, width=400 * util.ui_scale())
+    world_type: bpy.props.EnumProperty(
+        name="Sky type",
+        description=(
+            "Decide to improt dynamic (time/hour-controlled) vs static sky "
+            "(daytime only), and the type of sun/moon (if any) to use"
+        ),
+        items=enum_options,
+    )
+    initial_time: bpy.props.EnumProperty(
+        name="Set time (dynamic only)",
+        description="Set initial time of day, only supported for dynamic sky types",
+        items=(
+            ("8", "Morning", "Set initial time to 9am"),
+            ("12", "Noon", "Set initial time to 12pm"),
+            ("18", "Sunset", "Set initial time to 6pm"),
+            ("0", "Midnight", "Set initial time to 12am"),
+            ("6", "Sunrise", "Set initial time to 6am"),
+        ),
+    )
+    add_clouds: bpy.props.BoolProperty(
+        name="Add clouds", description="Add in a cloud mesh", default=True
+    )
+    remove_existing_suns: bpy.props.BoolProperty(
+        name="Remove initial suns",
+        description="Remove any existing sunlamps",
+        default=True,
+    )
 
-	def draw(self, context):
-		self.layout.prop(self, "world_type")
-		# self.layout.prop(self, "initial_time")
-		# issue updating driver when set this way
-		row = self.layout.row()
-		row.prop(self, "add_clouds")
-		row.prop(self, "remove_existing_suns")
-		row = self.layout.row()
-		row.label(
-			text="Note: Dynamic skies use drivers, enable auto-run python scripts")
+    def invoke(self, context, event):
+        return context.window_manager.invoke_props_dialog(
+            self, width=400 * util.ui_scale()
+        )
 
-	track_function = "world_time"
-	track_param = None
-	@tracking.report_error
-	def execute(self, context):
-		# must be in object mode
-		if context.mode != "OBJECT":
-			bpy.ops.object.mode_set(mode="OBJECT")
+    def draw(self, context):
+        self.layout.prop(self, "world_type")
+        # self.layout.prop(self, "initial_time")
+        # issue updating driver when set this way
+        row = self.layout.row()
+        row.prop(self, "add_clouds")
+        row.prop(self, "remove_existing_suns")
+        row = self.layout.row()
+        row.label(
+            text="Note: Dynamic skies use drivers, enable auto-run python scripts"
+        )
 
-		new_objs = []
-		if self.remove_existing_suns:
-			for lamp in context.scene.objects:
-				if lamp.type not in ("LAMP", "LIGHT") or lamp.data.type != "SUN":
-					continue
-				util.obj_unlink_remove(lamp, True)
+    track_function = "world_time"
+    track_param = None
 
-		engine = context.scene.render.engine
-		wname = None
-		if engine == "BLENDER_EEVEE":
-			blend = "clouds_moon_sun_eevee.blend"
-			wname = "MCprepWorldEevee"
-		else:
-			blend = "clouds_moon_sun.blend"
-			wname = "MCprepWorldCycles"
+    @tracking.report_error
+    def execute(self, context):
+        # must be in object mode
+        if context.mode != "OBJECT":
+            bpy.ops.object.mode_set(mode="OBJECT")
 
-		blendfile = os.path.join(
-			os.path.dirname(__file__), "MCprep_resources", blend)
+        new_objs = []
+        if self.remove_existing_suns:
+            for lamp in context.scene.objects:
+                if lamp.type not in ("LAMP", "LIGHT") or lamp.data.type != "SUN":
+                    continue
+                util.obj_unlink_remove(lamp, True)
 
-		prev_world = None
-		if self.world_type in ("world_static_mesh", "world_static_only"):
-			# Create world dynamically (previous, simpler implementation)
-			new_sun = self.create_sunlamp(context)
-			new_objs.append(new_sun)
+        engine = context.scene.render.engine
+        wname = None
+        if engine == "BLENDER_EEVEE":
+            blend = "clouds_moon_sun_eevee.blend"
+            wname = "MCprepWorldEevee"
+        else:
+            blend = "clouds_moon_sun.blend"
+            wname = "MCprepWorldCycles"
 
-			if engine in ('BLENDER_RENDER', 'BLENDER_GAME'):
-				world = context.scene.world
-				if not world:
-					world = bpy.data.worlds.new("MCprep World")
-					context.scene.world = world
-				new_sun.data.shadow_method = 'RAY_SHADOW'
-				new_sun.data.shadow_soft_size = 0.5
-				world.use_sky_blend = False
-				world.horizon_color = (0.00938029, 0.0125943, 0.0140572)
-			bpy.ops.mcprep.world(skipUsage=True)  # do rest of sky setup
+        blendfile = os.path.join(os.path.dirname(__file__), "MCprep_resources", blend)
 
-		elif engine == 'CYCLES' or engine == 'BLENDER_EEVEE':
-			if not os.path.isfile(blendfile):
-				self.report(
-					{'ERROR'},
-					"Source MCprep world blend file does not exist: " + blendfile)
-				env.log(
-					"Source MCprep world blend file does not exist: " + blendfile)
-				return {'CANCELLED'}
-			if wname in bpy.data.worlds:
-				prev_world = bpy.data.worlds[wname]
-				prev_world.name = "-old"
-			new_objs += self.create_dynamic_world(context, blendfile, wname)
+        prev_world = None
+        if self.world_type in ("world_static_mesh", "world_static_only"):
+            # Create world dynamically (previous, simpler implementation)
+            new_sun = self.create_sunlamp(context)
+            new_objs.append(new_sun)
 
-		elif engine == 'BLENDER_RENDER' or engine == 'BLENDER_GAME':
-			# dynamic world using built-in sun sky and atmosphere
-			new_sun = self.create_sunlamp(context)
-			new_objs.append(new_sun)
-			new_sun.data.shadow_method = 'RAY_SHADOW'
-			new_sun.data.shadow_soft_size = 0.5
+            if engine in ("BLENDER_RENDER", "BLENDER_GAME"):
+                world = context.scene.world
+                if not world:
+                    world = bpy.data.worlds.new("MCprep World")
+                    context.scene.world = world
+                new_sun.data.shadow_method = "RAY_SHADOW"
+                new_sun.data.shadow_soft_size = 0.5
+                world.use_sky_blend = False
+                world.horizon_color = (0.00938029, 0.0125943, 0.0140572)
+            bpy.ops.mcprep.world(skipUsage=True)  # do rest of sky setup
 
-			world = context.scene.world
-			if not world:
-				world = bpy.data.worlds.new("MCprep World")
-				context.scene.world = world
-			world.use_sky_blend = False
-			world.horizon_color = (0.00938029, 0.0125943, 0.0140572)
+        elif engine == "CYCLES" or engine == "BLENDER_EEVEE":
+            if not os.path.isfile(blendfile):
+                self.report(
+                    {"ERROR"},
+                    "Source MCprep world blend file does not exist: " + blendfile,
+                )
+                env.log("Source MCprep world blend file does not exist: " + blendfile)
+                return {"CANCELLED"}
+            if wname in bpy.data.worlds:
+                prev_world = bpy.data.worlds[wname]
+                prev_world.name = "-old"
+            new_objs += self.create_dynamic_world(context, blendfile, wname)
 
-			# be sure to turn off all other sun lamps with atmosphere set
-			new_sun.data.sky.use_sky = True  # use sun orientation settings if BI
-			for lamp in context.scene.objects:
-				if lamp.type not in ("LAMP", "LIGHT") or lamp.data.type != "SUN":
-					continue
-				if lamp == new_sun:
-					continue
-				lamp.data.sky.use_sky = False
+        elif engine == "BLENDER_RENDER" or engine == "BLENDER_GAME":
+            # dynamic world using built-in sun sky and atmosphere
+            new_sun = self.create_sunlamp(context)
+            new_objs.append(new_sun)
+            new_sun.data.shadow_method = "RAY_SHADOW"
+            new_sun.data.shadow_soft_size = 0.5
 
-			time_obj = get_time_object()
-			if not time_obj:
-				env.log(
-					"TODO: implement create time_obj, parent sun to it & driver setup")
+            world = context.scene.world
+            if not world:
+                world = bpy.data.worlds.new("MCprep World")
+                context.scene.world = world
+            world.use_sky_blend = False
+            world.horizon_color = (0.00938029, 0.0125943, 0.0140572)
 
-		if self.world_type in ("world_static_mesh", "world_mesh"):
-			if not os.path.isfile(blendfile):
-				self.report(
-					{'ERROR'},
-					"Source MCprep world blend file does not exist: " + blendfile)
-				env.log(
-					"Source MCprep world blend file does not exist: " + blendfile)
-				return {'CANCELLED'}
-			resource = blendfile + "/Object"
+            # be sure to turn off all other sun lamps with atmosphere set
+            new_sun.data.sky.use_sky = True  # use sun orientation settings if BI
+            for lamp in context.scene.objects:
+                if lamp.type not in ("LAMP", "LIGHT") or lamp.data.type != "SUN":
+                    continue
+                if lamp == new_sun:
+                    continue
+                lamp.data.sky.use_sky = False
 
-			util.bAppendLink(resource, "MoonMesh", False)
-			non_empties = [
-				ob for ob in context.selected_objects if ob.type != 'EMPTY']
-			if non_empties:
-				moonmesh = non_empties[0]
-				tobj = get_time_object()
-				if tobj != moonmesh:
-					# Sometimes would error, see report -MfO6dDjpxFF4lfqqYGM
-					moonmesh.parent = tobj
-				new_objs.append(moonmesh)
-			else:
-				self.report({'WARNING'}, "Could not add moon")
+            time_obj = get_time_object()
+            if not time_obj:
+                env.log(
+                    "TODO: implement create time_obj, parent sun to it & driver setup"
+                )
 
-			util.bAppendLink(resource, "SunMesh", False)
-			non_empties = [
-				ob for ob in context.selected_objects if ob.type != 'EMPTY']
-			if non_empties:
-				sunmesh = non_empties[0]
-				tobj = get_time_object()
-				if tobj != moonmesh:
-					sunmesh.parent = tobj
-				new_objs.append(sunmesh)
-			else:
-				self.report({'WARNING'}, "Could not add sun")
+        if self.world_type in ("world_static_mesh", "world_mesh"):
+            if not os.path.isfile(blendfile):
+                self.report(
+                    {"ERROR"},
+                    "Source MCprep world blend file does not exist: " + blendfile,
+                )
+                env.log("Source MCprep world blend file does not exist: " + blendfile)
+                return {"CANCELLED"}
+            resource = blendfile + "/Object"
 
-		if prev_world:
-			bpy.data.worlds.remove(prev_world)
+            util.bAppendLink(resource, "MoonMesh", False)
+            non_empties = [ob for ob in context.selected_objects if ob.type != "EMPTY"]
+            if non_empties:
+                moonmesh = non_empties[0]
+                tobj = get_time_object()
+                if tobj != moonmesh:
+                    # Sometimes would error, see report -MfO6dDjpxFF4lfqqYGM
+                    moonmesh.parent = tobj
+                new_objs.append(moonmesh)
+            else:
+                self.report({"WARNING"}, "Could not add moon")
 
-		if self.add_clouds:
-			resource = blendfile + "/Object"
-			util.bAppendLink(resource, "clouds", False)
-			new_objs += list(context.selected_objects)
-			if engine in ('BLENDER_RENDER', 'BLENDER_GAME'):
-				materials = util.materialsFromObj(context.selected_objects)
-				for mat in materials:
-					mat.use_nodes = False
-					mat.use_shadeless = False
-					mat.translucency = 1
+            util.bAppendLink(resource, "SunMesh", False)
+            non_empties = [ob for ob in context.selected_objects if ob.type != "EMPTY"]
+            if non_empties:
+                sunmesh = non_empties[0]
+                tobj = get_time_object()
+                if tobj != moonmesh:
+                    sunmesh.parent = tobj
+                new_objs.append(sunmesh)
+            else:
+                self.report({"WARNING"}, "Could not add sun")
 
-			# Now also increase camera render distance to see clouds
-			cams = [obj for obj in bpy.data.objects if obj.type == "CAMERA"]
-			for cam in cams:
-				cam.data.clip_end = 1000  # 1000 matches explicitly to shader
+        if prev_world:
+            bpy.data.worlds.remove(prev_world)
 
-		# ensure all new objects (lights, meshes, control objs) in same group
-		if "mcprep_world" in util.collections():
-			util.collections()["mcprep_world"].name = "mcprep_world_old"
-		time_group = util.collections().new("mcprep_world")
-		for obj in new_objs:
-			time_group.objects.link(obj)
+        if self.add_clouds:
+            resource = blendfile + "/Object"
+            util.bAppendLink(resource, "clouds", False)
+            new_objs += list(context.selected_objects)
+            if engine in ("BLENDER_RENDER", "BLENDER_GAME"):
+                materials = util.materialsFromObj(context.selected_objects)
+                for mat in materials:
+                    mat.use_nodes = False
+                    mat.use_shadeless = False
+                    mat.translucency = 1
 
-		self.track_param = self.world_type
-		self.track_param = engine
-		return {'FINISHED'}
+            # Now also increase camera render distance to see clouds
+            cams = [obj for obj in bpy.data.objects if obj.type == "CAMERA"]
+            for cam in cams:
+                cam.data.clip_end = 1000  # 1000 matches explicitly to shader
 
-	def create_sunlamp(self, context):
-		"""Create new sun lamp from primitives"""
-		if hasattr(bpy.data, "lamps"):  # 2.7
-			newlamp = bpy.data.lamps.new("Sun", "SUN")
-		else:  # 2.8
-			newlamp = bpy.data.lights.new("Sun", "SUN")
-		obj = bpy.data.objects.new("Sunlamp", newlamp)
-		obj.location = (0, 0, 20)
-		obj.rotation_euler[0] = 0.481711
-		obj.rotation_euler[1] = 0.303687
-		obj.rotation_euler[1] = 0.527089
-		obj.data.energy = 1.0
-		# obj.data.color
-		util.obj_link_scene(obj, context)
-		util.scene_update(context)
-		if hasattr(obj, "use_contact_shadow"):
-			obj.use_contact_shadow = True
-		return obj
+        # ensure all new objects (lights, meshes, control objs) in same group
+        if "mcprep_world" in util.collections():
+            util.collections()["mcprep_world"].name = "mcprep_world_old"
+        time_group = util.collections().new("mcprep_world")
+        for obj in new_objs:
+            time_group.objects.link(obj)
 
-	def create_dynamic_world(self, context, blendfile, wname):
-		"""Setup fpr creating a dynamic world and setting up driver targets"""
-		resource = blendfile + "/World"
-		obj_list = []
+        self.track_param = self.world_type
+        self.track_param = engine
+        return {"FINISHED"}
 
-		global time_obj_cache
-		if time_obj_cache:
-			try:
-				util.obj_unlink_remove(time_obj_cache, True, context)
-			except Exception as e:
-				print("Error, could not unlink time_obj_cache " + str(time_obj_cache))
-				print(e)
+    def create_sunlamp(self, context):
+        """Create new sun lamp from primitives"""
+        if hasattr(bpy.data, "lamps"):  # 2.7
+            newlamp = bpy.data.lamps.new("Sun", "SUN")
+        else:  # 2.8
+            newlamp = bpy.data.lights.new("Sun", "SUN")
+        obj = bpy.data.objects.new("Sunlamp", newlamp)
+        obj.location = (0, 0, 20)
+        obj.rotation_euler[0] = 0.481711
+        obj.rotation_euler[1] = 0.303687
+        obj.rotation_euler[1] = 0.527089
+        obj.data.energy = 1.0
+        # obj.data.color
+        util.obj_link_scene(obj, context)
+        util.scene_update(context)
+        if hasattr(obj, "use_contact_shadow"):
+            obj.use_contact_shadow = True
+        return obj
 
-		time_obj_cache = None  # force reset to use newer cache object
+    def create_dynamic_world(self, context, blendfile, wname):
+        """Setup fpr creating a dynamic world and setting up driver targets"""
+        resource = blendfile + "/World"
+        obj_list = []
 
-		# Append the world (and time control elements)
-		util.bAppendLink(resource, wname, False)
-		obj_list += list(context.selected_objects)
+        global time_obj_cache
+        if time_obj_cache:
+            try:
+                util.obj_unlink_remove(time_obj_cache, True, context)
+            except Exception as e:
+                print("Error, could not unlink time_obj_cache " + str(time_obj_cache))
+                print(e)
 
-		if wname in bpy.data.worlds:
-			context.scene.world = bpy.data.worlds[wname]
-			context.scene.world["mcprep_world"] = True
-		else:
-			self.report({'ERROR'}, "Failed to import new world")
-			env.log("Failed to import new world")
+        time_obj_cache = None  # force reset to use newer cache object
 
-		# assign sun/moon shader accordingly
-		use_shader = 1 if self.world_type == "world_shader" else 0
-		for node in context.scene.world.node_tree.nodes:
-			if node.type != "GROUP":
-				continue
-			node.inputs[3].default_value = use_shader
+        # Append the world (and time control elements)
+        util.bAppendLink(resource, wname, False)
+        obj_list += list(context.selected_objects)
 
-		# set initial times of day, if dynamic
-		# time_obj = get_time_object()
-		# time_obj["MCprepHour"] = float(self.initial_time)
+        if wname in bpy.data.worlds:
+            context.scene.world = bpy.data.worlds[wname]
+            context.scene.world["mcprep_world"] = True
+        else:
+            self.report({"ERROR"}, "Failed to import new world")
+            env.log("Failed to import new world")
 
-		# # update drivers, needed if time has changed vs import source
-		# if context.scene.world.node_tree.animation_data:
-		#	# context.scene.world.node_tree.animation_data.drivers[0].update()
-		#	drivers = context.scene.world.node_tree.animation_data.drivers[0]
-		#	drivers.driver.variables[0].targets[0].id = time_obj
-		#	# nope, still doesn't work.
+        # assign sun/moon shader accordingly
+        use_shader = 1 if self.world_type == "world_shader" else 0
+        for node in context.scene.world.node_tree.nodes:
+            if node.type != "GROUP":
+                continue
+            node.inputs[3].default_value = use_shader
 
-		# if needed: create time object and setup drivers
-		# if not time_obj:
-		# 	env.log("Creating time_obj")
-		# 	time_obj = bpy.data.objects.new('MCprep Time Control', None)
-		# 	util.obj_link_scene(time_obj, context)
-		# 	global time_obj_cache
-		# 	time_obj_cache = time_obj
-		# 	if hasattr(time_obj, "empty_draw_type"):  # 2.7
-		# 		time_obj.empty_draw_type = 'SPHERE'
-		# 	else:  # 2.8
-		# 		time_obj.empty_display_type = 'SPHERE'
-		# first, get the driver
-		# if (not world.node_tree.animation_data
-		# 		or not world.node_tree.animation_data.drivers
-		# 		or not world.node_tree.animation_data.drivers[0].driver):
-		# 	env.log("Could not get driver from imported dynamic world")
-		# 	self.report({'WARNING'}, "Could not update driver for dynamic world")
-		# 	driver = None
-		# else:
-		#	driver = world.node_tree.animation_data.drivers[0].driver
-		# if driver and driver.variables[0].targets[0].id_type == 'OBJECT':
-		#	driver.variables[0].targets[0].id = time_obj
-		# add driver to control obj's x rotation
+        # set initial times of day, if dynamic
+        # time_obj = get_time_object()
+        # time_obj["MCprepHour"] = float(self.initial_time)
 
-		return obj_list
+        # # update drivers, needed if time has changed vs import source
+        # if context.scene.world.node_tree.animation_data:
+        # 	# context.scene.world.node_tree.animation_data.drivers[0].update()
+        # 	drivers = context.scene.world.node_tree.animation_data.drivers[0]
+        # 	drivers.driver.variables[0].targets[0].id = time_obj
+        # 	# nope, still doesn't work.
+
+        # if needed: create time object and setup drivers
+        # if not time_obj:
+        # 	env.log("Creating time_obj")
+        # 	time_obj = bpy.data.objects.new('MCprep Time Control', None)
+        # 	util.obj_link_scene(time_obj, context)
+        # 	global time_obj_cache
+        # 	time_obj_cache = time_obj
+        # 	if hasattr(time_obj, "empty_draw_type"):  # 2.7
+        # 		time_obj.empty_draw_type = 'SPHERE'
+        # 	else:  # 2.8
+        # 		time_obj.empty_display_type = 'SPHERE'
+        # first, get the driver
+        # if (not world.node_tree.animation_data
+        # 		or not world.node_tree.animation_data.drivers
+        # 		or not world.node_tree.animation_data.drivers[0].driver):
+        # 	env.log("Could not get driver from imported dynamic world")
+        # 	self.report({'WARNING'}, "Could not update driver for dynamic world")
+        # 	driver = None
+        # else:
+        # 	driver = world.node_tree.animation_data.drivers[0].driver
+        # if driver and driver.variables[0].targets[0].id_type == 'OBJECT':
+        # 	driver.variables[0].targets[0].id = time_obj
+        # add driver to control obj's x rotation
+
+        return obj_list
 
 
 class MCPREP_OT_time_set(bpy.types.Operator):
-	"""Set the time affecting light, sun and moon position, similar to in-game commands"""
-	bl_idname = "mcprep.time_set"
-	bl_label = "Set time of day"
-	bl_options = {'REGISTER', 'UNDO'}
+    """Set the time affecting light, sun and moon position, similar to in-game commands"""
 
-	# subject center to place lighting around
-	time_enum: bpy.props.EnumProperty(
-		name="Time selection",
-		description="Select between the different reflections",
-		items=[
-			("1000", "Day", "Time (day)=1,000, morning time"),
-			("6000", "Noon", "Time=6,000, sun is at zenith"),
-			# Approx matching resource:
-			("12000", "Sunset", "Time=12,000, sun starts setting"),
-			# matches command:
-			("13000", "Night", "Time (night)=13,000"),
-			# matches reference:
-			("18000", "Midnight", "Time=18,000, moon at zenish"),
-			("23000", "Sunrise", "Time set day=23,000, sun first visible")
-		])
-	day_offset: bpy.props.IntProperty(
-		name="Day offset",
-		description="Offset by number of days (ie +/- 24000*n)",
-		default=0)
+    bl_idname = "mcprep.time_set"
+    bl_label = "Set time of day"
+    bl_options = {"REGISTER", "UNDO"}
 
-	def invoke(self, context, event):
-		return context.window_manager.invoke_props_dialog(
-			self, width=400 * util.ui_scale())
+    # subject center to place lighting around
+    time_enum: bpy.props.EnumProperty(
+        name="Time selection",
+        description="Select between the different reflections",
+        items=[
+            ("1000", "Day", "Time (day)=1,000, morning time"),
+            ("6000", "Noon", "Time=6,000, sun is at zenith"),
+            # Approx matching resource:
+            ("12000", "Sunset", "Time=12,000, sun starts setting"),
+            # matches command:
+            ("13000", "Night", "Time (night)=13,000"),
+            # matches reference:
+            ("18000", "Midnight", "Time=18,000, moon at zenish"),
+            ("23000", "Sunrise", "Time set day=23,000, sun first visible"),
+        ],
+    )
+    day_offset: bpy.props.IntProperty(
+        name="Day offset",
+        description="Offset by number of days (ie +/- 24000*n)",
+        default=0,
+    )
 
-	def draw(self, context):
-		self.layout.prop(self, "time_enum")
-		self.layout.prop(self, "day_offset")
-		self.layout.prop(self, "keyframe")
+    def invoke(self, context, event):
+        return context.window_manager.invoke_props_dialog(
+            self, width=400 * util.ui_scale()
+        )
 
-	@tracking.report_error
-	def execute(self, context):
-		new_time = 24 * self.day_offset
-		new_time += int(self.time_enum)
-		context.scene.mcprep_props.world_time = new_time
-		if bpy.context.scene.tool_settings.use_keyframe_insert_auto:
-			if not context.scene.animation_data:
-				context.scene.animation_data_create()
-			anim_data = context.scene.animation_data
-			if not anim_data.action:
-				ac = bpy.data.actions.new("SceneAnimation")
-				anim_data.action = ac
-			context.scene.mcprep_props.keyframe_insert(
-				"world_time")
+    def draw(self, context):
+        self.layout.prop(self, "time_enum")
+        self.layout.prop(self, "day_offset")
+        self.layout.prop(self, "keyframe")
 
-		return {'FINISHED'}
+    @tracking.report_error
+    def execute(self, context):
+        new_time = 24 * self.day_offset
+        new_time += int(self.time_enum)
+        context.scene.mcprep_props.world_time = new_time
+        if bpy.context.scene.tool_settings.use_keyframe_insert_auto:
+            if not context.scene.animation_data:
+                context.scene.animation_data_create()
+            anim_data = context.scene.animation_data
+            if not anim_data.action:
+                ac = bpy.data.actions.new("SceneAnimation")
+                anim_data.action = ac
+            context.scene.mcprep_props.keyframe_insert("world_time")
+
+        return {"FINISHED"}
 
 
-class MCPREP_OT_render_helper():
-	render_queue = []
-	render_queue_cleanup = []
+class MCPREP_OT_render_helper:
+    render_queue = []
+    render_queue_cleanup = []
 
-	old_res_x = None
-	old_res_y = None
-	original_cam = None
+    old_res_x = None
+    old_res_y = None
+    original_cam = None
 
-	filepath = None
+    filepath = None
 
-	rendered_count = 0
-	rendering = False
-	current_render = {}
-	prior_frame = {}
-	previews = []
-	open_folder = False
+    rendered_count = 0
+    rendering = False
+    current_render = {}
+    prior_frame = {}
+    previews = []
+    open_folder = False
 
-	def cleanup_scene(self):
-		# Clean up
-		env.log("Cleanup pano rendering")
-		for i in range(len(self.render_queue_cleanup)):
-			util.obj_unlink_remove(self.render_queue_cleanup[i]["camera"], True)
+    def cleanup_scene(self):
+        # Clean up
+        env.log("Cleanup pano rendering")
+        for i in range(len(self.render_queue_cleanup)):
+            util.obj_unlink_remove(self.render_queue_cleanup[i]["camera"], True)
 
-		bpy.context.scene.render.resolution_x = self.old_res_x
-		bpy.context.scene.render.resolution_y = self.old_res_y
-		bpy.context.scene.camera = self.original_cam
+        bpy.context.scene.render.resolution_x = self.old_res_x
+        bpy.context.scene.render.resolution_y = self.old_res_y
+        bpy.context.scene.camera = self.original_cam
 
-		self.rendered_count = 0
+        self.rendered_count = 0
 
-		# Attempt to remove self from handlers.
-		try:
-			bpy.app.handlers.render_cancel.remove(self.cancel_render)
-			bpy.app.handlers.render_complete.remove(self.render_next_in_queue)
-		except ValueError as e:
-			print("Failed to remove handler:", e)
+        # Attempt to remove self from handlers.
+        try:
+            bpy.app.handlers.render_cancel.remove(self.cancel_render)
+            bpy.app.handlers.render_complete.remove(self.render_next_in_queue)
+        except ValueError as e:
+            print("Failed to remove handler:", e)
 
-		self.rendering = False
-		self.render_queue_cleanup = []
+        self.rendering = False
+        self.render_queue_cleanup = []
 
-		self.display_current(use_rendered=True)
-		for img in self.previews:
-			bpy.data.images.remove(img)
+        self.display_current(use_rendered=True)
+        for img in self.previews:
+            bpy.data.images.remove(img)
 
-		if self.open_folder:
-			bpy.ops.mcprep.openfolder(folder=self.filepath)
+        if self.open_folder:
+            bpy.ops.mcprep.openfolder(folder=self.filepath)
 
-	def create_panorama_cam(self, name, camera_data, rot, loc):
-		"""Create a camera"""
+    def create_panorama_cam(self, name, camera_data, rot, loc):
+        """Create a camera"""
 
-		camera = bpy.data.objects.new(name, camera_data)
-		camera.rotation_euler = rot
-		camera.location = loc
-		util.obj_link_scene(camera)
-		return camera
+        camera = bpy.data.objects.new(name, camera_data)
+        camera.rotation_euler = rot
+        camera.location = loc
+        util.obj_link_scene(camera)
+        return camera
 
-	def cancel_render(self, scene):
-		env.log("Cancelling pano render queue")
-		self.render_queue = []
-		self.cleanup_scene()
+    def cancel_render(self, scene):
+        env.log("Cancelling pano render queue")
+        self.render_queue = []
+        self.cleanup_scene()
 
-	def display_current(self, use_rendered=False):
-		"""Display the most recent image in a window."""
-		if self.rendered_count == 0:
-			bpy.ops.render.view_show("INVOKE_DEFAULT")
+    def display_current(self, use_rendered=False):
+        """Display the most recent image in a window."""
+        if self.rendered_count == 0:
+            bpy.ops.render.view_show("INVOKE_DEFAULT")
 
-		# Set up the window as needed.
-		area = None
-		for window in reversed(bpy.context.window_manager.windows):
-			this_area = window.screen.areas[0]
-			if this_area.type == "IMAGE_EDITOR":
-				area = this_area
-				break
-		if not area:
-			print("Could not fetch area tod isplay interim pano render")
-			return
+        # Set up the window as needed.
+        area = None
+        for window in reversed(bpy.context.window_manager.windows):
+            this_area = window.screen.areas[0]
+            if this_area.type == "IMAGE_EDITOR":
+                area = this_area
+                break
+        if not area:
+            print("Could not fetch area tod isplay interim pano render")
+            return
 
-		if self.rendering:
-			header_text = "Pano render in progress: {}/6 done".format(
-				self.rendered_count)
-		else:
-			header_text = "Pano render finished"
+        if self.rendering:
+            header_text = "Pano render in progress: {}/6 done".format(
+                self.rendered_count
+            )
+        else:
+            header_text = "Pano render finished"
 
-		env.log(header_text)
-		area.header_text_set(header_text)
-		area.show_menus = False
+        env.log(header_text)
+        area.header_text_set(header_text)
+        area.show_menus = False
 
-		if use_rendered:
-			img = bpy.data.images.get("Render Result")
-			if img:
-				area.spaces[0].image = img
-		elif self.rendered_count > 0 and self.prior_frame:
-			path = os.path.join(self.filepath, self.prior_frame["filename"])
-			print(path)
-			if not os.path.isfile(path):
-				print("Failed to find pano frame to load preview")
-			elif area:
-				img = bpy.data.images.load(path)  # DO cleanup.
-				area.spaces[0].image = img
-				self.previews.append(img)
+        if use_rendered:
+            img = bpy.data.images.get("Render Result")
+            if img:
+                area.spaces[0].image = img
+        elif self.rendered_count > 0 and self.prior_frame:
+            path = os.path.join(self.filepath, self.prior_frame["filename"])
+            print(path)
+            if not os.path.isfile(path):
+                print("Failed to find pano frame to load preview")
+            elif area:
+                img = bpy.data.images.load(path)  # DO cleanup.
+                area.spaces[0].image = img
+                self.previews.append(img)
 
-		for region in area.regions:
-			region.tag_redraw()
+        for region in area.regions:
+            region.tag_redraw()
 
-	def render_next_in_queue(self, scene, dummy):
-		"""Render the next image in the queue"""
-		if not self.rendering:
-			self.rendering = True  # The initial call.
-		else:
-			self.rendered_count += 1
-			self.prior_frame = self.current_render
+    def render_next_in_queue(self, scene, dummy):
+        """Render the next image in the queue"""
+        if not self.rendering:
+            self.rendering = True  # The initial call.
+        else:
+            self.rendered_count += 1
+            self.prior_frame = self.current_render
 
-		if not self.render_queue:
-			env.log("Finished pano render queue")
-			self.cleanup_scene()
-			return
+        if not self.render_queue:
+            env.log("Finished pano render queue")
+            self.cleanup_scene()
+            return
 
-		self.current_render = self.render_queue.pop()
+        self.current_render = self.render_queue.pop()
 
-		bpy.context.scene.camera = self.current_render["camera"]
+        bpy.context.scene.camera = self.current_render["camera"]
 
-		bpy.context.scene.render.filepath = os.path.join(
-			self.filepath, self.current_render["filename"])
+        bpy.context.scene.render.filepath = os.path.join(
+            self.filepath, self.current_render["filename"]
+        )
 
-		env.log("Starting pano render {}".format(self.current_render["filename"]))
-		self.display_current()
+        env.log("Starting pano render {}".format(self.current_render["filename"]))
+        self.display_current()
 
-		bpy.app.timers.register(
-			render_pano_frame_timer, first_interval=0.05, persistent=False)
+        bpy.app.timers.register(
+            render_pano_frame_timer, first_interval=0.05, persistent=False
+        )
 
 
 render_helper = MCPREP_OT_render_helper()
 
 
 def init_render_timer():
-	"""Helper for pano renders to offset the start of the queue from op run."""
-	env.log("Initial render timer started pano queue")
-	render_helper.render_next_in_queue(None, None)
+    """Helper for pano renders to offset the start of the queue from op run."""
+    env.log("Initial render timer started pano queue")
+    render_helper.render_next_in_queue(None, None)
 
 
 def render_pano_frame_timer():
-	"""Pano render timer callback, giving a chance to refresh display."""
-	bpy.ops.render.render(
-		'EXEC_DEFAULT', write_still=True, use_viewport=False)
+    """Pano render timer callback, giving a chance to refresh display."""
+    bpy.ops.render.render("EXEC_DEFAULT", write_still=True, use_viewport=False)
 
 
 class MCPREP_OT_render_panorama(bpy.types.Operator, ExportHelper):
-	"""Render the Panorama images for a texture Pack"""
-	bl_idname = "mcprep.render_panorama"
-	bl_label = "Render Panorama"
-	bl_description = "Render Panorama for texture Pack"
-	bl_options = {'REGISTER', 'UNDO'}
+    """Render the Panorama images for a texture Pack"""
 
-	panorama_resolution: bpy.props.IntProperty(
-		name="Render resolution",
-		description="The resolution of the output images",
-		default=1024
-	)
-	open_folder: bpy.props.BoolProperty(
-		name="Open folder when done",
-		description="Open the output folder when render completes",
-		default=False)
+    bl_idname = "mcprep.render_panorama"
+    bl_label = "Render Panorama"
+    bl_description = "Render Panorama for texture Pack"
+    bl_options = {"REGISTER", "UNDO"}
 
-	filepath: bpy.props.StringProperty(subtype='DIR_PATH')
-	filename_ext = ""  # Not used, but required by ExportHelper.
+    panorama_resolution: bpy.props.IntProperty(
+        name="Render resolution",
+        description="The resolution of the output images",
+        default=1024,
+    )
+    open_folder: bpy.props.BoolProperty(
+        name="Open folder when done",
+        description="Open the output folder when render completes",
+        default=False,
+    )
 
-	def draw(self, context):
-		col = self.layout.column()
-		col.scale_y = 0.8
-		col.label(text="Pick the output folder")
-		col.label(text="to place pano images.")
-		self.layout.prop(self, "panorama_resolution")
-		self.layout.prop(self, "open_folder")
+    filepath: bpy.props.StringProperty(subtype="DIR_PATH")
+    filename_ext = ""  # Not used, but required by ExportHelper.
 
-	def execute(self, context):
-		# Save old Values
-		render_helper.original_cam = bpy.context.scene.camera
-		render_helper.old_res_x = bpy.context.scene.render.resolution_x
-		render_helper.old_res_y = bpy.context.scene.render.resolution_y
-		render_helper.filepath = self.filepath
-		render_helper.open_folder = self.open_folder
+    def draw(self, context):
+        col = self.layout.column()
+        col.scale_y = 0.8
+        col.label(text="Pick the output folder")
+        col.label(text="to place pano images.")
+        self.layout.prop(self, "panorama_resolution")
+        self.layout.prop(self, "open_folder")
 
-		camera_data = bpy.data.cameras.new(name="panorama_cam")
-		camera_data.angle = math.pi / 2
+    def execute(self, context):
+        # Save old Values
+        render_helper.original_cam = bpy.context.scene.camera
+        render_helper.old_res_x = bpy.context.scene.render.resolution_x
+        render_helper.old_res_y = bpy.context.scene.render.resolution_y
+        render_helper.filepath = self.filepath
+        render_helper.open_folder = self.open_folder
 
-		pi_half = math.pi / 2
-		orig_pos = render_helper.original_cam.location
-		render_helper.render_queue.append({
-			"camera": render_helper.create_panorama_cam(
-				"panorama_0", camera_data, (pi_half, 0.0, 0.0), orig_pos),
-			"filename": "panorama_0.png"
-		})
-		render_helper.render_queue.append({
-			"camera": render_helper.create_panorama_cam(
-				"panorama_1", camera_data, (pi_half, 0.0, math.pi + pi_half), orig_pos),
-			"filename": "panorama_1.png"
-		})
-		render_helper.render_queue.append({
-			"camera": render_helper.create_panorama_cam(
-				"panorama_2", camera_data, (pi_half, 0.0, math.pi), orig_pos),
-			"filename": "panorama_2.png"
-		})
-		render_helper.render_queue.append({
-			"camera": render_helper.create_panorama_cam(
-				"panorama_3", camera_data, (pi_half, 0.0, pi_half), orig_pos),
-			"filename": "panorama_3.png"
-		})
-		render_helper.render_queue.append({
-			"camera": render_helper.create_panorama_cam(
-				"panorama_4", camera_data, (math.pi, 0.0, 0.0), orig_pos),
-			"filename": "panorama_4.png"
-		})
-		render_helper.render_queue.append({
-			"camera": render_helper.create_panorama_cam(
-				"panorama_5", camera_data, (0.0, 0.0, 0.0), orig_pos),
-			"filename": "panorama_5.png"
-		})
+        camera_data = bpy.data.cameras.new(name="panorama_cam")
+        camera_data.angle = math.pi / 2
 
-		render_helper.render_queue_cleanup = render_helper.render_queue.copy()
+        pi_half = math.pi / 2
+        orig_pos = render_helper.original_cam.location
+        render_helper.render_queue.append(
+            {
+                "camera": render_helper.create_panorama_cam(
+                    "panorama_0", camera_data, (pi_half, 0.0, 0.0), orig_pos
+                ),
+                "filename": "panorama_0.png",
+            }
+        )
+        render_helper.render_queue.append(
+            {
+                "camera": render_helper.create_panorama_cam(
+                    "panorama_1",
+                    camera_data,
+                    (pi_half, 0.0, math.pi + pi_half),
+                    orig_pos,
+                ),
+                "filename": "panorama_1.png",
+            }
+        )
+        render_helper.render_queue.append(
+            {
+                "camera": render_helper.create_panorama_cam(
+                    "panorama_2", camera_data, (pi_half, 0.0, math.pi), orig_pos
+                ),
+                "filename": "panorama_2.png",
+            }
+        )
+        render_helper.render_queue.append(
+            {
+                "camera": render_helper.create_panorama_cam(
+                    "panorama_3", camera_data, (pi_half, 0.0, pi_half), orig_pos
+                ),
+                "filename": "panorama_3.png",
+            }
+        )
+        render_helper.render_queue.append(
+            {
+                "camera": render_helper.create_panorama_cam(
+                    "panorama_4", camera_data, (math.pi, 0.0, 0.0), orig_pos
+                ),
+                "filename": "panorama_4.png",
+            }
+        )
+        render_helper.render_queue.append(
+            {
+                "camera": render_helper.create_panorama_cam(
+                    "panorama_5", camera_data, (0.0, 0.0, 0.0), orig_pos
+                ),
+                "filename": "panorama_5.png",
+            }
+        )
 
-		# Do the renderage
-		bpy.context.scene.render.resolution_x = self.panorama_resolution
-		bpy.context.scene.render.resolution_y = self.panorama_resolution
-		bpy.app.handlers.render_cancel.append(render_helper.cancel_render)
-		bpy.app.handlers.render_complete.append(render_helper.render_next_in_queue)
+        render_helper.render_queue_cleanup = render_helper.render_queue.copy()
 
-		render_helper.display_current()
+        # Do the renderage
+        bpy.context.scene.render.resolution_x = self.panorama_resolution
+        bpy.context.scene.render.resolution_y = self.panorama_resolution
+        bpy.app.handlers.render_cancel.append(render_helper.cancel_render)
+        bpy.app.handlers.render_complete.append(render_helper.render_next_in_queue)
 
-		bpy.app.timers.register(
-			init_render_timer, first_interval=0.05, persistent=False)
+        render_helper.display_current()
 
-		return {'FINISHED'}
+        bpy.app.timers.register(
+            init_render_timer, first_interval=0.05, persistent=False
+        )
+
+        return {"FINISHED"}
 
 
 # -----------------------------------------------------------------------------
@@ -1376,24 +1440,24 @@ class MCPREP_OT_render_panorama(bpy.types.Operator, ExportHelper):
 
 
 classes = (
-	MCPREP_OT_open_jmc2obj,
-	MCPREP_OT_install_jmc2obj,
-	MCPREP_OT_open_mineways,
-	MCPREP_OT_install_mineways,
-	MCPREP_OT_prep_world,
-	MCPREP_OT_add_mc_world,
-	MCPREP_OT_add_mc_sky,
-	MCPREP_OT_time_set,
-	MCPREP_OT_import_world_split,
-	MCPREP_OT_render_panorama,
+    MCPREP_OT_open_jmc2obj,
+    MCPREP_OT_install_jmc2obj,
+    MCPREP_OT_open_mineways,
+    MCPREP_OT_install_mineways,
+    MCPREP_OT_prep_world,
+    MCPREP_OT_add_mc_world,
+    MCPREP_OT_add_mc_sky,
+    MCPREP_OT_time_set,
+    MCPREP_OT_import_world_split,
+    MCPREP_OT_render_panorama,
 )
 
 
 def register():
-	for cls in classes:
-		bpy.utils.register_class(cls)
+    for cls in classes:
+        bpy.utils.register_class(cls)
 
 
 def unregister():
-	for cls in reversed(classes):
-		bpy.utils.unregister_class(cls)
+    for cls in reversed(classes):
+        bpy.utils.unregister_class(cls)

--- a/mcprep_data_refresh.py
+++ b/mcprep_data_refresh.py
@@ -22,93 +22,93 @@ JMC_1_13 = "https://raw.githubusercontent.com/jmc2obj/j-mc-2-obj/0fb2bd742f0d64b
 
 
 def save_file_str(url):
-	"""Save to temp location next to script."""
-	request = urllib.request.Request(url)
-	result = urllib.request.urlopen(request, timeout=10)
-	result_string = result.read()
-	result.close()
-	return result_string.decode()
+    """Save to temp location next to script."""
+    request = urllib.request.Request(url)
+    result = urllib.request.urlopen(request, timeout=10)
+    result_string = result.read()
+    result.close()
+    return result_string.decode()
 
 
 def get_jmc2obj_list():
-	"""Get the list of material names for jmc2obj"""
-	raw_str = save_file_str(JMC_URL)
-	root = ET.fromstring(raw_str)
-	outlist = {}
-	for block in root:
-		mats = block.findall("materials")
-		for itm in mats:
-			materials = itm.text.split()
-			outlist.update({sub.strip():None for sub in materials})
-		# if mats:
-		# 	outlist.update({itm.text:None for itm in mats})
-	return outlist
+    """Get the list of material names for jmc2obj"""
+    raw_str = save_file_str(JMC_URL)
+    root = ET.fromstring(raw_str)
+    outlist = {}
+    for block in root:
+        mats = block.findall("materials")
+        for itm in mats:
+            materials = itm.text.split()
+            outlist.update({sub.strip(): None for sub in materials})
+        # if mats:
+        # 	outlist.update({itm.text:None for itm in mats})
+    return outlist
 
 
 def get_jmc2obj_mapping():
-	"""Download the original texture mapping from the jmc2obj source code"""
-	raw_str = save_file_str(JMC_1_13)
-	root = ET.fromstring(raw_str)
-	outlist = {}
-	ln = len('assets/minecraft/textures/')
+    """Download the original texture mapping from the jmc2obj source code"""
+    raw_str = save_file_str(JMC_1_13)
+    root = ET.fromstring(raw_str)
+    outlist = {}
+    ln = len("assets/minecraft/textures/")
 
-	for tex in root:
-		src_tex = tex.get('name')
-		jmc_tex = list(tex)[0].get('name')
+    for tex in root:
+        src_tex = tex.get("name")
+        jmc_tex = list(tex)[0].get("name")
 
-		if not src_tex.endswith('.png'):
-			print("Not a png: "+src_tex)
-			raise Exception("Src file is not a png")
+        if not src_tex.endswith(".png"):
+            print("Not a png: " + src_tex)
+            raise Exception("Src file is not a png")
 
-		# note that block is not plural in this conf file, but is in tex packs
-		if src_tex.startswith('assets/minecraft/textures/block/'):
-			outlist[jmc_tex] = os.path.basename(src_tex)[:-4]
-		elif src_tex.startswith('assets/minecraft/textures/'):
-			if jmc_tex in outlist:
-				continue # don't duplicate for non blocks
-			outlist[jmc_tex] = src_tex[ln:-4]
+        # note that block is not plural in this conf file, but is in tex packs
+        if src_tex.startswith("assets/minecraft/textures/block/"):
+            outlist[jmc_tex] = os.path.basename(src_tex)[:-4]
+        elif src_tex.startswith("assets/minecraft/textures/"):
+            if jmc_tex in outlist:
+                continue  # don't duplicate for non blocks
+            outlist[jmc_tex] = src_tex[ln:-4]
 
-		# so, if it stars with "assets/minecraft/textures/block/",
-		# then truncate to just the basename
-		# else, join one level up (ie entity instead of block, etc)
-	return outlist
+        # so, if it stars with "assets/minecraft/textures/block/",
+        # then truncate to just the basename
+        # else, join one level up (ie entity instead of block, etc)
+    return outlist
+
 
 def jmc2obj_extras():
-	"""Known additional mappings for jmc2obj"""
-	outlist = {
-		"vines":"vine",
+    """Known additional mappings for jmc2obj"""
+    outlist = {
+        "vines": "vine",
+        # removed ~ Jan 15 2021,
+        # added back to maintain longer backwards compatibility
+        "cake_inside": "cake_inner",
+        "cauldron_feet": "cauldron_bottom",
+        "cauldron_inside": "cauldron_inner",
+        "door_wood_bottom": "oak_door_bottom",
+        "door_wood_top": "oak_door_top",
+        "enderchest": "entity/chest/ender",
+        "largechest": "entity/chest/normal_double",
+        "largechest_trapped": "entity/chest/trapped_double",
+        "plank_acacia": "acacia_planks",
+        "plank_birch": "birch_planks",
+        "plank_dark_oak": "dark_oak_planks",
+        "plank_jungle": "jungle_planks",
+        "plank_oak": "oak_planks",
+        "plank_spruce": "spruce_planks",
+        "quartz_bottom": "quartz_block_bottom",
+        "quartz_side": "quartz_block_side",
+        "quartz_side_chiseled": "chiseled_quartz_block",
+        "quartz_side_lines": "quartz_pillar",
+        "quartz_top": "quartz_block_top",
+        "quartz_top_chiseled": "chiseled_quartz_block_top",
+        "quartz_top_lines": "quartz_pillar_top",
+        "red_sandstone_carved": "chiseled_red_sandstone",
+        "sandstone_side": "sandstone",
+        "sandstone_side_carved": "chiseled_sandstone",
+        "stone_brick_circle": "chiseled_stone_bricks",
+        "stone_brick_cracked": "cracked_stone_bricks",
+    }
+    return outlist
 
-		# removed ~ Jan 15 2021,
-		# added back to maintain longer backwards compatibility
-		"cake_inside": "cake_inner",
-		"cauldron_feet": "cauldron_bottom",
-		"cauldron_inside": "cauldron_inner",
-		"door_wood_bottom": "oak_door_bottom",
-		"door_wood_top": "oak_door_top",
-		"enderchest": "entity/chest/ender",
-		"largechest": "entity/chest/normal_double",
-		"largechest_trapped": "entity/chest/trapped_double",
-		"plank_acacia": "acacia_planks",
-		"plank_birch": "birch_planks",
-		"plank_dark_oak": "dark_oak_planks",
-		"plank_jungle": "jungle_planks",
-		"plank_oak": "oak_planks",
-		"plank_spruce": "spruce_planks",
-		"quartz_bottom": "quartz_block_bottom",
-		"quartz_side": "quartz_block_side",
-		"quartz_side_chiseled": "chiseled_quartz_block",
-		"quartz_side_lines": "quartz_pillar",
-		"quartz_top": "quartz_block_top",
-		"quartz_top_chiseled": "chiseled_quartz_block_top",
-		"quartz_top_lines": "quartz_pillar_top",
-		"red_sandstone_carved": "chiseled_red_sandstone",
-		"sandstone_side": "sandstone",
-		"sandstone_side_carved": "chiseled_sandstone",
-		"stone_brick_circle": "chiseled_stone_bricks",
-		"stone_brick_cracked": "cracked_stone_bricks",
-
-	}
-	return outlist
 
 # def jmc2mc(name, vanilla):
 # 	"""Function that attemtps to map jmc2obj texture name to canonical"""
@@ -183,471 +183,513 @@ def jmc2obj_extras():
 
 
 def get_mineways_list(vanilla):
-	"""Get the list of material names for Mineways"""
-	raw_str = save_file_str(MINEWAYS_URL) # for individual file-based mats
-	outlist = {}
+    """Get the list of material names for Mineways"""
+    raw_str = save_file_str(MINEWAYS_URL)  # for individual file-based mats
+    outlist = {}
 
-	# This is super low-level page parsing, will break if source code changes
-	textblock = raw_str.split("} gTilesTable[TOTAL_TILES] = {")[1]
-	textblock = textblock.split("};")[0]
+    # This is super low-level page parsing, will break if source code changes
+    textblock = raw_str.split("} gTilesTable[TOTAL_TILES] = {")[1]
+    textblock = textblock.split("};")[0]
 
-	mats = []
-	for line in textblock.split('\n'):
-		if not ',' in line or not line.strip().startswith('{'):
-			continue
-		prename = line.split(',')[4] # fourth item in {0,0,0,L"block"}
-		name = prename.split('"')[1] # go from  ' L"lectern_sides"'  to 'lectern_sides'
-		presubname = line.split(',')[4]
-		presubname = presubname.split('"')[1]
+    mats = []
+    for line in textblock.split("\n"):
+        if not "," in line or not line.strip().startswith("{"):
+            continue
+        prename = line.split(",")[4]  # fourth item in {0,0,0,L"block"}
+        name = prename.split('"')[1]  # go from  ' L"lectern_sides"'  to 'lectern_sides'
+        presubname = line.split(",")[4]
+        presubname = presubname.split('"')[1]
 
-		# special, bespoke names like MWO_double_chest_top_left should be ignored
-		if presubname.lower().startswith("mwo_") or presubname.lower().startswith("mw_"):
-			continue
+        # special, bespoke names like MWO_double_chest_top_left should be ignored
+        if presubname.lower().startswith("mwo_") or presubname.lower().startswith(
+            "mw_"
+        ):
+            continue
 
-		if presubname:
-			# print("YES!: ", presubname)
-			name_sub = name+"_"+presubname
-			if name_sub in vanilla:
-				outlist[name_sub] = name_sub
-				#mats.append(name_sub)
-			elif name in vanilla:
-				outlist[name] = name
-				#mats.append(name)
-			else:
-				outlist[name.lower()] = name
-				#mats.append(name.lower())
-		else:
-			if name in vanilla:
-				outlist[name] = name
-				#mats.append(name)
-			else:
-				outlist[name.lower()] = name
-				#mats.append(name.lower()) # make it none?
-	return outlist
+        if presubname:
+            # print("YES!: ", presubname)
+            name_sub = name + "_" + presubname
+            if name_sub in vanilla:
+                outlist[name_sub] = name_sub
+                # mats.append(name_sub)
+            elif name in vanilla:
+                outlist[name] = name
+                # mats.append(name)
+            else:
+                outlist[name.lower()] = name
+                # mats.append(name.lower())
+        else:
+            if name in vanilla:
+                outlist[name] = name
+                # mats.append(name)
+            else:
+                outlist[name.lower()] = name
+                # mats.append(name.lower()) # make it none?
+    return outlist
+
 
 def mineways_extras():
-	"""Known additional mappings for Mineways"""
-	outlist = {
-		"Acacia_Door":"acacia_door_bottom",
-		"Activator_Rail":"activator_rail",
-		"Beacon":"beacon",
-		# do NOT include Bamboo, it's completely off (overloaded w/ campfire)
-		"Birch_Door":"birch_door_bottom",
-		"Brewing_Stand":"brewing_stand_base", # maybe don't? since only for meshswap
-		"Bookshelf":"bookshelf",
-		"Bricks":"bricks",
-		"Cactus":"cactus_side",
-		"Command_Block":"chain_command_block",
-		"Chain_Command_Block":"chain_command_block",
-		"Carrots":"carrots_stage3",
-		"Campfire":"campfire_log",
-		"Chest":"entity/chest/normal",
-		"MWO_chest_top":"entity/chest/normal",
-		# "MWO_double_chest_top_right":"entity/chest/chest_double", ensures only placing once
-		"MWO_double_chest_top_left":"entity/chest/normal_double",
-		"Cobweb":"cobweb",
-		"Crafting_Table":"crafting_table_top",
-		"Crafting_Table__Cartography_Table":"cartography_table_top",
-		"Crafting_Table__Fletching_Table":"fletching_table_top",
-		"Crafting_Table__Smithing_Table":"smithing_table_top",
-		"Dandelion":"dandelion",
-		"Dark_Oak_Door":"dark_oak_door_bottom",
-		"Dead_Bush":"dead_bush",
-		"Detector_Rail":"detector_rail",
-		"Enchanting_Table":"enchanting_table_top",
-		"End_Rod":"end_rod",
-		"Ender_Chest":"entity/chest/ender",
-		"Furnace":"furnace_front_on", # assume on? meshswap implication
-		"Furnace__Blast_Furnace":"blast_furnace_front_on", # assume on? meshswap implication
-		"Furnace__Loom":"loom_top",
-		"Furnace__Smoker":"smoker_front_on", # assume on? meshswap implication
-		"Fire":"fire_0",
-		"Glowstone":"glowstone",
-		"Grass__Fern":"fern", # single block high
-		"Grass__Tall_Grass":"grass", # ie tall grass
-		"Glass":"glass",
-		"Glass_Pane":"glass_pane_top",
-		"Lily_Pad":"lily_pad",
-		"Iron_Door":"iron_door_bottom",
-		"Jack_o'Lantern":"jack_o_lantern",
-		"Pumpkin":"carved_pumpkin",
-		"Kelp":"kelp",
-		# "Kelp__1":"",
-		"Ladder":"ladder",
-		"Lantern":"lantern",
-		"Large_Flowers":"sunflower", # decide block
-		"Large_Flowers__1":"",
-		"Large_Flowers__2":"",
-		"Large_Flowers__3":"large_fern_bottom",
-		"Large_Flowers__4":"",
-		"Large_Flowers__5":"",
-		"Magma_Block":"magma",
-		"Poppy":"poppy",
-		"Poppy__Allium":"allium",
-		"Poppy__Azure_Bluet":"azure_bluet",
-		"Poppy__Blue_Orchid":"blue_orchid",
-		"Poppy__Orange_Tulip":"orange_tulip",
-		"Poppy__Oxeye_Daisy":"oxeye_daisy",
-		"Poppy__Pink_Tulip":"pink_tulip",
-		"Poppy__Red_Tulip":"red_tulip",
-		"Poppy__White_Tulip":"white_tulip",
-		"Poppy__Wither_Rose":"wither_rose",
-		"Powered_Rail":"powered_rail",
-		"Rail":"rail",
-		"Redstone_Lamp_(active)":"redstone_lamp",
-		"Redstone_Lamp_(inactive)":"redstone_lamp_off",
-		"Redstone_Torch_(active)":"redstone_torch",
-		"Redstone_Torch_(inactive)":"redstone_torch_off",
-		"Sapling":"oak_sapling",
-		"Sapling__Acacia_Sapling":"acacia_sapling",
-		"Sapling__Birch_Sapling":"birch_sapling",
-		"Sapling__Dark_Oak_Sapling":"dark_oak_sapling",
-		"Sapling__Jungle_Sapling":"jungle_sapling",
-		"Sapling__Spruce_Sapling":"spruce_sapling",
-		"Spruce_Door":"spruce_door_bottom",
-		"Seagrass":"tall_seagrass_bottom",
-		"Sea_Pickle":"sea_pickle",
-		"Sea_Lantern":"sea_lantern",
-		"Sugar_Cane":"sugar_cane",
-		"Stationary_Lava":"lava_still",
-		"Stationary_Water":"water_still",
-		# "Stained_Glass*":"",
-		# "Stone_Bricks*":"",
-		"Stone_Cutter":"stonecutter_top", # should be a meshswap item evetually
-		"Sunflower":"sunflower_bottom",
-		"Trapped_Chest":"entity/chest/normal",
-		"Torch":"torch",
-		"TNT":"tnt_top",
-		"Vines":"vine",
-		"Wheat":"wheat_stage7",
-		"Wooden_Door":"oak_door_bottom",
-		"Campfire":"campfire_log"
-	}
-	return outlist
+    """Known additional mappings for Mineways"""
+    outlist = {
+        "Acacia_Door": "acacia_door_bottom",
+        "Activator_Rail": "activator_rail",
+        "Beacon": "beacon",
+        # do NOT include Bamboo, it's completely off (overloaded w/ campfire)
+        "Birch_Door": "birch_door_bottom",
+        "Brewing_Stand": "brewing_stand_base",  # maybe don't? since only for meshswap
+        "Bookshelf": "bookshelf",
+        "Bricks": "bricks",
+        "Cactus": "cactus_side",
+        "Command_Block": "chain_command_block",
+        "Chain_Command_Block": "chain_command_block",
+        "Carrots": "carrots_stage3",
+        "Campfire": "campfire_log",
+        "Chest": "entity/chest/normal",
+        "MWO_chest_top": "entity/chest/normal",
+        # "MWO_double_chest_top_right":"entity/chest/chest_double", ensures only placing once
+        "MWO_double_chest_top_left": "entity/chest/normal_double",
+        "Cobweb": "cobweb",
+        "Crafting_Table": "crafting_table_top",
+        "Crafting_Table__Cartography_Table": "cartography_table_top",
+        "Crafting_Table__Fletching_Table": "fletching_table_top",
+        "Crafting_Table__Smithing_Table": "smithing_table_top",
+        "Dandelion": "dandelion",
+        "Dark_Oak_Door": "dark_oak_door_bottom",
+        "Dead_Bush": "dead_bush",
+        "Detector_Rail": "detector_rail",
+        "Enchanting_Table": "enchanting_table_top",
+        "End_Rod": "end_rod",
+        "Ender_Chest": "entity/chest/ender",
+        "Furnace": "furnace_front_on",  # assume on? meshswap implication
+        "Furnace__Blast_Furnace": "blast_furnace_front_on",  # assume on? meshswap implication
+        "Furnace__Loom": "loom_top",
+        "Furnace__Smoker": "smoker_front_on",  # assume on? meshswap implication
+        "Fire": "fire_0",
+        "Glowstone": "glowstone",
+        "Grass__Fern": "fern",  # single block high
+        "Grass__Tall_Grass": "grass",  # ie tall grass
+        "Glass": "glass",
+        "Glass_Pane": "glass_pane_top",
+        "Lily_Pad": "lily_pad",
+        "Iron_Door": "iron_door_bottom",
+        "Jack_o'Lantern": "jack_o_lantern",
+        "Pumpkin": "carved_pumpkin",
+        "Kelp": "kelp",
+        # "Kelp__1":"",
+        "Ladder": "ladder",
+        "Lantern": "lantern",
+        "Large_Flowers": "sunflower",  # decide block
+        "Large_Flowers__1": "",
+        "Large_Flowers__2": "",
+        "Large_Flowers__3": "large_fern_bottom",
+        "Large_Flowers__4": "",
+        "Large_Flowers__5": "",
+        "Magma_Block": "magma",
+        "Poppy": "poppy",
+        "Poppy__Allium": "allium",
+        "Poppy__Azure_Bluet": "azure_bluet",
+        "Poppy__Blue_Orchid": "blue_orchid",
+        "Poppy__Orange_Tulip": "orange_tulip",
+        "Poppy__Oxeye_Daisy": "oxeye_daisy",
+        "Poppy__Pink_Tulip": "pink_tulip",
+        "Poppy__Red_Tulip": "red_tulip",
+        "Poppy__White_Tulip": "white_tulip",
+        "Poppy__Wither_Rose": "wither_rose",
+        "Powered_Rail": "powered_rail",
+        "Rail": "rail",
+        "Redstone_Lamp_(active)": "redstone_lamp",
+        "Redstone_Lamp_(inactive)": "redstone_lamp_off",
+        "Redstone_Torch_(active)": "redstone_torch",
+        "Redstone_Torch_(inactive)": "redstone_torch_off",
+        "Sapling": "oak_sapling",
+        "Sapling__Acacia_Sapling": "acacia_sapling",
+        "Sapling__Birch_Sapling": "birch_sapling",
+        "Sapling__Dark_Oak_Sapling": "dark_oak_sapling",
+        "Sapling__Jungle_Sapling": "jungle_sapling",
+        "Sapling__Spruce_Sapling": "spruce_sapling",
+        "Spruce_Door": "spruce_door_bottom",
+        "Seagrass": "tall_seagrass_bottom",
+        "Sea_Pickle": "sea_pickle",
+        "Sea_Lantern": "sea_lantern",
+        "Sugar_Cane": "sugar_cane",
+        "Stationary_Lava": "lava_still",
+        "Stationary_Water": "water_still",
+        # "Stained_Glass*":"",
+        # "Stone_Bricks*":"",
+        "Stone_Cutter": "stonecutter_top",  # should be a meshswap item evetually
+        "Sunflower": "sunflower_bottom",
+        "Trapped_Chest": "entity/chest/normal",
+        "Torch": "torch",
+        "TNT": "tnt_top",
+        "Vines": "vine",
+        "Wheat": "wheat_stage7",
+        "Wooden_Door": "oak_door_bottom",
+        "Campfire": "campfire_log",
+    }
+    return outlist
 
 
 def split_underscore_mappings(mineways_dict):
-	"""Returns the list, adding new items like Sapling__Spruce_Sapling to Spruce_Sapling"""
-	return {itm.split("__")[-1]:mineways_dict[itm] for itm in mineways_dict
-		if "__" in itm}
+    """Returns the list, adding new items like Sapling__Spruce_Sapling to Spruce_Sapling"""
+    return {
+        itm.split("__")[-1]: mineways_dict[itm] for itm in mineways_dict if "__" in itm
+    }
 
 
 def mineways2mc(name, vanilla):
-	"""Function that attemtps to map Mineways texture name to canonical"""
-	if name in vanilla:
-		return name
-	return None
+    """Function that attemtps to map Mineways texture name to canonical"""
+    if name in vanilla:
+        return name
+    return None
 
 
 def get_vanilla_list(copy_file=False):
-	"""Get the list of material names from vanilla Minecraft (local install)"""
-	outlist = {}
+    """Get the list of material names from vanilla Minecraft (local install)"""
+    outlist = {}
 
-	# OSX path
-	path = os.path.join(
-		os.path.expanduser('~'),
-		"Library", "Application Support", "minecraft", "versions")
-	if not os.path.isdir(path):
-		raise Exception('Could not get vanilla path')
+    # OSX path
+    path = os.path.join(
+        os.path.expanduser("~"),
+        "Library",
+        "Application Support",
+        "minecraft",
+        "versions",
+    )
+    if not os.path.isdir(path):
+        raise Exception("Could not get vanilla path")
 
-	versions = [ver for ver in os.listdir(path)
-				if os.path.isdir(os.path.join(path, ver))]
+    versions = [
+        ver for ver in os.listdir(path) if os.path.isdir(os.path.join(path, ver))
+    ]
 
-	# turn into sortable tuples
-	verion_tuples = []
-	for ver in versions:
-		temp = []
-		for itm in ver.split('.'):
-			try:
-				temp.append(int(itm))
-			except:
-				break
-		verion_tuples.append(tuple(temp))
+    # turn into sortable tuples
+    verion_tuples = []
+    for ver in versions:
+        temp = []
+        for itm in ver.split("."):
+            try:
+                temp.append(int(itm))
+            except:
+                break
+        verion_tuples.append(tuple(temp))
 
-	# parallel sort the list based on the generated tuple
-	verion_tuples, versions = zip(*sorted(zip(verion_tuples, versions)))
-	print(versions)
+    # parallel sort the list based on the generated tuple
+    verion_tuples, versions = zip(*sorted(zip(verion_tuples, versions)))
+    print(versions)
 
-	jarfile = None
-	for i, ver in reversed(list(enumerate(verion_tuples))):
-		ver_folder = os.path.join(path, versions[i])
-		any_jar = [jar for jar in os.listdir(ver_folder)
-			if jar.lower().endswith('.jar')]
-		if any_jar:
-			jarfile = os.path.join(path, versions[i], any_jar[0])
-			break
+    jarfile = None
+    for i, ver in reversed(list(enumerate(verion_tuples))):
+        ver_folder = os.path.join(path, versions[i])
+        any_jar = [
+            jar for jar in os.listdir(ver_folder) if jar.lower().endswith(".jar")
+        ]
+        if any_jar:
+            jarfile = os.path.join(path, versions[i], any_jar[0])
+            break
 
-	if not jarfile:
-		raise Exception("Could not get most recent jar version")
-	else:
-		print("Extracting from jar " + jarfile)
+    if not jarfile:
+        raise Exception("Could not get most recent jar version")
+    else:
+        print("Extracting from jar " + jarfile)
 
-	mcprep_resources = os.path.join(
-		"MCprep_addon", "MCprep_resources",
-		"resourcepacks", "mcprep_default")
-	tprefix = os.path.join("assets", "minecraft", "textures")
-	mprefix = os.path.join("assets", "minecraft", "models")
-	t_subfolders = [
-		"block", "entity", "environment", "item", "mob_effect", "models",
-		"painting", "particle"]
-	m_subfolders = ["block", "item"]  # Folders of json files to copy.
-	if copy_file:
-		for sub in t_subfolders:
-			if sub == "block":
-				continue  # Avoid deleting animated textures used by meshswap.
-			checkpath = os.path.join(mcprep_resources, tprefix, sub)
-			if os.path.isdir(checkpath):
-				# print("Removing MCprep resources folder: " + sub)
-				shutil.rmtree(checkpath)
-			else:
-				print("Error! Could not find " + checkpath)
+    mcprep_resources = os.path.join(
+        "MCprep_addon", "MCprep_resources", "resourcepacks", "mcprep_default"
+    )
+    tprefix = os.path.join("assets", "minecraft", "textures")
+    mprefix = os.path.join("assets", "minecraft", "models")
+    t_subfolders = [
+        "block",
+        "entity",
+        "environment",
+        "item",
+        "mob_effect",
+        "models",
+        "painting",
+        "particle",
+    ]
+    m_subfolders = ["block", "item"]  # Folders of json files to copy.
+    if copy_file:
+        for sub in t_subfolders:
+            if sub == "block":
+                continue  # Avoid deleting animated textures used by meshswap.
+            checkpath = os.path.join(mcprep_resources, tprefix, sub)
+            if os.path.isdir(checkpath):
+                # print("Removing MCprep resources folder: " + sub)
+                shutil.rmtree(checkpath)
+            else:
+                print("Error! Could not find " + checkpath)
 
-		# Now we also need to copy the model files (json files)
-		for sub in m_subfolders:
-			checkpath = os.path.join(mcprep_resources, mprefix, sub)
-			if os.path.isdir(checkpath):
-				# print("Removing MCprep models folder: " + sub)
-				shutil.rmtree(checkpath)
-			else:
-				print("Error! Could not find " + checkpath)
-		print("Removed MCprep resource folders, will copy over replacements")
+        # Now we also need to copy the model files (json files)
+        for sub in m_subfolders:
+            checkpath = os.path.join(mcprep_resources, mprefix, sub)
+            if os.path.isdir(checkpath):
+                # print("Removing MCprep models folder: " + sub)
+                shutil.rmtree(checkpath)
+            else:
+                print("Error! Could not find " + checkpath)
+        print("Removed MCprep resource folders, will copy over replacements")
 
-	print("Got jar version: {}".format(os.path.basename(jarfile)))
-	archive = zipfile.ZipFile(jarfile, 'r')
+    print("Got jar version: {}".format(os.path.basename(jarfile)))
+    archive = zipfile.ZipFile(jarfile, "r")
 
-	for name in archive.namelist():
-		if not (name.endswith('.png') or name.endswith('.mcmeta') or name.endswith('.json')):
-			continue
-		base = os.path.splitext(os.path.basename(name))[0]
-		tsub = name.startswith(tprefix) and os.path.basename(os.path.dirname(name)) in t_subfolders
-		msub = name.startswith(mprefix) and os.path.basename(os.path.dirname(name)) in m_subfolders
-		tsubsub = name.startswith(tprefix) and os.path.basename(os.path.dirname(os.path.dirname(name))) in t_subfolders
+    for name in archive.namelist():
+        if not (
+            name.endswith(".png") or name.endswith(".mcmeta") or name.endswith(".json")
+        ):
+            continue
+        base = os.path.splitext(os.path.basename(name))[0]
+        tsub = (
+            name.startswith(tprefix)
+            and os.path.basename(os.path.dirname(name)) in t_subfolders
+        )
+        msub = (
+            name.startswith(mprefix)
+            and os.path.basename(os.path.dirname(name)) in m_subfolders
+        )
+        tsubsub = (
+            name.startswith(tprefix)
+            and os.path.basename(os.path.dirname(os.path.dirname(name))) in t_subfolders
+        )
 
-		if copy_file is True and (tsub or msub or tsubsub) is True:
-			# TODO: Further ensure subfolder is one of mcp_subfolders
-			# copy file to MCprep resource directory
-			new_path = os.path.join(mcprep_resources, name)
-			os.makedirs(os.path.dirname(new_path), exist_ok=True)
-			with archive.open(name) as zf, open(new_path, 'wb') as f:
-				shutil.copyfileobj(zf, f)
-			# print("\tCopied "+name)
+        if copy_file is True and (tsub or msub or tsubsub) is True:
+            # TODO: Further ensure subfolder is one of mcp_subfolders
+            # copy file to MCprep resource directory
+            new_path = os.path.join(mcprep_resources, name)
+            os.makedirs(os.path.dirname(new_path), exist_ok=True)
+            with archive.open(name) as zf, open(new_path, "wb") as f:
+                shutil.copyfileobj(zf, f)
+            # print("\tCopied "+name)
 
-		# limit to textures only hereafter
-		if not name.endswith('.png'):
-			continue
+        # limit to textures only hereafter
+        if not name.endswith(".png"):
+            continue
 
-		if name.startswith(tprefix + os.sep + "block"):
-			outlist[base] = base
-		elif base in outlist:
-			continue  # don't duplicate for non blocks textures
-		elif name.startswith(tprefix + os.sep + "item"):
-			continue  # skip adding duplicative item mappings
-		elif name.startswith(tprefix):  # at least in textures folder
-			if 'lava' in name and 'particle' in name:
-				continue  # hack to avoid clash with jmc2obj lava:lava_still
-			outlist[base] = name[len(tprefix) + 1:-4]
-		else:
-			outlist[base] = None
-			# print("Not in textures folder: "+name)
-			# mostly just "realms" stuff
+        if name.startswith(tprefix + os.sep + "block"):
+            outlist[base] = base
+        elif base in outlist:
+            continue  # don't duplicate for non blocks textures
+        elif name.startswith(tprefix + os.sep + "item"):
+            continue  # skip adding duplicative item mappings
+        elif name.startswith(tprefix):  # at least in textures folder
+            if "lava" in name and "particle" in name:
+                continue  # hack to avoid clash with jmc2obj lava:lava_still
+            outlist[base] = name[len(tprefix) + 1 : -4]
+        else:
+            outlist[base] = None
+            # print("Not in textures folder: "+name)
+            # mostly just "realms" stuff
 
-	archive.close()
-	return outlist
+    archive.close()
+    return outlist
 
 
 def vanilla_overrides(vanilla_map):
-	"""go through and create the mapping with special overrides"""
-	outlist = vanilla_map.copy()
-	overrides = {
-		"fire":"fire_0",
-		"Campfire":"campfire_log"
-	}
-	outlist.update(overrides)
-	return outlist
+    """go through and create the mapping with special overrides"""
+    outlist = vanilla_map.copy()
+    overrides = {"fire": "fire_0", "Campfire": "campfire_log"}
+    outlist.update(overrides)
+    return outlist
 
 
 def get_current_json(backup=False):
-	"""Returns filepath of current json"""
-	suffix = "" if not backup else "backup"
-	filepath = os.path.join(
-		"MCprep_addon", "MCprep_resources",
-		"mcprep_data_update"+suffix+".json")
-	return filepath
+    """Returns filepath of current json"""
+    suffix = "" if not backup else "backup"
+    filepath = os.path.join(
+        "MCprep_addon", "MCprep_resources", "mcprep_data_update" + suffix + ".json"
+    )
+    return filepath
 
 
 def read_base_mapping():
-	"""Read in the existing mcprep_data_update.json file shipped with MCprep"""
-	filepath = "mcprep_data_base.json"
-	if not os.path.isfile(filepath):
-		raise Exception("File missing: "+filepath)
+    """Read in the existing mcprep_data_update.json file shipped with MCprep"""
+    filepath = "mcprep_data_base.json"
+    if not os.path.isfile(filepath):
+        raise Exception("File missing: " + filepath)
 
-	with open(filepath, 'r') as rawfile:
-		data = json.load(rawfile)
-	return data
+    with open(filepath, "r") as rawfile:
+        data = json.load(rawfile)
+    return data
+
 
 def get_cannon_block_mappping():
-	"""Returns a dict of the Block (not material) names to texturepack map"""
+    """Returns a dict of the Block (not material) names to texturepack map"""
 
-	# only include those special cases that need overrides,
-	# used in meshswap for display name
-	outlist = {
-		"entity/chest/normal":"chest",
-		"entity/chest/normal_double":"chest_double",
-		"fire_0":"fire"
-	}
-	return outlist
+    # only include those special cases that need overrides,
+    # used in meshswap for display name
+    outlist = {
+        "entity/chest/normal": "chest",
+        "entity/chest/normal_double": "chest_double",
+        "fire_0": "fire",
+    }
+    return outlist
 
 
 def run_all(auto=False):
-	"""Execute getting all of the texture lists and to compare."""
+    """Execute getting all of the texture lists and to compare."""
 
-	data = {"blocks": {}}
+    data = {"blocks": {}}
 
-	# loads in existing resource json, for truly hand-stated things
-	# ie reflection, emission, etc
-	base_override = read_base_mapping()
+    # loads in existing resource json, for truly hand-stated things
+    # ie reflection, emission, etc
+    base_override = read_base_mapping()
 
-	if auto:
-		xin = "n"
-	else:
-		xin = input("Copy latest vanilla textures to MCprep? (y): ")
+    if auto:
+        xin = "n"
+    else:
+        xin = input("Copy latest vanilla textures to MCprep? (y): ")
 
-	# consider also passing in pref to get specific version, for old names
-	vanilla = get_vanilla_list(xin=="y")
-	vanilla_map = vanilla_overrides(vanilla) # don't need to return as pass ref?
+    # consider also passing in pref to get specific version, for old names
+    vanilla = get_vanilla_list(xin == "y")
+    vanilla_map = vanilla_overrides(vanilla)  # don't need to return as pass ref?
 
-	# load material lists from online blobs
-	jmc = get_jmc2obj_mapping()  # Legacy, most jmc2obj mats are now live-parsed.
-	mineways = get_mineways_list(vanilla)
+    # load material lists from online blobs
+    jmc = get_jmc2obj_mapping()  # Legacy, most jmc2obj mats are now live-parsed.
+    mineways = get_mineways_list(vanilla)
 
-	# load the hard-coded lists
-	# hard_coded = ["reflective", "water", "emit", "desaturated",
-	# 	"animated_mineways_index", "solid", "metallic"]
-	# for setname in hard_coded:
-	# 	data["blocks"] = {}
-	# 	data["blocks"][setname] = existing["blocks"].get(setname)
+    # load the hard-coded lists
+    # hard_coded = ["reflective", "water", "emit", "desaturated",
+    # 	"animated_mineways_index", "solid", "metallic"]
+    # for setname in hard_coded:
+    # 	data["blocks"] = {}
+    # 	data["blocks"][setname] = existing["blocks"].get(setname)
 
-	# now update the main blocks with the known mappings only
-	# already exact, but could do cross check for any current MC canonical missing
-	data["blocks"]["block_mapping_jmc"] = jmc
-	data["blocks"]["block_mapping_jmc"].update(jmc2obj_extras())
+    # now update the main blocks with the known mappings only
+    # already exact, but could do cross check for any current MC canonical missing
+    data["blocks"]["block_mapping_jmc"] = jmc
+    data["blocks"]["block_mapping_jmc"].update(jmc2obj_extras())
 
-	# data["blocks"]["block_mapping_jmc"] = {
-	# 	mat:jmc2mc(mat, vanilla) for mat in jmc
-	# 	if jmc2mc(mat, vanilla) is not None}
-	data["blocks"]["block_mapping_mineways"] = mineways
-	data["blocks"]["block_mapping_mineways"].update(mineways_extras())
-	data["blocks"]["block_mapping_mineways"].update(
-		split_underscore_mappings(data["blocks"]["block_mapping_mineways"]))
+    # data["blocks"]["block_mapping_jmc"] = {
+    # 	mat:jmc2mc(mat, vanilla) for mat in jmc
+    # 	if jmc2mc(mat, vanilla) is not None}
+    data["blocks"]["block_mapping_mineways"] = mineways
+    data["blocks"]["block_mapping_mineways"].update(mineways_extras())
+    data["blocks"]["block_mapping_mineways"].update(
+        split_underscore_mappings(data["blocks"]["block_mapping_mineways"])
+    )
 
-	data["blocks"]["block_mapping_mc"] = vanilla_map
-	data["blocks"]["canon_mapping_block"] = get_cannon_block_mappping()
-	# data["blocks"]["block_mapping_mineways"] = {
-	# 	mat:mineways2mc(mat, vanilla) for mat in mineways
-	# 	if mineways2mc(mat, vanilla) is not None}
+    data["blocks"]["block_mapping_mc"] = vanilla_map
+    data["blocks"]["canon_mapping_block"] = get_cannon_block_mappping()
+    # data["blocks"]["block_mapping_mineways"] = {
+    # 	mat:mineways2mc(mat, vanilla) for mat in mineways
+    # 	if mineways2mc(mat, vanilla) is not None}
 
-	# Update all fields coming from base override
-	for key in base_override.keys():
-		if key in data:
-			data[key].update(base_override[key])
-		else:
-			data[key] = base_override[key]
+    # Update all fields coming from base override
+    for key in base_override.keys():
+        if key in data:
+            data[key].update(base_override[key])
+        else:
+            data[key] = base_override[key]
 
-	vanilla_blocks = [vanilla[itm] for itm in vanilla
-			if itm is not None
-			and vanilla[itm] is not None
-			and ("/" not in vanilla[itm] or vanilla[itm].startswith("blocks"))]
+    vanilla_blocks = [
+        vanilla[itm]
+        for itm in vanilla
+        if itm is not None
+        and vanilla[itm] is not None
+        and ("/" not in vanilla[itm] or vanilla[itm].startswith("blocks"))
+    ]
 
-	bl = data["blocks"]
-	print_str = """Found the following:
+    bl = data["blocks"]
+    print_str = """Found the following:
 	{jmc} jmc2obj blocks
 	{mine} Mineways blocks
 	{MC} mc textures,
 	{BLK} are blocks
 	""".format(
-		jmc=len(bl["block_mapping_jmc"]),
-		mine=len(bl["block_mapping_mineways"]),
-		MC=len(vanilla),
-		BLK=len(vanilla_blocks))
-	print(print_str)
-	# same for the other two..
+        jmc=len(bl["block_mapping_jmc"]),
+        mine=len(bl["block_mapping_mineways"]),
+        MC=len(vanilla),
+        BLK=len(vanilla_blocks),
+    )
+    print(print_str)
+    # same for the other two..
 
-	# Goal: generate, best we can, the actual mapping file to use for materials
+    # Goal: generate, best we can, the actual mapping file to use for materials
 
-	# save the output
-	fileout = "mcprep_data_update_staging.json"
-	fileout = os.path.abspath(fileout)
-	with open(fileout, "w") as dmp:
-		json.dump(data, dmp, indent="\t", sort_keys=True)
-	print("Output file:")
-	print(fileout)
+    # save the output
+    fileout = "mcprep_data_update_staging.json"
+    fileout = os.path.abspath(fileout)
+    with open(fileout, "w") as dmp:
+        json.dump(data, dmp, indent="\t", sort_keys=True)
+    print("Output file:")
+    print(fileout)
 
-	if auto:
-		xin = "n"
-	else:
-		xin = input("Show missing jmc2obj mappings? (y): ")
-	if xin == "y":
-		print("PRINTING jmc2obj MATERIALS WITH NO VANILLA MAPPING")
-		miss = [itm for itm in jmc
-			if os.path.basename(jmc[itm]) not in vanilla]
-		for itm in sorted(miss):
-			print("\t"+itm)
-		print("Total miss {}, versus {} total".format(
-			len(miss), len(jmc)))
+    if auto:
+        xin = "n"
+    else:
+        xin = input("Show missing jmc2obj mappings? (y): ")
+    if xin == "y":
+        print("PRINTING jmc2obj MATERIALS WITH NO VANILLA MAPPING")
+        miss = [itm for itm in jmc if os.path.basename(jmc[itm]) not in vanilla]
+        for itm in sorted(miss):
+            print("\t" + itm)
+        print("Total miss {}, versus {} total".format(len(miss), len(jmc)))
 
-		# now, find how many vanilla textures are NOT in jmc2obj
-		print("PRINTING vanilla MATERIALS NOT IN JMC2OBJ")
-		jmc_v = [jmc[itm] for itm in jmc]
-		miss = [vanilla[itm] for itm in vanilla
-			if itm not in jmc_v
-			and vanilla[itm] is not None
-			and ("/" not in vanilla[itm] or vanilla[itm].startswith("blocks"))]
-		for itm in sorted(miss):
-			print("\t"+itm)
-		print("Total miss {}, versus {} (blocks only)".format(
-			len(miss), len(vanilla_blocks)))
+        # now, find how many vanilla textures are NOT in jmc2obj
+        print("PRINTING vanilla MATERIALS NOT IN JMC2OBJ")
+        jmc_v = [jmc[itm] for itm in jmc]
+        miss = [
+            vanilla[itm]
+            for itm in vanilla
+            if itm not in jmc_v
+            and vanilla[itm] is not None
+            and ("/" not in vanilla[itm] or vanilla[itm].startswith("blocks"))
+        ]
+        for itm in sorted(miss):
+            print("\t" + itm)
+        print(
+            "Total miss {}, versus {} (blocks only)".format(
+                len(miss), len(vanilla_blocks)
+            )
+        )
 
-	if auto:
-		xin = "n"
-	else:
-		xin = input("Show missing Mineways mappings? (y): ")
-	if xin == "y":
-		print("PRINTING mineways MISSED MATERIALS")
-		miss = [itm for itm in mineways
-			if not mineways[itm]
-			or os.path.basename(mineways[itm]) not in vanilla]
-		for itm in sorted(miss):
-			print("\t"+itm)
-		print("\tTotal miss {}, versus {} total".format(
-			len(miss), len(mineways)))
+    if auto:
+        xin = "n"
+    else:
+        xin = input("Show missing Mineways mappings? (y): ")
+    if xin == "y":
+        print("PRINTING mineways MISSED MATERIALS")
+        miss = [
+            itm
+            for itm in mineways
+            if not mineways[itm] or os.path.basename(mineways[itm]) not in vanilla
+        ]
+        for itm in sorted(miss):
+            print("\t" + itm)
+        print("\tTotal miss {}, versus {} total".format(len(miss), len(mineways)))
 
-		# now, find how many vanilla textures are NOT in jmc2obj
-		print("PRINTING vanilla MATERIALS NOT IN MINEWAYS")
-		minew_v = [mineways[itm] for itm in mineways]
-		miss = [vanilla[itm] for itm in vanilla
-			if itm not in minew_v
-			and vanilla[itm] is not None
-			and ("/" not in vanilla[itm] or vanilla[itm].startswith("blocks"))]
-		for itm in sorted(miss):
-			print("\t"+itm)
-		print("Total miss {}, versus {} (blocks only)".format(
-			len(miss), len(vanilla_blocks)))
+        # now, find how many vanilla textures are NOT in jmc2obj
+        print("PRINTING vanilla MATERIALS NOT IN MINEWAYS")
+        minew_v = [mineways[itm] for itm in mineways]
+        miss = [
+            vanilla[itm]
+            for itm in vanilla
+            if itm not in minew_v
+            and vanilla[itm] is not None
+            and ("/" not in vanilla[itm] or vanilla[itm].startswith("blocks"))
+        ]
+        for itm in sorted(miss):
+            print("\t" + itm)
+        print(
+            "Total miss {}, versus {} (blocks only)".format(
+                len(miss), len(vanilla_blocks)
+            )
+        )
 
-	if auto:
-		xin = "y"
-	else:
-		xin = input("Replace current mapping file? (y): ")
-	if xin == "y":
-		main_file = get_current_json()
-		bup_file = get_current_json(backup=True)
-		if os.path.isfile(bup_file):
-			os.remove(bup_file)
-		os.rename(fileout, main_file)
-		print("Replaced file: "+main_file)
+    if auto:
+        xin = "y"
+    else:
+        xin = input("Replace current mapping file? (y): ")
+    if xin == "y":
+        main_file = get_current_json()
+        bup_file = get_current_json(backup=True)
+        if os.path.isfile(bup_file):
+            os.remove(bup_file)
+        os.rename(fileout, main_file)
+        print("Replaced file: " + main_file)
 
 
-if __name__ == '__main__':
-	if "-auto" in sys.argv:
-		run_all(auto=True)
-	else:
-		run_all()
+if __name__ == "__main__":
+    if "-auto" in sys.argv:
+        run_all(auto=True)
+    else:
+        run_all()

--- a/poetry.lock
+++ b/poetry.lock
@@ -80,30 +80,6 @@ files = [
 ]
 
 [[package]]
-name = "darker"
-version = "1.7.1"
-description = "Apply Black formatting only in regions changed since last commit"
-category = "main"
-optional = false
-python-versions = ">=3.7"
-files = [
-    {file = "darker-1.7.1-py3-none-any.whl", hash = "sha256:d72126418194871aeaf1e8aa620ad06edc5472848bef71c4d393c22b65571878"},
-    {file = "darker-1.7.1.tar.gz", hash = "sha256:cf4173be4ad2982e5b2ebab7e08bd0d27173f2459ec1b1cf66aec9290da80cce"},
-]
-
-[package.dependencies]
-black = ">=21.5b1"
-toml = ">=0.10.0"
-typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
-
-[package.extras]
-color = ["Pygments (>=2.4.0)"]
-flynt = ["flynt (>=0.76,<0.78)"]
-isort = ["isort (>=5.0.1)"]
-release = ["airium (>=0.2.3)", "click (>=8.0.0)", "defusedxml (>=0.7.1)", "requests-cache (>=0.7)"]
-test = ["airium (>=0.2.3)", "black (>=21.7b1)", "cryptography (>=3.3.2)", "defusedxml (>=0.7.1)", "flynt (>=0.76,<0.78)", "isort (>=5.0.1)", "pygments", "pytest (>=6.2.0)", "pytest-darker", "pytest-kwparametrize (>=0.0.3)", "regex (>=2021.4.4)", "requests-cache (>=0.7)", "ruamel.yaml (>=0.17.21)", "twine (>=2.0.0)", "types-requests (>=2.27.9)", "types-toml (>=0.10.4)", "urllib3 (>=1.25.9)", "wheel (>=0.21.0)"]
-
-[[package]]
 name = "fake-bpy-module-2-80"
 version = "20230117"
 description = "Collection of the fake Blender Python API module for the code completion."
@@ -192,18 +168,6 @@ docs = ["furo (>=2023.3.27)", "proselint (>=0.13)", "sphinx (>=6.1.3)", "sphinx-
 test = ["appdirs (==1.4.4)", "covdefaults (>=2.3)", "pytest (>=7.3.1)", "pytest-cov (>=4)", "pytest-mock (>=3.10)"]
 
 [[package]]
-name = "toml"
-version = "0.10.2"
-description = "Python Library for Tom's Obvious, Minimal Language"
-category = "main"
-optional = false
-python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
-files = [
-    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
-    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
-]
-
-[[package]]
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
@@ -280,4 +244,4 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.7"
-content-hash = "76aa01e904c61d0de4ecea595a4555250c18c1efd92cba5425ffd34ed39fa11e"
+content-hash = "f364a37f47e1fed5d459f148956581a13e79330f144564427ff540f6a5ef9214"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,8 +9,7 @@ readme = "README.md"
 [tool.poetry.dependencies]
 python = "^3.7"
 fake-bpy-module-2-80 = "^20230117"
-darker = "^1.7.1"
-
+black = "^23.3.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,13 +1,11 @@
 black==23.3.0
 click==8.1.3
-darker==1.7.1
 fake-bpy-module-2.80==20230117
 importlib-metadata==6.6.0
 mypy-extensions==1.0.0
 packaging==23.1
 pathspec==0.11.1
 platformdirs==3.5.0
-toml==0.10.2
 tomli==2.0.1
 typed-ast==1.5.4
 typing_extensions==4.5.0

--- a/test_files/addon_tests.py
+++ b/test_files/addon_tests.py
@@ -43,2339 +43,2412 @@ TEST_FILE = "test_results.tsv"
 # -----------------------------------------------------------------------------
 
 
-class mcprep_testing():
-	# {status}, func, prefunc caller (reference only)
-
-	def __init__(self):
-		self.suppress = True  # hold stdout
-		self.test_status = {}  # {func.__name__: {"check":-1, "res":-1,0,1}}
-		self.test_cases = [
-			self.enable_mcprep,
-			self.prep_materials,
-			self.prep_materials_pbr,
-			self.prep_missing_passes,
-			self.openfolder,
-			self.spawn_mob,
-			self.spawn_mob_linked,
-			self.check_blend_eligible,
-			self.check_blend_eligible_middle,
-			self.check_blend_eligible_real,
-			self.change_skin,
-			self.import_world_split,
-			self.import_world_fail,
-			self.import_jmc2obj,
-			self.import_mineways_separated,
-			self.import_mineways_combined,
-			self.name_generalize,
-			self.canonical_name_no_none,
-			self.canonical_test_mappings,
-			self.meshswap_spawner,
-			self.meshswap_jmc2obj,
-			self.meshswap_mineways_separated,
-			self.meshswap_mineways_combined,
-			self.detect_desaturated_images,
-			self.detect_extra_passes,
-			self.find_missing_images_cycles,
-			self.qa_meshswap_file,
-			self.item_spawner,
-			self.item_spawner_resize,
-			self.entity_spawner,
-			self.model_spawner,
-			self.geonode_effect_spawner,
-			self.particle_area_effect_spawner,
-			self.collection_effect_spawner,
-			self.img_sequence_effect_spawner,
-			self.particle_plane_effect_spawner,
-			self.sync_materials,
-			self.sync_materials_link,
-			self.load_material,
-			self.uv_transform_detection,
-			self.uv_transform_no_alert,
-			self.uv_transform_combined_alert,
-			self.world_tools,
-			self.test_enable_obj_importer,
-			self.test_generate_material_sequence,
-			self.qa_effects,
-			self.qa_rigs,
-			self.convert_mtl_simple,
-			self.convert_mtl_skip,
-		]
-		self.run_only = None  # Name to give to only run this test
-
-		self.mcprep_json = {}
-
-	def run_all_tests(self):
-		"""For use in command line mode, run all tests and checks"""
-		if self.run_only and self.run_only not in [tst.__name__ for tst in self.test_cases]:
-			print("{}No tests ran!{} Test function not found: {}".format(
-				COL.FAIL, COL.ENDC, self.run_only))
-
-		for test in self.test_cases:
-			if self.run_only and test.__name__ != self.run_only:
-				continue
-			self.mcrprep_run_test(test)
-
-		failed_tests = [
-			tst for tst in self.test_status
-			if self.test_status[tst]["check"] < 0]
-		passed_tests = [
-			tst for tst in self.test_status
-			if self.test_status[tst]["check"] > 0]
-
-		print("\n{}COMPLETED, {} passed and {} failed{}".format(
-			COL.HEADER,
-			len(passed_tests), len(failed_tests),
-			COL.ENDC))
-		if passed_tests:
-			print("{}Passed tests:{}".format(COL.OKGREEN, COL.ENDC))
-			print("\t" + ", ".join(passed_tests))
-		if failed_tests:
-			print("{}Failed tests:{}".format(COL.FAIL, COL.ENDC))
-			for tst in self.test_status:
-				if self.test_status[tst]["check"] > 0:
-					continue
-				ert = suffix_chars(self.test_status[tst]["res"], 70)
-				print("\t{}{}{}: {}".format(COL.UNDERLINE, tst, COL.ENDC, ert))
-
-		# indicate if all tests passed for this blender version
-		if not failed_tests:
-			with open(TEST_FILE, 'a') as tsv:
-				tsv.write("{}\t{}\t-\n".format(bpy.app.version, "ALL PASSED"))
-
-	def write_placeholder(self, test_name):
-		"""Append placeholder, presuming if not changed then blender crashed"""
-		with open(TEST_FILE, 'a') as tsv:
-			tsv.write("{}\t{}\t-\n".format(
-				bpy.app.version, "CRASH during " + test_name))
-
-	def update_placeholder(self, test_name, test_failure):
-		"""Update text of (if error) or remove placeholder row of file"""
-		with open(TEST_FILE, 'r') as tsv:
-			contents = tsv.readlines()
-
-		if not test_failure:  # None or ""
-			contents = contents[:-1]
-		else:
-			this_failure = "{}\t{}\t{}\n".format(
-				bpy.app.version, test_name, suffix_chars(test_failure, 20))
-			contents[-1] = this_failure
-		with open(TEST_FILE, 'w') as tsv:
-			for row in contents:
-				tsv.write(row)
-
-	def mcrprep_run_test(self, test_func):
-		"""Run a single MCprep test"""
-		print("\n{}Testing {}{}".format(COL.HEADER, test_func.__name__, COL.ENDC))
-		self.write_placeholder(test_func.__name__)
-		self._clear_scene()
-		try:
-			if self.suppress:
-				stdout = io.StringIO()
-				with redirect_stdout(stdout):
-					res = test_func()
-			else:
-				res = test_func()
-			if not res:
-				print("\t{}TEST PASSED{}".format(COL.OKGREEN, COL.ENDC))
-				self.test_status[test_func.__name__] = {"check": 1, "res": res}
-			else:
-				print("\t{}TEST FAILED:{}".format(COL.FAIL, COL.ENDC))
-				print("\t" + res)
-				self.test_status[test_func.__name__] = {"check": -1, "res": res}
-		except Exception:
-			print("\t{}TEST FAILED{}".format(COL.FAIL, COL.ENDC))
-			print(traceback.format_exc())  # other info, e.g. line number/file
-			res = traceback.format_exc()
-			self.test_status[test_func.__name__] = {"check": -1, "res": res}
-		# print("\tFinished test {}".format(test_func.__name__))
-		self.update_placeholder(test_func.__name__, res)
-
-	def setup_env_paths(self):
-		"""Adds the MCprep installed addon path to sys for easier importing."""
-		to_add = None
-
-		for base in bpy.utils.script_paths():
-			init = os.path.join(base, "addons", "MCprep_addon", "__init__.py")
-			if os.path.isfile(init):
-				to_add = init
-				break
-		if not to_add:
-			raise Exception("Could not add the environment path for direct importing")
-
-		# add to path and bind so it can use relative improts (3.5 trick)
-		spec = importlib.util.spec_from_file_location("MCprep", to_add)
-		module = importlib.util.module_from_spec(spec)
-		sys.modules[spec.name] = module
-		spec.loader.exec_module(module)
-
-		from MCprep import conf
-		conf.env = conf.MCprepEnv()
-
-	def get_mcprep_path(self):
-		"""Returns the addon basepath installed in this blender instance"""
-		for base in bpy.utils.script_paths():
-			init = os.path.join(
-				base, "addons", "MCprep_addon")  # __init__.py folder
-			if os.path.isdir(init):
-				return init
-		return None
-
-	# -----------------------------------------------------------------------------
-	# Testing utilities, not tests themselves (ie assumed to work)
-	# -----------------------------------------------------------------------------
-
-	def _clear_scene(self):
-		"""Clear scene and data without printouts"""
-		# if not self.suppress:
-		# stdout = io.StringIO()
-		# with redirect_stdout(stdout):
-		bpy.ops.wm.read_homefile(app_template="")
-		for obj in bpy.data.objects:
-			bpy.data.objects.remove(obj)
-		for mat in bpy.data.materials:
-			bpy.data.materials.remove(mat)
-			# for txt in bpy.data.texts:
-			# 	bpy.data.texts.remove(txt)
-
-	def _add_character(self):
-		"""Add a rigged character to the scene, specifically Alex"""
-		bpy.ops.mcprep.reload_mobs()
-		# mcmob_type='player/Simple Rig - Boxscape-TheDuckCow.blend:/:Simple Player'
-		# mcmob_type='player/Alex FancyFeet - TheDuckCow & VanguardEnni.blend:/:alex'
-		# Formatting os.path.sep below required for windows support.
-		mcmob_type = 'hostile{}mobs - Rymdnisse.blend:/:silverfish'.format(
-			os.path.sep)
-		bpy.ops.mcprep.mob_spawner(mcmob_type=mcmob_type)
-
-	def _import_jmc2obj_full(self):
-		"""Import the full jmc2obj test set"""
-		testdir = os.path.dirname(__file__)
-		obj_path = os.path.join(testdir, "jmc2obj", "jmc2obj_test_1_15_2.obj")
-		bpy.ops.mcprep.import_world_split(filepath=obj_path)
-
-	def _import_mineways_separated(self):
-		"""Import the full jmc2obj test set"""
-		testdir = os.path.dirname(__file__)
-		obj_path = os.path.join(
-			testdir, "mineways", "separated_textures",
-			"mineways_test_separated_1_15_2.obj")
-		bpy.ops.mcprep.import_world_split(filepath=obj_path)
-
-	def _import_mineways_combined(self):
-		"""Import the full jmc2obj test set"""
-		testdir = os.path.dirname(__file__)
-		obj_path = os.path.join(
-			testdir, "mineways", "combined_textures",
-			"mineways_test_combined_1_15_2.obj")
-		bpy.ops.mcprep.import_world_split(filepath=obj_path)
-
-	def _create_canon_mat(self, canon=None, test_pack=False):
-		"""Creates a material that should be recognized"""
-		name = canon if canon else "dirt"
-		mat = bpy.data.materials.new(name)
-		mat.use_nodes = True
-		img_node = mat.node_tree.nodes.new(type="ShaderNodeTexImage")
-		if canon and not test_pack:
-			base = self.get_mcprep_path()
-			filepath = os.path.join(
-				base, "MCprep_resources",
-				"resourcepacks", "mcprep_default", "assets", "minecraft", "textures",
-				"block", canon + ".png")
-			img = bpy.data.images.load(filepath)
-		elif canon and test_pack:
-			testdir = os.path.dirname(__file__)
-			filepath = os.path.join(
-				testdir, "test_resource_pack", "textures", canon + ".png")
-			img = bpy.data.images.load(filepath)
-		else:
-			img = bpy.data.images.new(name, 16, 16)
-		img_node.image = img
-		return mat, img_node
-
-	def _set_test_mcprep_texturepack_path(self, reset=False):
-		"""Assigns or resets the local texturepack path."""
-		testdir = os.path.dirname(__file__)
-		path = os.path.join(testdir, "test_resource_pack")
-		if not os.path.isdir(path):
-			raise Exception("Failed to set test texturepack path")
-		bpy.context.scene.mcprep_texturepack_path = path
-
-	# Seems that infolog doesn't update in background mode
-	def _get_last_infolog(self):
-		"""Return back the latest info window log"""
-		for txt in bpy.data.texts:
-			bpy.data.texts.remove(txt)
-		_ = bpy.ops.ui.reports_to_textblock()
-		print("DEVVVV get last infolog:")
-		for ln in bpy.data.texts['Recent Reports'].lines:
-			print(ln.body)
-		print("END printlines")
-		return bpy.data.texts['Recent Reports'].lines[-1].body
-
-	def _set_exporter(self, name):
-		"""Sets the exporter name"""
-		# from MCprep.util import get_user_preferences
-		if name not in ['(choose)', 'jmc2obj', 'Mineways']:
-			raise Exception('Invalid exporter set tyep')
-		context = bpy.context
-		if hasattr(context, "user_preferences"):
-			prefs = context.user_preferences.addons.get("MCprep_addon", None)
-		elif hasattr(context, "preferences"):
-			prefs = context.preferences.addons.get("MCprep_addon", None)
-		prefs.preferences.MCprep_exporter_type = name
-
-	def _debug_save_file_state(self):
-		"""Saves the current scene state to a test file for inspection."""
-		testdir = os.path.dirname(__file__)
-		path = os.path.join(testdir, "debug_save_state.blend")
-		bpy.ops.wm.save_as_mainfile(filepath=path)
-
-	# -----------------------------------------------------------------------------
-	# Operator unit tests
-	# -----------------------------------------------------------------------------
-
-	def enable_mcprep(self):
-		"""Ensure we can both enable and disable MCprep"""
-
-		# brute force enable
-		# stdout = io.StringIO()
-		# with redirect_stdout(stdout):
-		try:
-			if hasattr(bpy.ops, "preferences") and "addon_enable" in dir(bpy.ops.preferences):
-				bpy.ops.preferences.addon_enable(module="MCprep_addon")
-			else:
-				bpy.ops.wm.addon_enable(module="MCprep_addon")
-		except Exception:
-			pass
-
-		# see if we can safely toggle off and back on
-		if hasattr(bpy.ops, "preferences") and "addon_enable" in dir(bpy.ops.preferences):
-			bpy.ops.preferences.addon_disable(module="MCprep_addon")
-			bpy.ops.preferences.addon_enable(module="MCprep_addon")
-		else:
-			bpy.ops.wm.addon_disable(module="MCprep_addon")
-			bpy.ops.wm.addon_enable(module="MCprep_addon")
-
-	def prep_materials(self):
-		# run once when nothing is selected, no active object
-		self._clear_scene()
-
-		status = 'fail'
-		print("Checking blank usage")
-		try:
-			bpy.ops.mcprep.prep_materials(
-				animateTextures=False,
-				packFormat="simple",
-				autoFindMissingTextures=False,
-				improveUiSettings=False)
-		except RuntimeError as e:
-			if "Error: No objects selected" in str(e):
-				status = 'success'
-			else:
-				return "prep_materials other err: " + str(e)
-		if status == 'fail':
-			return "Prep should have failed with error on no objects"
-
-		# add object, no material. Should still fail as no materials
-		bpy.ops.mesh.primitive_plane_add()
-		obj = bpy.context.object
-		status = 'fail'
-		try:
-			res = bpy.ops.mcprep.prep_materials(
-				animateTextures=False,
-				packFormat="simple",
-				autoFindMissingTextures=False,
-				improveUiSettings=False)
-		except RuntimeError as e:
-			if 'No materials found' in str(e):
-				status = 'success'  # Expect to fail when nothing selected.
-		if status == 'fail':
-			return "mcprep.prep_materials-02 failure"
-
-		# TODO: Add test where material is added but without an image/nodes
-
-		# add object with canonical material name. Assume cycles
-		new_mat, _ = self._create_canon_mat()
-		obj.active_material = new_mat
-		status = 'fail'
-		try:
-			res = bpy.ops.mcprep.prep_materials(
-				animateTextures=False,
-				packFormat="simple",
-				autoFindMissingTextures=False,
-				improveUiSettings=False)
-		except Exception as e:
-			return "Unexpected error: " + str(e)
-		# how to tell if prepping actually occured? Should say 1 material prepped
-		# print(self._get_last_infolog()) # error in 2.82+, not used anyways
-		if res != {'FINISHED'}:
-			return "Did not return finished"
-
-	def prep_materials_pbr(self):
-		# add object with canonical material name. Assume cycles
-		self._clear_scene()
-		bpy.ops.mesh.primitive_plane_add()
-
-		obj = bpy.context.object
-		new_mat, _ = self._create_canon_mat()
-		obj.active_material = new_mat
-		try:
-			res = bpy.ops.mcprep.prep_materials(
-				animateTextures=False,
-				autoFindMissingTextures=False,
-				packFormat="specular",
-				improveUiSettings=False)
-		except Exception as e:
-			return "Unexpected error: " + str(e)
-		if res != {'FINISHED'}:
-			return "Did not return finished"
-
-		self._clear_scene()
-		bpy.ops.mesh.primitive_plane_add()
-
-		obj = bpy.context.object
-		new_mat, _ = self._create_canon_mat()
-		obj.active_material = new_mat
-		try:
-			res = bpy.ops.mcprep.prep_materials(
-				animateTextures=False,
-				autoFindMissingTextures=False,
-				packFormat="seus",
-				improveUiSettings=False)
-		except Exception as e:
-			return "Unexpected error: " + str(e)
-		if res != {'FINISHED'}:
-			return "Did not return finished"
-
-	def prep_missing_passes(self):
-		"""Test when prepping with passes after simple, n/s passes loaded."""
-
-		self._clear_scene()
-		bpy.ops.mesh.primitive_plane_add()
-
-		self._set_test_mcprep_texturepack_path()
-
-		obj = bpy.context.object
-		new_mat, _ = self._create_canon_mat("diamond_ore", test_pack=True)
-		obj.active_material = new_mat
-
-		# Start with simple material loaded, non pbr/no extra passes
-		try:
-			res = bpy.ops.mcprep.prep_materials(
-				animateTextures=False,
-				autoFindMissingTextures=False,
-				packFormat="simple",
-				useExtraMaps=False,
-				syncMaterials=False,
-				improveUiSettings=False)
-		except Exception as e:
-			return "Unexpected error: " + str(e)
-		if res != {'FINISHED'}:
-			return "Did not return finished"
-		count_images = 0
-		missing_images = 0
-		for node in new_mat.node_tree.nodes:
-			if node.type != "TEX_IMAGE":
-				continue
-			elif node.image:
-				count_images += 1
-			else:
-				missing_images += 1
-		if count_images != 1:
-			return "Should have only 1 pass after simple load - had {}".format(
-				count_images)
-		if missing_images != 0:
-			return (
-				"Should have only 0 unloaded passes after simple load - "
-				"had {}".format(count_images))
-
-		# Now try pbr load, should find the adjacent _n and _s passes and auto
-		# load it in.
-		self._set_test_mcprep_texturepack_path()
-		# return bpy.context.scene.mcprep_texturepack_path
-		try:
-			res = bpy.ops.mcprep.prep_materials(
-				animateTextures=False,
-				autoFindMissingTextures=False,
-				packFormat="specular",
-				useExtraMaps=True,
-				syncMaterials=False,  # For some reason, had to turn off.
-				improveUiSettings=False)
-		except Exception as e:
-			return "Unexpected error: " + str(e)
-		if res != {'FINISHED'}:
-			return "Did not return finished"
-		count_images = 0
-		missing_images = 0
-		new_mat = obj.active_material
-		for node in new_mat.node_tree.nodes:
-			if node.type != "TEX_IMAGE":
-				continue
-			elif node.image:
-				count_images += 1
-			else:
-				missing_images += 1
-		self._debug_save_file_state()
-		if count_images != 3:
-			return "Should have all 3 passes after pbr load - had {}".format(
-				count_images)
-		if missing_images != 0:
-			return "Should have 0 unloaded passes after pbr load - had {}".format(
-				count_images)
-
-	def prep_materials_cycles(self):
-		"""Cycles-specific tests"""
-
-	def find_missing_images_cycles(self):
-		"""Find missing images from selected materials, cycles.
-
-		Scenarios in which we find new textures
-		One: material is empty with no image block assigned at all, though has
-			image node and material is a canonical name
-		Two: material has image block but the filepath is missing, find it
-		Three: image is there, or image is packed; ie assume is fine (don't change)
-		"""
-
-		# first, import a material that has no filepath
-		self._clear_scene()
-		mat, node = self._create_canon_mat("sugar_cane")
-		bpy.ops.mesh.primitive_plane_add()
-		bpy.context.object.active_material = mat
-
-		pre_path = node.image.filepath
-		bpy.ops.mcprep.replace_missing_textures(animateTextures=False)
-		post_path = node.image.filepath
-		if pre_path != post_path:
-			return "Pre/post path differed, should be the same"
-
-		# now save the texturefile somewhere
-		tmp_dir = tempfile.gettempdir()
-		tmp_image = os.path.join(tmp_dir, "sugar_cane.png")
-		shutil.copyfile(node.image.filepath, tmp_image)  # leave original intact
-
-		# Test that path is unchanged even when with a non canonical path
-		node.image.filepath = tmp_image
-		if node.image.filepath != tmp_image:
-			os.remove(tmp_image)
-			return "fialed to setup test, node path not = " + tmp_image
-		pre_path = node.image.filepath
-		bpy.ops.mcprep.replace_missing_textures(animateTextures=False)
-		post_path = node.image.filepath
-		if pre_path != post_path:
-			os.remove(tmp_image)
-			return (
-				"Pre/post path differed in tmp dir when there should have "
-				"been no change: pre {} vs post {}".format(pre_path, post_path))
-
-		# test that an empty node within a canonically named material is fixed
-		pre_path = node.image.filepath
-		node.image = None  # remove the image from block
-		if node.image:
-			os.remove(tmp_image)
-			return "failed to setup test, image block still assigned"
-		bpy.ops.mcprep.replace_missing_textures(animateTextures=False)
-		post_path = node.image.filepath
-		if not post_path:
-			os.remove(tmp_image)
-			return "No post path found, should have loaded file"
-		elif post_path == pre_path:
-			os.remove(tmp_image)
-			return "Should have loaded image as new datablock from canon location"
-		elif not os.path.isfile(post_path):
-			os.remove(tmp_image)
-			return "New path file does not exist"
-
-		# test an image with broken texturepath is fixed for cannon material name
-
-		# node.image.filepath = tmp_image # assert it's not the canonical path
-		# pre_path = node.image.filepath # the original path before renaming
-		# os.rename(tmp_image, tmp_image+"x")
-		# if os.path.isfile(bpy.path.abspath(node.image.filepath)) or pre_path != node.image.filepath:
-		# 	os.remove(pre_path)
-		# 	os.remove(tmp_image+"x")
-		# 	return "Failed to setup test, original file exists/img path updated"
-		# bpy.ops.mcprep.replace_missing_textures(animateTextures=False)
-		# post_path = node.image.filepath
-		# if pre_path == post_path:
-		# 	os.remove(tmp_image+"x")
-		# 	return "Should have updated missing image to canonical, still is "+post_path
-		# elif post_path != canonical_path:
-		# 	os.remove(tmp_image+"x")
-		# 	return "New path not canonical: "+post_path
-		# os.rename(tmp_image+"x", tmp_image)
-
-		# Example where we save and close the blend file, move the file,
-		# and re-open. First, load the scene
-		self._clear_scene()
-		mat, node = self._create_canon_mat("sugar_cane")
-		bpy.ops.mesh.primitive_plane_add()
-		bpy.context.object.active_material = mat
-		# Then, create the textures locally
-		bpy.ops.file.pack_all()
-		bpy.ops.file.unpack_all(method='USE_LOCAL')
-		unpacked_path = bpy.path.abspath(node.image.filepath)
-		# close and open, moving the file in the meantime
-		save_tmp_file = os.path.join(tmp_dir, "tmp_test.blend")
-		os.rename(unpacked_path, unpacked_path + "x")
-		bpy.ops.wm.save_mainfile(filepath=save_tmp_file)
-		bpy.ops.wm.open_mainfile(filepath=save_tmp_file)
-		# now run the operator
-		img = bpy.data.images['sugar_cane.png']
-		pre_path = img.filepath
-		if os.path.isfile(pre_path):
-			os.remove(unpacked_path + "x")
-			return "Failed to setup test for save/reopn move"
-		bpy.ops.mcprep.replace_missing_textures(animateTextures=False)
-		post_path = img.filepath
-		if post_path == pre_path:
-			os.remove(unpacked_path + "x")
-			return "Did not change path from " + pre_path
-		elif not os.path.isfile(post_path):
-			os.remove(unpacked_path + "x")
-			return "File for blend reloaded image does not exist: {}".format(
-				node.image.filepath)
-		os.remove(unpacked_path + "x")
-
-		# address the example of sugar_cane.png.001 not being detected as canonical
-		# as a front-end name (not image file)
-		self._clear_scene()
-		mat, node = self._create_canon_mat("sugar_cane")
-		bpy.ops.mesh.primitive_plane_add()
-		bpy.context.object.active_material = mat
-
-		pre_path = node.image.filepath
-		node.image = None  # remove the image from block
-		mat.name = "sugar_cane.png.001"
-		if node.image:
-			os.remove(tmp_image)
-			return "failed to setup test, image block still assigned"
-		bpy.ops.mcprep.replace_missing_textures(animateTextures=False)
-		if not node.image:
-			os.remove(tmp_image)
-			return "Failed to load new image within mat named .png.001"
-		post_path = node.image.filepath
-		if not post_path:
-			os.remove(tmp_image)
-			return "No image loaded for " + mat.name
-		elif not os.path.isfile(node.image.filepath):
-			return "File for loaded image does not exist: " + node.image.filepath
-
-		# Example running with animateTextures too
-
-		# check on image that is packed or not, or packed but no data
-		os.remove(tmp_image)
-
-	def openfolder(self):
-		if bpy.app.background is True:
-			return ""  # can't test this in background mode
-
-		folder = bpy.utils.script_path_user()
-		if not os.path.isdir(folder):
-			return "Sample folder doesn't exist, couldn't test"
-		res = bpy.ops.mcprep.openfolder(folder)
-		if res == {"FINISHED"}:
-			return ""
-		else:
-			return "Failed, returned cancelled"
-
-	def spawn_mob(self):
-		"""Spawn mobs, reload mobs, etc"""
-		self._clear_scene()
-		self._add_character()  # run the utility as it's own sort of test
-
-		self._clear_scene()
-		bpy.ops.mcprep.reload_mobs()
-
-		# sample don't specify mob, just load whatever is first
-		bpy.ops.mcprep.mob_spawner()
-
-		# spawn with linking
-		# try changing the folder
-		# try install mob and uninstall
-
-	def spawn_mob_linked(self):
-		self._clear_scene()
-		bpy.ops.mcprep.reload_mobs()
-		bpy.ops.mcprep.mob_spawner(toLink=True)
-
-	def check_blend_eligible(self):
-		from MCprep.spawner import spawn_util
-		fake_base = "MyMob - by Person"
-
-		suffix_new = " pre9.0.0"  # Force active blender instance as older
-		suffix_old = " pre1.0.0"  # Force active blender instance as newer.
-
-		p_none = fake_base + ".blend"
-		p_new = fake_base + suffix_new + ".blend"
-		p_old = fake_base + suffix_old + ".blend"
-		rando = "rando_name" + suffix_old + ".blend"
-
-		# Check where input file is the "non-versioned" one.
-
-		res = spawn_util.check_blend_eligible(p_none, [p_none, rando])
-		if res is not True:
-			return "Should have been true even if rando has suffix"
-
-		res = spawn_util.check_blend_eligible(p_none, [p_none, p_old])
-		if res is not True:
-			return "Should be true as curr blend eligible and checked latest"
-
-		res = spawn_util.check_blend_eligible(p_none, [p_none, p_new])
-		if res is not False:
-			print(p_none, p_new, res)
-			return "Should be false as curr blend not eligible and checked latest"
-
-		# Now check if input is a versioned file.
-
-		res = spawn_util.check_blend_eligible(p_new, [p_none, p_new])
-		if res is not True:
-			return "Should have been true since we are below min blender"
-
-		res = spawn_util.check_blend_eligible(p_old, [p_none, p_old])
-		if res is not False:
-			return "Should have been false since we are above this min blender"
-
-	def check_blend_eligible_middle(self):
-		# Warden-like example, where we have equiv of pre2.80, pre3.0, and
-		# live blender 3.0+ (presuming we want to test a 2.93-like user)
-		from MCprep.spawner import spawn_util
-		fake_base = "WardenExample"
-
-		# Assume the "current" version of blender is like 9.1
-		# To make test not be flakey, actual version of blender can be anything
-		# in range of 2.7.0 upwards to 8.999.
-		suffix_old = " pre2.7.0"  # Force active blender instance as older.
-		suffix_mid = " pre9.0.0"  # Force active blender instance as older.
-		suffix_new = ""  # presume "latest" version
-
-		p_old = fake_base + suffix_old + ".blend"
-		p_mid = fake_base + suffix_mid + ".blend"
-		p_new = fake_base + suffix_new + ".blend"
-
-		# Test in order
-		filelist = [p_old, p_mid, p_new]
-
-		res = spawn_util.check_blend_eligible(p_old, filelist)
-		if res is True:
-			return "Older file should not match (in order)"
-		res = spawn_util.check_blend_eligible(p_mid, filelist)
-		if res is not True:
-			return "Mid file SHOULD match (in order)"
-		res = spawn_util.check_blend_eligible(p_new, filelist)
-		if res is True:
-			return "Newer file should not match (in order)"
-
-		# Test out of order
-		filelist = [p_mid, p_new, p_old]
-
-		res = spawn_util.check_blend_eligible(p_old, filelist)
-		if res is True:
-			return "Older file should not match (out of order)"
-		res = spawn_util.check_blend_eligible(p_mid, filelist)
-		if res is not True:
-			return "Mid file SHOULD match (out of order)"
-		res = spawn_util.check_blend_eligible(p_new, filelist)
-		if res is True:
-			return "Newer file should not match (out of order)"
-
-	def check_blend_eligible_real(self):
-		# This order below matches a user's who was encountering an error
-		# (the actual in-memory python list order)
-		riglist = [
-			"bee - Boxscape.blend",
-			"Blaze - Trainguy.blend",
-			"Cave Spider - Austin Prescott.blend",
-			"creeper - TheDuckCow.blend",
-			"drowned - HissingCreeper-thefunnypie2.blend",
-			"enderman - Trainguy.blend",
-			"Ghast - Trainguy.blend",
-			"guardian - Trainguy.blend",
-			"hostile - boxscape.blend",
-			"illagers - Boxscape.blend",
-			"mobs - Rymdnisse.blend",
-			"nether hostile - Boxscape.blend",
-			"piglin zombified piglin - Boxscape.blend",
-			"PolarBear - PixelFrosty.blend",
-			"ravager - Boxscape.blend",
-			"Shulker - trainguy.blend",
-			"Skeleton - Trainguy.blend",
-			"stray - thefunnypie2.blend",
-			"Warden - DigDanAnimates pre2.80.0.blend",
-			"Warden - DigDanAnimates pre3.0.0.blend",
-			"Warden - DigDanAnimates.blend",
-			"Zombie - Hissing Creeper.blend",
-			"Zombie Villager - Hissing Creeper-thefunnypie2.blend"
-		]
-		target_list = [
-			"Warden - DigDanAnimates pre2.80.0.blend",
-			"Warden - DigDanAnimates pre3.0.0.blend",
-			"Warden - DigDanAnimates.blend",
-		]
-
-		from MCprep.spawner import spawn_util
-		if bpy.app.version < (2, 80):
-			correct = "Warden - DigDanAnimates pre2.80.0.blend"
-		elif bpy.app.version < (3, 0):
-			correct = "Warden - DigDanAnimates pre3.0.0.blend"
-		else:
-			correct = "Warden - DigDanAnimates.blend"
-
-		for rig in target_list:
-			res = spawn_util.check_blend_eligible(rig, riglist)
-			if rig == correct:
-				if res is not True:
-					return "Did not pick {} as correct rig".format(rig)
-			else:
-				if res is True:
-					return "Should have said {} was correct - not {}".format(correct, rig)
-
-	def change_skin(self):
-		"""Test scenarios for changing skin after adding a character."""
-		self._clear_scene()
-
-		bpy.ops.mcprep.reload_skins()
-		skin_ind = bpy.context.scene.mcprep_skins_list_index
-		skin_item = bpy.context.scene.mcprep_skins_list[skin_ind]
-		tex_name = skin_item['name']
-		skin_path = os.path.join(bpy.context.scene.mcprep_skin_path, tex_name)
-
-		status = 'fail'
-		try:
-			_ = bpy.ops.mcprep.applyskin(
-				filepath=skin_path,
-				new_material=False)
-		except RuntimeError as e:
-			if 'No materials found to update' in str(e):
-				status = 'success'  # expect to fail when nothing selected
-		if status == 'fail':
-			return "Should have failed to skin swap with no objects selected"
-
-		# now run on a real test character, with 1 material and 2 objects
-		self._add_character()
-
-		pre_mats = len(bpy.data.materials)
-		bpy.ops.mcprep.applyskin(
-			filepath=skin_path,
-			new_material=False)
-		post_mats = len(bpy.data.materials)
-		if post_mats != pre_mats:  # should be unchanged
-			return (
-				"change_skin.mat counts diff despit no new mat request, "
-				"{} before and {} after".format(pre_mats, post_mats))
-
-		# do counts of materials before and after to ensure they match
-		pre_mats = len(bpy.data.materials)
-		bpy.ops.mcprep.applyskin(
-			filepath=skin_path,
-			new_material=True)
-		post_mats = len(bpy.data.materials)
-		if post_mats != pre_mats * 2:  # should exactly double since in new scene
-			return (
-				"change_skin.mat counts diff mat counts, "
-				"{} before and {} after".format(pre_mats, post_mats))
-
-		pre_mats = len(bpy.data.materials)
-
-		# not diff operator name, this is popup browser
-		bpy.ops.mcprep.skin_swapper(
-			filepath=skin_path,
-			new_material=False)
-		post_mats = len(bpy.data.materials)
-		if post_mats != pre_mats:  # should be unchanged
-			return (
-				"change_skin.mat counts differ even though should be same, "
-				"{} before and {} after".format(pre_mats, post_mats))
-
-		# TODO: Add test for when there is a bogus filename, responds with
-		# Image file not found in err
-
-		# capture info or recent out?
-		# check that username was there before or not
-		bpy.ops.mcprep.applyusernameskin(
-			username='TheDuckCow',
-			skip_redownload=False,
-			new_material=True)
-
-		# check that timestamp of last edit of file was longer ago than above cmd
-
-		bpy.ops.mcprep.applyusernameskin(
-			username='TheDuckCow',
-			skip_redownload=True,
-			new_material=True)
-
-		# test deleting username skin and that file is indeed deleted
-		# and not in list anymore
-
-		# bpy.ops.mcprep.applyusernameskin(
-		# 	username='TheDuckCow',
-		# 	skip_redownload=True,
-		# 	new_material=True)
-
-		# test that the file was added back
-
-		bpy.ops.mcprep.spawn_with_skin()
-		# test changing skin to file when no existing images/textres
-		# test changing skin to file when existing material
-		# test changing skin to file for both above, cycles and internal
-		# test changing skin file for both above without, then with,
-		#   then without again, normals + spec etc.
-		return
-
-	def import_world_split(self):
-		"""Test that imported world has multiple objects"""
-		self._clear_scene()
-
-		pre_objects = len(bpy.data.objects)
-		self._import_jmc2obj_full()
-		post_objects = len(bpy.data.objects)
-		if post_objects + 1 > pre_objects:
-			print("Success, had {} objs, post import {}".format(
-				pre_objects, post_objects))
-			return
-		elif post_objects + 1 == pre_objects:
-			return "Only one new object imported"
-		else:
-			return "Nothing imported"
-
-	def import_world_fail(self):
-		"""Ensure loader fails if an invalid path is loaded"""
-		testdir = os.path.dirname(__file__)
-		obj_path = os.path.join(testdir, "jmc2obj", "xx_jmc2obj_test_1_14_4.obj")
-		try:
-			bpy.ops.mcprep.import_world_split(filepath=obj_path)
-		except Exception as e:
-			print("Failed, as intended: " + str(e))
-			return
-		return "World import should have returned an error"
-
-	def import_materials_util(self, mapping_set):
-		"""Reusable function for testing on different obj setups"""
-		from MCprep.materials.generate import get_mc_canonical_name
-		from MCprep.materials.generate import find_from_texturepack
-		from MCprep import util
-		from MCprep import conf
-
-		util.load_mcprep_json()  # force load json cache
-		mcprep_data = conf.env.json_data["blocks"][mapping_set]
-
-		# first detect alignment to the raw underlining mappings, nothing to
-		# do with canonical yet
-		mapped = [
-			mat.name for mat in bpy.data.materials
-			if mat.name in mcprep_data]  # ok!
-		unmapped = [
-			mat.name for mat in bpy.data.materials
-			if mat.name not in mcprep_data]  # not ok
-		fullset = mapped + unmapped  # ie all materials
-		unleveraged = [
-			mat for mat in mcprep_data
-			if mat not in fullset]  # not ideal, means maybe missed check
-
-		print("Mapped: {}, unmapped: {}, unleveraged: {}".format(
-			len(mapped), len(unmapped), len(unleveraged)))
-
-		if len(unmapped):
-			err = "Textures not mapped to json file"
-			print(err)
-			print(sorted(unmapped))
-			print("")
-			# return err
-		if len(unleveraged) > 20:
-			err = "Json file materials not found in obj test file, may need to update world"
-			print(err)
-			print(sorted(unleveraged))
-			# return err
-
-		if len(mapped) == 0:
-			return "No materials mapped"
-		elif mapping_set == "block_mapping_mineways" and len(mapped) > 75:
-			# Known that the "combined" atlas texture of Mineways imports
-			# has low coverge, and we're not doing anything about it.
-			# but will at least capture if coverage gets *worse*.
-			pass
-		elif len(mapped) < len(unmapped):  # too many esp. for Mineways
-			# not a very optimistic threshold, but better than none
-			return "More materials unmapped than mapped"
-		print("")
-
-		# each element is [cannon_name, form], form is none if not matched
-		mapped = [get_mc_canonical_name(mat.name) for mat in bpy.data.materials]
-
-		# no matching canon name (warn)
-		mats_not_canon = [itm[0] for itm in mapped if itm[1] is None]
-		if mats_not_canon and mapping_set != "block_mapping_mineways":
-			print("Non-canon material names found: ({})".format(len(mats_not_canon)))
-			print(mats_not_canon)
-			if len(mats_not_canon) > 30:  # arbitrary threshold
-				return "Too many materials found without canonical name ({})".format(
-					len(mats_not_canon))
-		else:
-			print("Confirmed - no non-canon images found")
-
-		# affirm the correct mappings
-		mats_no_packimage = [
-			find_from_texturepack(itm[0]) for itm in mapped
-			if itm[1] is not None]
-		mats_no_packimage = [path for path in mats_no_packimage if path]
-		print("Mapped paths: " + str(len(mats_no_packimage)))
-
-		# could not resolve image from resource pack (warn) even though in mapping
-		mats_no_packimage = [
-			itm[0] for itm in mapped
-			if itm[1] is not None and not find_from_texturepack(itm[0])]
-		print("No resource images found for mapped items: ({})".format(
-			len(mats_no_packimage)))
-		print("These would appear to have cannon mappings, but then fail on lookup")
-
-		# known number up front, e.g. chests, stone_slab_side, stone_slab_top
-		if len(mats_no_packimage) > 5:
-			return "Missing images for blocks specified in mcprep_data.json: {}".format(
-				",".join(mats_no_packimage))
-
-		# also test that there are not raw image names not in mapping list
-		# but that otherwise could be added to the mapping list as file exists
-
-	def import_jmc2obj(self):
-		"""Checks that material names in output obj match the mapping file"""
-		self._clear_scene()
-		self._import_jmc2obj_full()
-
-		res = self.import_materials_util("block_mapping_jmc")
-		return res
-
-	def import_mineways_separated(self):
-		"""Checks Mineways (single-image) material name mapping to mcprep_data"""
-		self._clear_scene()
-		self._import_mineways_separated()
-
-		res = self.import_materials_util("block_mapping_mineways")
-		return res
-
-	def import_mineways_combined(self):
-		"""Checks Mineways (multi-image) material name mapping to mcprep_data"""
-		self._clear_scene()
-		self._import_mineways_combined()
-
-		res = self.import_materials_util("block_mapping_mineways")
-		return res
-
-	def name_generalize(self):
-		"""Tests the outputs of the generalize function"""
-		from MCprep.util import nameGeneralize
-		test_sets = {
-			"ab": "ab",
-			"table.001": "table",
-			"table.100": "table",
-			"table001": "table001",
-			"fire_0": "fire_0",
-			# "fire_0_0001.png":"fire_0", not current behavior, but desired?
-			"fire_0_0001": "fire_0",
-			"fire_0_0001.001": "fire_0",
-			"fire_layer_1": "fire_layer_1",
-			"cartography_table_side1": "cartography_table_side1"
-		}
-		errors = []
-		for key in list(test_sets):
-			res = nameGeneralize(key)
-			if res != test_sets[key]:
-				errors.append("{} converts to {} and should be {}".format(
-					key, res, test_sets[key]))
-			else:
-				print("{}:{} passed".format(key, res))
-
-		if errors:
-			return "Generalize failed: " + ", ".join(errors)
-
-	def canonical_name_no_none(self):
-		"""Ensure that MC canonical name never returns none"""
-		from MCprep.materials.generate import get_mc_canonical_name
-		from MCprep.util import materialsFromObj
-		self._clear_scene()
-		self._import_jmc2obj_full()
-		self._import_mineways_separated()
-		self._import_mineways_combined()
-
-		bpy.ops.object.select_all(action='SELECT')
-		mats = materialsFromObj(bpy.context.selected_objects)
-		canons = [[get_mc_canonical_name(mat.name)][0] for mat in mats]
-
-		if None in canons:  # detect None response to canon input
-			return "Canon returned none value"
-		if '' in canons:
-			return "Canon returned empty str value"
-
-		# Ensure it never returns None
-		in_str, _ = get_mc_canonical_name('')
-		if in_str != '':
-			return "Empty str should return empty string, not" + str(in_str)
-
-		did_raise = False
-		try:
-			get_mc_canonical_name(None)
-		except Exception:
-			did_raise = True
-		if not did_raise:
-			return "None input SHOULD raise error"
-
-		# TODO: patch conf.env.json_data["blocks"] used by addon if possible,
-		# if this is transformed into a true py unit test. This will help
-		# check against report (-MNGGQfGGTJRqoizVCer)
-
-	def canonical_test_mappings(self):
-		"""Test some specific mappings to ensure they return correctly."""
-		from MCprep.materials.generate import get_mc_canonical_name
-
-		misc = {
-			".emit": ".emit",
-		}
-		jmc_to_canon = {
-			"grass": "grass",
-			"mushroom_red": "red_mushroom",
-			# "slime": "slime_block",  # KNOWN jmc, need to address
-		}
-		mineways_to_canon = {}
-
-		for map_type in [misc, jmc_to_canon, mineways_to_canon]:
-			for key, val in map_type.items():
-				res, mapped = get_mc_canonical_name(key)
-				if res == val:
-					continue
-				return "Wrong mapping: {} mapped to {} ({}), not {}".format(
-					key, res, mapped, val)
-
-	def meshswap_util(self, mat_name):
-		"""Run meshswap on the first object with found mat_name"""
-		from MCprep.util import select_set
-
-		if mat_name not in bpy.data.materials:
-			return "Not a material: " + mat_name
-		print("\nAttempt meshswap of " + mat_name)
-		mat = bpy.data.materials[mat_name]
-
-		obj = None
-		for ob in bpy.data.objects:
-			for slot in ob.material_slots:
-				if slot and slot.material == mat:
-					obj = ob
-					break
-			if obj:
-				break
-		if not obj:
-			return "Failed to find obj for " + mat_name
-		print("Found the object - " + obj.name)
-
-		bpy.ops.object.select_all(action='DESELECT')
-		select_set(obj, True)
-		res = bpy.ops.mcprep.meshswap()
-		if res != {'FINISHED'}:
-			return "Meshswap returned cancelled for " + mat_name
-
-	def meshswap_spawner(self):
-		"""Tests direct meshswap spawning"""
-		self._clear_scene()
-		scn_props = bpy.context.scene.mcprep_props
-		bpy.ops.mcprep.reload_meshswap()
-		if not scn_props.meshswap_list:
-			return "No meshswap assets loaded for spawning"
-		elif len(scn_props.meshswap_list) < 15:
-			return "Too few meshswap assets available"
-
-		if bpy.app.version >= (2, 80):
-			# Add with make real = False
-			bpy.ops.mcprep.meshswap_spawner(
-				block='banner', method="collection", make_real=False)
-
-			# test doing two of the same one (first won't be cached, second will)
-			# Add one with make real = True
-			bpy.ops.mcprep.meshswap_spawner(
-				block='fire', method="collection", make_real=True)
-			if 'fire' not in bpy.data.collections:
-				return "Fire not in collections"
-			elif not bpy.context.selected_objects:
-				return "Added made-real meshswap objects not selected"
-
-			# Test that cache is properly used. Also test that the default
-			# 'method=colleciton' is used, since that's the only mode of
-			# support for meshswap spawner at the moment.
-			bpy.ops.mcprep.meshswap_spawner(block='fire', make_real=False)
-			if 'fire' not in bpy.data.collections:
-				return "Fire not in collections"
-			count = sum([1 for itm in bpy.data.collections if 'fire' in itm.name])
-			if count != 1:
-				return "Imported extra fire group, should have cached instead!"
-
-			# test that added item ends up in location location=(1,2,3)
-			loc = (1, 2, 3)
-			bpy.ops.mcprep.meshswap_spawner(
-				block='fire', method="collection", make_real=False, location=loc)
-			if not bpy.context.object:
-				return "Added meshswap object not added as active"
-			elif not bpy.context.selected_objects:
-				return "Added meshswap object not selected"
-			if bpy.context.object.location != Vector(loc):
-				return "Location not properly applied"
-			count = sum([1 for itm in bpy.data.collections if 'fire' in itm.name])
-			if count != 1:
-				return "Should have 1 fire groups exactly, did not cache"
-		else:
-			# Add with make real = False
-			bpy.ops.mcprep.meshswap_spawner(
-				block='banner', method="collection", make_real=False)
-
-			# test doing two of the same one (first won't be cached, second will)
-			# Add one with make real = True
-			bpy.ops.mcprep.meshswap_spawner(
-				block='fire', method="collection", make_real=True)
-			if 'fire' not in bpy.data.groups:
-				return "Fire not in groups"
-			elif not bpy.context.selected_objects:
-				return "Added made-real meshswap objects not selected"
-
-			bpy.ops.mcprep.meshswap_spawner(
-				block='fire', method="collection", make_real=False)
-			if 'fire' not in bpy.data.groups:
-				return "Fire not in groups"
-			count_torch = sum([1 for itm in bpy.data.groups if 'fire' in itm.name])
-			if count_torch != 1:
-				return "Imported extra fire group, should have cached instead!"
-
-			# test that added item ends up in location location=(1,2,3)
-			loc = (1, 2, 3)
-			bpy.ops.mcprep.meshswap_spawner(
-				block='fire', method="collection", make_real=False, location=loc)
-			if not bpy.context.object:
-				return "Added meshswap object not added as active"
-			elif not bpy.context.selected_objects:
-				return "Added meshswap object not selected"
-			if bpy.context.object.location != Vector(loc):
-				return "Location not properly applied"
-
-	def meshswap_jmc2obj(self):
-		"""Tests jmc2obj meshswapping"""
-		self._clear_scene()
-		self._import_jmc2obj_full()
-		self._set_exporter('jmc2obj')
-
-		# known jmc2obj material names which we expect to be able to meshswap
-		test_materials = [
-			"torch",
-			"fire",
-			"lantern",
-			"cactus_side",
-			"vines",  # plural
-			"enchant_table_top",
-			"redstone_torch_on",
-			"glowstone",
-			"redstone_lamp_on",
-			"pumpkin_front_lit",
-			"sugarcane",
-			"chest",
-			"largechest",
-			"sunflower_bottom",
-			"sapling_birch",
-			"white_tulip",
-			"sapling_oak",
-			"sapling_acacia",
-			"sapling_jungle",
-			"blue_orchid",
-			"allium",
-		]
-
-		errors = []
-		for mat_name in test_materials:
-			try:
-				res = self.meshswap_util(mat_name)
-			except Exception as err:
-				err = str(err)
-				if len(err) > 15:
-					res = err[:15].replace("\n", "")
-				else:
-					res = err
-			if res:
-				errors.append(mat_name + ":" + res)
-		if errors:
-			return "Meshswap failed: " + ", ".join(errors)
-
-	def meshswap_mineways_separated(self):
-		"""Tests jmc2obj meshswapping"""
-		self._clear_scene()
-		self._import_mineways_separated()
-		self._set_exporter('Mineways')
-
-		# known Mineways (separated) material names expected for meshswap
-		test_materials = [
-			"grass",
-			"torch",
-			"fire_0",
-			"MWO_chest_top",
-			"MWO_double_chest_top_left",
-			# "lantern", not in test object
-			"cactus_side",
-			"vine",  # singular
-			"enchanting_table_top",
-			# "redstone_torch_on", no separate "on" for Mineways separated exports
-			"glowstone",
-			"redstone_torch",
-			"jack_o_lantern",
-			"sugar_cane",
-			"jungle_sapling",
-			"dark_oak_sapling",
-			"oak_sapling",
-			"campfire_log",
-			"white_tulip",
-			"blue_orchid",
-			"allium",
-		]
-
-		errors = []
-		for mat_name in test_materials:
-			try:
-				res = self.meshswap_util(mat_name)
-			except Exception as err:
-				err = str(err)
-				if len(err) > 15:
-					res = err[:15].replace("\n", "")
-				else:
-					res = err
-			if res:
-				errors.append(mat_name + ":" + res)
-		if errors:
-			return "Meshswap failed: " + ", ".join(errors)
-
-	def meshswap_mineways_combined(self):
-		"""Tests jmc2obj meshswapping"""
-		self._clear_scene()
-		self._import_mineways_combined()
-		self._set_exporter('Mineways')
-
-		# known Mineways (separated) material names expected for meshswap
-		test_materials = [
-			"Sunflower",
-			"Torch",
-			"Redstone_Torch_(active)",
-			"Lantern",
-			"Dark_Oak_Sapling",
-			"Sapling",  # should map to oak sapling
-			"Birch_Sapling",
-			"Cactus",
-			"White_Tulip",
-			"Vines",
-			"Ladder",
-			"Enchanting_Table",
-			"Campfire",
-			"Jungle_Sapling",
-			"Red_Tulip",
-			"Blue_Orchid",
-			"Allium",
-		]
-
-		errors = []
-		for mat_name in test_materials:
-			try:
-				res = self.meshswap_util(mat_name)
-			except Exception as err:
-				err = str(err)
-				if len(err) > 15:
-					res = err[:15].replace("\n", "")
-				else:
-					res = err
-			if res:
-				errors.append(mat_name + ":" + res)
-		if errors:
-			return "Meshswap combined failed: " + ", ".join(errors)
-
-	def detect_desaturated_images(self):
-		"""Checks the desaturate images function works"""
-		from MCprep.materials.generate import is_image_grayscale
-
-		base = self.get_mcprep_path()
-		print("Raw base", base)
-		base = os.path.join(
-			base, "MCprep_resources", "resourcepacks", "mcprep_default",
-			"assets", "minecraft", "textures", "block")
-		print("Remapped base: ", base)
-
-		# known images that ARE desaturated:
-		desaturated = [
-			"grass_block_top.png"
-		]
-		saturated = [
-			"grass_block_side.png",
-			"glowstone.png"
-		]
-
-		for tex in saturated:
-			img = bpy.data.images.load(os.path.join(base, tex))
-			if not img:
-				raise Exception('Failed to load img ' + str(tex))
-			if is_image_grayscale(img) is True:
-				raise Exception(
-					'Image {} detected as grayscale, should be saturated'.format(tex))
-		for tex in desaturated:
-			img = bpy.data.images.load(os.path.join(base, tex))
-			if not img:
-				raise Exception('Failed to load img ' + str(tex))
-			if is_image_grayscale(img) is False:
-				raise Exception(
-					'Image {} detected as saturated - should be grayscale'.format(tex))
-
-		# test that it is caching as expected.. by setting a false
-		# value for cache flag and seeing it's returning the property value
-
-	def detect_extra_passes(self):
-		"""Ensure only the correct pbr file matches are found for input file"""
-		from MCprep.materials.generate import find_additional_passes
-
-		tmp_dir = tempfile.gettempdir()
-
-		# physically generate these empty files, then delete
-		tmp_files = [
-			"oak_log_top.png",
-			"oak_log_top-s.png",
-			"oak_log_top_n.png",
-			"oak_log.jpg",
-			"oak_log_s.jpg",
-			"oak_log_n.jpeg",
-			"oak_log_disp.jpeg",
-			"stonecutter_saw.tiff",
-			"stonecutter_saw n.tiff"
-		]
-
-		for tmp in tmp_files:
-			fname = os.path.join(tmp_dir, tmp)
-			with open(fname, 'a'):
-				os.utime(fname)
-
-		def cleanup():
-			"""Failsafe delete files before raising error within test method"""
-			for tmp in tmp_files:
-				try:
-					os.remove(os.path.join(tmp_dir, tmp))
-				except Exception:
-					pass
-
-		# assert setup was successful
-		for tmp in tmp_files:
-			if os.path.isfile(os.path.join(tmp_dir, tmp)):
-				continue
-			cleanup()
-			raise Exception("Failed to generate test empty files")
-
-		# the test cases; input is diffuse, output is the whole dict
-		cases = [
-			{
-				"diffuse": os.path.join(tmp_dir, "oak_log_top.png"),
-				"specular": os.path.join(tmp_dir, "oak_log_top-s.png"),
-				"normal": os.path.join(tmp_dir, "oak_log_top_n.png"),
-			}, {
-				"diffuse": os.path.join(tmp_dir, "oak_log.jpg"),
-				"specular": os.path.join(tmp_dir, "oak_log_s.jpg"),
-				"normal": os.path.join(tmp_dir, "oak_log_n.jpeg"),
-				"displace": os.path.join(tmp_dir, "oak_log_disp.jpeg"),
-			}, {
-				"diffuse": os.path.join(tmp_dir, "stonecutter_saw.tiff"),
-				"normal": os.path.join(tmp_dir, "stonecutter_saw n.tiff"),
-			}
-		]
-
-		for test in cases:
-			res = find_additional_passes(test["diffuse"])
-			if res != test:
-				cleanup()
-				# for debug readability, basepath everything
-				for itm in res:
-					res[itm] = os.path.basename(res[itm])
-				for itm in test:
-					test[itm] = os.path.basename(test[itm])
-				raise Exception("Mismatch for set {}: got {} but expected {}".format(
-					test["diffuse"], res, test))
-
-		# test other cases intended to fail
-		res = find_additional_passes(os.path.join(tmp_dir, "not_a_file.png"))
-		if res != {}:
-			cleanup()
-			raise Exception("Fake file should not have any return")
-
-	def _qa_helper(self, basepath, allow_packed):
-		"""File used to help QC an open blend file."""
-
-		# bpy.ops.file.make_paths_relative() instead of this, do manually.
-		different_base = []
-		not_relative = []
-		missing = []
-		for img in bpy.data.images:
-			if not img.filepath:
-				continue
-			abspath = os.path.abspath(bpy.path.abspath(img.filepath))
-			if not abspath.startswith(basepath):
-				if allow_packed is True and img.packed_file:
-					pass
-				else:
-					different_base.append(os.path.basename(img.filepath))
-			if img.filepath != bpy.path.relpath(img.filepath):
-				not_relative.append(os.path.basename(img.filepath))
-			if not os.path.isfile(abspath):
-				if allow_packed is True and img.packed_file:
-					pass
-				else:
-					missing.append(img.name)
-
-		if len(different_base) > 50:
-			return "Wrong basepath for image filepath comparison!"
-		if different_base:
-			return "Found {} images with different basepath from file: {}".format(
-				len(different_base), ", ".join(different_base))
-		if not_relative:
-			return "Found {} non relative img files: {}".format(
-				len(not_relative), ", ".join(not_relative))
-		if missing:
-			return "Found {} img with missing source files: {}".format(
-				len(missing), ", ".join(missing))
-
-	def qa_meshswap_file(self):
-		"""Open the meshswap file, assert there are no relative paths"""
-		basepath = os.path.join("MCprep_addon", "MCprep_resources")
-		basepath = os.path.abspath(basepath)  # relative to the dev git folder
-		blendfile = os.path.join(basepath, "mcprep_meshSwap.blend")
-		if not os.path.isfile(blendfile):
-			return blendfile + ": missing tests dir local meshswap file"
-		bpy.ops.wm.open_mainfile(filepath=blendfile)
-		# do NOT save this file!
-
-		resp = self._qa_helper(basepath, allow_packed=False)
-		if resp:
-			return resp
-
-		# detect any non canonical material names?? how to exclude?
-
-		# Affirm that no materials have a principled node, should be basic only
-
-	def item_spawner(self):
-		"""Test item spawning and reloading"""
-		self._clear_scene()
-		scn_props = bpy.context.scene.mcprep_props
-
-		pre_items = len(scn_props.item_list)
-		bpy.ops.mcprep.reload_items()
-		post_items = len(scn_props.item_list)
-
-		if pre_items != 0:
-			return "Should have opened new file with unloaded assets?"
-		elif post_items == 0:
-			return "No items loaded"
-		elif post_items < 50:
-			return "Too few items loaded, missing texturepack?"
-
-		# spawn with whatever default index
-		pre_objs = len(bpy.data.objects)
-		bpy.ops.mcprep.spawn_item()
-		post_objs = len(bpy.data.objects)
-
-		if post_objs == pre_objs:
-			return "No items spawned"
-		elif post_objs > pre_objs + 1:
-			return "More than one item spawned"
-
-		# test core useage on a couple of out of the box textures
-
-		# test once with custom block
-		# bpy.ops.mcprep.spawn_item_file(filepath=)
-
-		# test with different thicknesses
-		# test after changing resource pack
-		# test that with an image of more than 1k pixels, it's truncated as expected
-		# test with different
-
-	def item_spawner_resize(self):
-		"""Test spawning an item that requires resizing."""
-		self._clear_scene()
-		bpy.ops.mcprep.reload_items()
-
-		# Create a tmp file
-		tmp_img = bpy.data.images.new("tmp_item_spawn", 32, 32, alpha=True)
-		tmp_img.filepath = os.path.join(bpy.app.tempdir, "tmp_item.png")
-		tmp_img.save()
-
-		# spawn with whatever default index
-		pre_objs = len(bpy.data.objects)
-		bpy.ops.mcprep.spawn_item_file(
-			max_pixels=16,
-			filepath=tmp_img.filepath
-		)
-		post_objs = len(bpy.data.objects)
-
-		if post_objs == pre_objs:
-			return "No items spawned"
-		elif post_objs > pre_objs + 1:
-			return "More than one item spawned"
-
-		# Now check that this item spawned has the expected face count.
-		obj = bpy.context.object
-		polys = len(obj.data.polygons)
-		print("Poly's count: ", polys)
-		if polys > 16:
-			return "Didn't scale enough to fewer pixels, facecount: " + str(polys)
-		elif polys < 16:
-			return "Over-scaled down facecount: " + str(polys)
-
-	def entity_spawner(self):
-		"""Test entity spawning and reloading"""
-		self._clear_scene()
-		scn_props = bpy.context.scene.mcprep_props
-
-		pre_count = len(scn_props.entity_list)
-		bpy.ops.mcprep.reload_entities()
-		post_count = len(scn_props.entity_list)
-
-		if pre_count != 0:
-			return "Should have opened new file with unloaded assets?"
-		elif post_count == 0:
-			return "No entities loaded"
-		elif post_count < 5:
-			return "Too few entities loaded ({}), missing texturepack?".format(
-				post_count - pre_count)
-
-		# spawn with whatever default index
-		pre_objs = len(bpy.data.objects)
-		bpy.ops.mcprep.entity_spawner()
-		post_objs = len(bpy.data.objects)
-
-		if post_objs == pre_objs:
-			return "No entity spawned"
-
-		# Test collection/group added
-		# Test loading from file.
-
-	def model_spawner(self):
-		"""Test model spawning and reloading"""
-		self._clear_scene()
-		scn_props = bpy.context.scene.mcprep_props
-
-		pre_count = len(scn_props.model_list)
-		bpy.ops.mcprep.reload_models()
-		post_count = len(scn_props.model_list)
-
-		if pre_count != 0:
-			return "Should have opened new file with unloaded assets?"
-		elif post_count == 0:
-			return "No models loaded"
-		elif post_count < 50:
-			return "Too few models loaded, missing texturepack?"
-
-		# spawn with whatever default index
-		pre_objs = list(bpy.data.objects)
-		bpy.ops.mcprep.spawn_model(
-			filepath=scn_props.model_list[scn_props.model_list_index].filepath)
-		post_objs = bpy.data.objects
-
-		if len(post_objs) == len(pre_objs):
-			return "No models spawned"
-		elif len(post_objs) > len(pre_objs) + 1:
-			return "More than one model spawned"
-
-		# Test that materials were properly added.
-		new_objs = list(set(post_objs) - set(pre_objs))
-		model = new_objs[0]
-		if not model.active_material:
-			return "No material on model"
-
-		# TODO: fetch/check there being a texture.
-
-		# Test collection/group added
-		# Test loading from file.
-
-	def geonode_effect_spawner(self):
-		"""Test the geo node variant of effect spawning works."""
-		if bpy.app.version < (3, 0):
-			return  # Not supported before 3.0 anyways.
-		self._clear_scene()
-		scn_props = bpy.context.scene.mcprep_props
-		etype = "geo_area"
-
-		pre_count = len([
-			x for x in scn_props.effects_list if x.effect_type == etype])
-		bpy.ops.mcprep.reload_effects()
-		post_count = len([
-			x for x in scn_props.effects_list if x.effect_type == etype])
-
-		if pre_count != 0:
-			return "Should start with no effects loaded"
-		if post_count == 0:
-			return "Should have more effects loaded after reload"
-
-		effect = [x for x in scn_props.effects_list if x.effect_type == etype][0]
-		res = bpy.ops.mcprep.spawn_global_effect(effect_id=str(effect.index))
-		if res != {'FINISHED'}:
-			return "Did not end with finished result"
-
-		# TODO: Further checks it actually loaded the effect.
-		# Check that the geonode inputs are updated.
-		obj = bpy.context.object
-		if not obj:
-			return "Geo node added object not selected"
-
-		geo_nodes = [mod for mod in obj.modifiers if mod.type == "NODES"]
-		if not geo_nodes:
-			return "No geonode modifier found"
-
-		# Now validate that one of the settings was updated.
-		# TODO: example where we assert the active effect `subpath` is non empty
-
-	def particle_area_effect_spawner(self):
-		"""Test the particle area variant of effect spawning works."""
-		self._clear_scene()
-		scn_props = bpy.context.scene.mcprep_props
-		etype = "particle_area"
-
-		pre_count = len([
-			x for x in scn_props.effects_list if x.effect_type == etype])
-		bpy.ops.mcprep.reload_effects()
-		post_count = len([
-			x for x in scn_props.effects_list if x.effect_type == etype])
-
-		if pre_count != 0:
-			return "Should start with no effects loaded"
-		if post_count == 0:
-			return "Should have more effects loaded after reload"
-
-		effect = [x for x in scn_props.effects_list if x.effect_type == etype][0]
-		res = bpy.ops.mcprep.spawn_global_effect(effect_id=str(effect.index))
-		if res != {'FINISHED'}:
-			return "Did not end with finished result"
-
-		# TODO: Further checks it actually loaded the effect.
-
-	def collection_effect_spawner(self):
-		"""Test the collection variant of effect spawning works."""
-		self._clear_scene()
-		scn_props = bpy.context.scene.mcprep_props
-		etype = "collection"
-
-		pre_count = len([
-			x for x in scn_props.effects_list if x.effect_type == etype])
-		bpy.ops.mcprep.reload_effects()
-		post_count = len([
-			x for x in scn_props.effects_list if x.effect_type == etype])
-
-		if pre_count != 0:
-			return "Should start with no effects loaded"
-		if post_count == 0:
-			return "Should have more effects loaded after reload"
-
-		init_objs = list(bpy.data.objects)
-
-		effect = [x for x in scn_props.effects_list if x.effect_type == etype][0]
-		res = bpy.ops.mcprep.spawn_instant_effect(effect_id=str(effect.index), frame=2)
-		if res != {'FINISHED'}:
-			return "Did not end with finished result"
-
-		final_objs = list(bpy.data.objects)
-		new_objs = list(set(final_objs) - set(init_objs))
-		if len(new_objs) == 0:
-			return "didn't crate new objects"
-		if bpy.context.object not in new_objs:
-			return "Selected obj is not a new object"
-
-		is_empty = bpy.context.object.type == 'EMPTY'
-		is_coll_inst = bpy.context.object.instance_type == 'COLLECTION'
-		if not is_empty or not is_coll_inst:
-			return "Didn't end up with selected collection instance"
-
-		# TODO: Further checks it actually loaded the effect.
-
-	def img_sequence_effect_spawner(self):
-		"""Test the image sequence variant of effect spawning works."""
-		if bpy.app.version < (2, 81):
-			return "Disabled due to consistent crashing"
-		self._clear_scene()
-		scn_props = bpy.context.scene.mcprep_props
-		etype = "img_seq"
-
-		pre_count = len([
-			x for x in scn_props.effects_list if x.effect_type == etype])
-		bpy.ops.mcprep.reload_effects()
-		post_count = len([
-			x for x in scn_props.effects_list if x.effect_type == etype])
-
-		if pre_count != 0:
-			return "Should start with no effects loaded"
-		if post_count == 0:
-			return "Should have more effects loaded after reload"
-
-		# Find the one with at least 10 frames.
-		effect_name = "Big smoke"
-		effect = None
-		for this_effect in scn_props.effects_list:
-			if this_effect.effect_type != etype:
-				continue
-			if this_effect.name == effect_name:
-				effect = this_effect
-
-		if not effect:
-			return "Failed to fetch {} target effect".format(effect_name)
-
-		t0 = time.time()
-		res = bpy.ops.mcprep.spawn_instant_effect(effect_id=str(effect.index))
-		if res != {'FINISHED'}:
-			return "Did not end with finished result"
-
-		t1 = time.time()
-		if t1 - t0 > 1.0:
-			return "Spawning took over 1 second for sequence effect"
-
-		# TODO: Further checks it actually loaded the effect.
-
-	def particle_plane_effect_spawner(self):
-		"""Test the particle plane variant of effect spawning works."""
-		self._clear_scene()
-
-		filepath = os.path.join(
-			bpy.context.scene.mcprep_texturepack_path,
-			"assets", "minecraft", "textures", "block", "dirt.png")
-		res = bpy.ops.mcprep.spawn_particle_planes(filepath=filepath)
-
-		if res != {'FINISHED'}:
-			return "Did not end with finished result"
-
-		# TODO: Further checks it actually loaded the effect.
-
-	def world_tools(self):
-		"""Test adding skies, prepping the world, etc"""
-		from MCprep.world_tools import get_time_object
-
-		# test with both engines (cycles+eevee, or cycles+internal)
-		self._clear_scene()
-		bpy.ops.mcprep.world()
-
-		pre_objs = len(bpy.data.objects)
-		bpy.ops.mcprep.add_mc_sky(
-			world_type='world_shader',
-			# initial_time='8',
-			add_clouds=True,
-			remove_existing_suns=True)
-		post_objs = len(bpy.data.objects)
-		if pre_objs >= post_objs:
-			return "Nothing added"
-		# find the sun, ensure it's pointed partially to the side
-		obj = get_time_object()
-		if not obj:
-			return "No detected MCprepHour controller (a)"
-
-		self._clear_scene()
-		pre_objs = len(bpy.data.objects)
-		bpy.ops.mcprep.add_mc_sky(
-			world_type='world_mesh',
-			# initial_time='12',
-			add_clouds=False,
-			remove_existing_suns=True)
-		post_objs = len(bpy.data.objects)
-		if pre_objs >= post_objs:
-			return "Nothing added"
-		# find the sun, ensure it's pointed straight down
-		obj = get_time_object()
-		if not obj:
-			return "No detected MCprepHour controller (b)"
-
-		self._clear_scene()
-		pre_objs = len(bpy.data.objects)
-		bpy.ops.mcprep.add_mc_sky(
-			world_type='world_only',
-			# initial_time='18',
-			add_clouds=False,
-			remove_existing_suns=True)
-		post_objs = len(bpy.data.objects)
-		if pre_objs >= post_objs:
-			return "Nothing added"
-		# find the sun, ensure it's pointed straight down
-		obj = get_time_object()
-		if not obj:
-			return "No detected MCprepHour controller (c)"
-
-		self._clear_scene()
-		pre_objs = len(bpy.data.objects)
-		bpy.ops.mcprep.add_mc_sky(
-			world_type='world_static_mesh',
-			# initial_time='0',
-			add_clouds=False,
-			remove_existing_suns=True)
-		post_objs = len(bpy.data.objects)
-		if pre_objs >= post_objs:
-			return "Nothing added"
-		# find the sun, ensure it's pointed straight down
-
-		self._clear_scene()
-		obj = get_time_object()
-		if obj:
-			return "Found MCprepHour controller, shouldn't be one (d)"
-		pre_objs = len(bpy.data.objects)
-		bpy.ops.mcprep.add_mc_sky(
-			world_type='world_static_only',
-			# initial_time='6',
-			add_clouds=False,
-			remove_existing_suns=True)
-		post_objs = len(bpy.data.objects)
-		if pre_objs >= post_objs:
-			return "Nothing added"
-		# test that it removes existing suns by first placing one, and then
-		# affirming it's gone
-
-	def sync_materials(self):
-		"""Test syncing materials works"""
-		self._clear_scene()
-
-		# test empty case
-		res = bpy.ops.mcprep.sync_materials(
-			link=False,
-			replace_materials=False,
-			skipUsage=True)  # track here false to avoid error
-		if res != {'CANCELLED'}:
-			return "Should return cancel in empty scene"
-
-		# test that the base test material is included as shipped
-		bpy.ops.mesh.primitive_plane_add()
-		obj = bpy.context.object
-		if bpy.app.version >= (2, 80):
-			obj.select_set(True)
-		else:
-			obj.select = True
-
-		new_mat = bpy.data.materials.new("mcprep_test")
-		obj.active_material = new_mat
-
-		init_mats = bpy.data.materials[:]
-		init_len = len(bpy.data.materials)
-		res = bpy.ops.mcprep.sync_materials(
-			link=False,
-			replace_materials=False)
-		if res != {'FINISHED'}:
-			return "Should return finished with test file"
-
-		# check there is another material now
-		imported = set(bpy.data.materials[:]) - set(init_mats)
-		post_len = len(bpy.data.materials)
-		if not list(imported):
-			return "No new materials found"
-		elif len(list(imported)) > 1:
-			return "More than one material generated"
-		elif list(imported)[0].library:
-			return "Material linked should not be a library"
-		elif post_len - 1 != init_len:
-			return "Should have imported specifically one material"
-
-		new_mat.name = "mcprep_test"
-		init_len = len(bpy.data.materials)
-		res = bpy.ops.mcprep.sync_materials(
-			link=False,
-			replace_materials=True)
-		if res != {'FINISHED'}:
-			return "Should return finished with test file (replace)"
-		if len(bpy.data.materials) != init_len:
-			return "Number of materials should not have changed with replace"
-
-		# Now test it works with name generalization, stripping .###
-		new_mat.name = "mcprep_test.005"
-		init_mats = bpy.data.materials[:]
-		init_len = len(bpy.data.materials)
-		res = bpy.ops.mcprep.sync_materials(
-			link=False,
-			replace_materials=False)
-		if res != {'FINISHED'}:
-			return "Should return finished with test file"
-
-		# check there is another material now
-		imported = set(bpy.data.materials[:]) - set(init_mats)
-		post_len = len(bpy.data.materials)
-		if not list(imported):
-			return "No new materials found"
-		elif len(list(imported)) > 1:
-			return "More than one material generated"
-		elif list(imported)[0].library:
-			return "Material linked should not be a library"
-		elif post_len - 1 != init_len:
-			return "Should have imported specifically one material"
-
-	def sync_materials_link(self):
-		"""Test syncing materials works"""
-		self._clear_scene()
-
-		# test that the base test material is included as shipped
-		bpy.ops.mesh.primitive_plane_add()
-		obj = bpy.context.object
-		if bpy.app.version >= (2, 80):
-			obj.select_set(True)
-		else:
-			obj.select = True
-
-		new_mat = bpy.data.materials.new("mcprep_test")
-		obj.active_material = new_mat
-
-		new_mat.name = "mcprep_test"
-		init_mats = bpy.data.materials[:]
-		res = bpy.ops.mcprep.sync_materials(
-			link=True,
-			replace_materials=False)
-		if res != {'FINISHED'}:
-			return "Should return finished with test file (link)"
-		imported = set(bpy.data.materials[:]) - set(init_mats)
-		imported = list(imported)
-		if not imported:
-			return "No new material found after linking"
-		if not list(imported)[0].library:
-			return "Material linked is not a library"
-
-	def load_material(self):
-		"""Test the load material operators and related resets"""
-		self._clear_scene()
-		bpy.ops.mcprep.reload_materials()
-
-		# add object
-		bpy.ops.mesh.primitive_cube_add()
-
-		scn_props = bpy.context.scene.mcprep_props
-		itm = scn_props.material_list[scn_props.material_list_index]
-		path = itm.path
-		bpy.ops.mcprep.load_material(filepath=path)
-
-		# validate that the loaded material has a name matching current list
-		mat = bpy.context.object.active_material
-		scn_props = bpy.context.scene.mcprep_props
-		mat_item = scn_props.material_list[scn_props.material_list_index]
-		if mat_item.name not in mat.name:
-			return "Material name not loaded " + mat.name
-
-	def uv_transform_detection(self):
-		"""Ensure proper detection and transforms for Mineways all-in-one images"""
-		from MCprep.materials.uv_tools import get_uv_bounds_per_material
-		self._clear_scene()
-
-		bpy.ops.mesh.primitive_cube_add()
-		bpy.ops.object.editmode_toggle()
-		bpy.ops.mesh.select_all(action='SELECT')
-		bpy.ops.uv.reset()
-		bpy.ops.object.editmode_toggle()
-		new_mat = bpy.data.materials.new(name="tmp")
-		bpy.context.object.active_material = new_mat
-
-		if not bpy.context.object or not bpy.context.object.active_material:
-			return "Failed set up for uv_transform_detection"
-
-		uv_bounds = get_uv_bounds_per_material(bpy.context.object)
-		mname = bpy.context.object.active_material.name
-		if uv_bounds != {mname: [0, 1, 0, 1]}:
-			return "UV transform for default cube should have max bounds"
-
-		bpy.ops.object.editmode_toggle()
-		bpy.ops.mesh.select_all(action='SELECT')
-		bpy.ops.uv.sphere_project()  # will ensure more irregular UV map, not bounded
-		bpy.ops.object.editmode_toggle()
-		uv_bounds = get_uv_bounds_per_material(bpy.context.object)
-		if uv_bounds == {mname: [0, 1, 0, 1]}:
-			return "UV mapping is irregular, should have different min/max"
-
-	def uv_transform_no_alert(self):
-		"""Ensure that uv transform alert does not go off unexpectedly"""
-		from MCprep.materials.uv_tools import detect_invalid_uvs_from_objs
-		self._clear_scene()
-
-		self._import_mineways_separated()
-		invalid, invalid_objs = detect_invalid_uvs_from_objs(
-			bpy.context.selected_objects)
-		prt = ",".join([obj.name for obj in invalid_objs])  # obj.name.split("_")[-1]
-		if invalid is True:
-			return "Mineways separated tiles export should not alert: " + prt
-
-		self._clear_scene()
-		self._import_jmc2obj_full()
-		invalid, invalid_objs = detect_invalid_uvs_from_objs(
-			bpy.context.selected_objects)
-		prt = ",".join([obj.name.split("_")[-1] for obj in invalid_objs])
-		if invalid is True:
-			return "jmc2obj export should not alert: " + prt
-
-	def uv_transform_combined_alert(self):
-		"""Ensure that uv transform alert goes off for Mineways all-in-one"""
-		from MCprep.materials.uv_tools import detect_invalid_uvs_from_objs
-		self._clear_scene()
-
-		self._import_mineways_combined()
-		invalid, invalid_objs = detect_invalid_uvs_from_objs(
-			bpy.context.selected_objects)
-		if invalid is False:
-			return "Combined image export should alert"
-		if not invalid_objs:
-			return "Correctly alerted combined image, but no obj's returned"
-
-		# Do specific checks for water and lava, since they might be combined
-		# and cover more than one uv position (and falsely pass the test)
-		# in combined, water is called "Stationary_Wat" and "Stationary_Lav"
-		# (yes, appears cutoff; and yes includes the flowing too)
-		# NOTE! in 2.7x, will be named "Stationary_Water", but in 2.9 it is
-		# "Test_MCprep_1.16.4__-145_4_1271_to_-118_255_1311_Stationary_Wat"
-		water_obj = [
-			obj for obj in bpy.data.objects if "Stationary_Wat" in obj.name][0]
-		lava_obj = [
-			obj for obj in bpy.data.objects if "Stationary_Lav" in obj.name][0]
-
-		invalid, invalid_objs = detect_invalid_uvs_from_objs([lava_obj, water_obj])
-		if invalid is False:
-			return "Combined lava/water should still alert"
-
-	def test_generate_material_sequence(self):
-		"""Ensure that generating an image sequence works as expected."""
-		from MCprep.materials.sequences import generate_material_sequence
-
-		# ALT: call animate_single_material
-		# animate_single_material(
-		# mat, engine, export_location='original', clear_cache=False)
-
-		tiled_img = os.path.join(
-			os.path.dirname(__file__),
-			"test_resource_pack", "textures", "campfire_fire.png")
-		fake_orig_img = tiled_img
-		result_dir = tiled_img[:-4]  # Same name, sans extension.
-
-		try:
-			shutil.rmtree(result_dir)
-		except Exception as err:
-			print("Error removing prior directory of animated campfire")
-			print(err)
-
-		# Ensure that the folder does not initially exist
-		if os.path.isdir(result_dir):
-			return "Folder pre-exists, should be removed before test"
-
-		res, err = generate_material_sequence(
-			source_path=fake_orig_img,
-			image_path=tiled_img,
-			form=None,
-			export_location="original",
-			clear_cache=True)
-
-		if err:
-			return "Generate materials had an error: " + str(err)
-		if not res:
-			return "Failed to get success resposne from generate img sequence"
-
-		if not os.path.isdir(result_dir):
-			return "Output directory does not exist"
-
-		gen_files = [img for img in os.listdir(result_dir) if img.endswith(".png")]
-		if not gen_files:
-			return "No images generated"
-
-		# Now do cleanup.
-		shutil.rmtree(result_dir)
-
-	def test_enable_obj_importer(self):
-		"""Ensure module name is correct, since error won't be reported."""
-		bpy.ops.preferences.addon_enable(module="io_scene_obj")
-
-	def qa_effects(self):
-		"""Ensures that effects files meet all QA needs"""
-
-		basepath = os.path.join("MCprep_addon", "MCprep_resources", "effects")
-		basepath = os.path.abspath(basepath)  # relative to the dev git folder
-
-		bfiles = []
-		for child in os.listdir(basepath):
-			fullp = os.path.join(basepath, child)
-			if os.path.isfile(fullp) and child.lower().endswith(".blend"):
-				bfiles.append(fullp)
-			elif not os.path.isdir(fullp):
-				continue
-			subblends = [
-				os.path.join(basepath, child, blend)
-				for blend in os.listdir(os.path.join(basepath, child))
-				if os.path.isfile(os.path.join(basepath, child, blend))
-				and blend.lower().endswith(".blend")
-			]
-			bfiles.extend(subblends)
-
-		print("Checking blend files")
-		if not bfiles:
-			return "No files loaded for bfiles"
-
-		issues = []
-		checked = 0
-		for blend in bfiles:
-			print("QC'ing:", blend)
-			if not os.path.isfile(blend):
-				return "Did not exist: " + str(blend)
-			bpy.ops.wm.open_mainfile(filepath=blend)
-
-			resp = self._qa_helper(basepath, allow_packed=True)
-			if resp:
-				issues.append([blend, resp])
-			checked += 1
-
-		if issues:
-			return issues
-
-	def qa_rigs(self):
-		"""Ensures that all rig files meet all QA needs.
-
-		NOTE: This test is actually surpisingly fast given the number of files
-		it needs to check against, but it's possible it can be unstable. Exit
-		early to override if needed.
-		"""
-
-		basepath = os.path.join("MCprep_addon", "MCprep_resources", "rigs")
-		basepath = os.path.abspath(basepath)  # relative to the dev git folder
-
-		bfiles = []
-		for child in os.listdir(basepath):
-			fullp = os.path.join(basepath, child)
-			if os.path.isfile(fullp) and child.lower().endswith(".blend"):
-				bfiles.append(fullp)
-			elif not os.path.isdir(fullp):
-				continue
-			subblends = [
-				os.path.join(basepath, child, blend)
-				for blend in os.listdir(os.path.join(basepath, child))
-				if os.path.isfile(os.path.join(basepath, child, blend))
-				and blend.lower().endswith(".blend")
-			]
-			bfiles.extend(subblends)
-
-		print("Checking blend files")
-		if not bfiles:
-			return "No files loaded for bfiles"
-
-		issues = []
-		checked = 0
-		for blend in bfiles:
-			print("QC'ing:", blend)
-			if not os.path.isfile(blend):
-				return "Did not exist: " + str(blend)
-			bpy.ops.wm.open_mainfile(filepath=blend)
-
-			resp = self._qa_helper(basepath, allow_packed=True)
-			if resp:
-				issues.append([blend, resp])
-			checked += 1
-
-		if issues:
-			return "Checked {} rigs, issues: {}".format(
-				checked, issues)
-
-	def convert_mtl_simple(self):
-		"""Ensures that conversion of the mtl with other color space works."""
-		from MCprep import world_tools
-
-		src = "mtl_simple_original.mtl"
-		end = "mtl_simple_modified.mtl"
-		test_dir = os.path.dirname(__file__)
-		simple_mtl = os.path.join(test_dir, src)
-		modified_mtl = os.path.join(test_dir, end)
-
-		# now save the texturefile somewhere
-		tmp_dir = tempfile.gettempdir()
-		tmp_mtl = os.path.join(tmp_dir, src)
-		shutil.copyfile(simple_mtl, tmp_mtl)  # leave original intact
-
-		if not os.path.isfile(tmp_mtl):
-			return "Failed to create tmp tml at " + tmp_mtl
-
-		# Need to mock:
-		# bpy.context.scene.view_settings.view_transform
-		# to be an invalid kind of attribute, to simulate an ACES or AgX space.
-		# But we can't do that since we're not (yet) using the real unittest
-		# framework, hence we'll just clear the  world_tool's vars.
-		save_init = list(world_tools.BUILTIN_SPACES)
-		world_tools.BUILTIN_SPACES = ["NotRealSpace"]
-		print("TEST: pre", world_tools.BUILTIN_SPACES)
-
-		# Resultant file
-		res = world_tools.convert_mtl(tmp_mtl)
-
-		# Restore the property we unset.
-		world_tools.BUILTIN_SPACES = save_init
-		print("TEST: post", world_tools.BUILTIN_SPACES)
-
-		if res is None:
-			return "Failed to mock color space and thus could not test convert_mtl"
-
-		if res is False:
-			return "Convert mtl failed with false response"
-
-		# Now check that the data is the same.
-		res = filecmp.cmp(tmp_mtl, modified_mtl, shallow=False)
-		if res is not True:
-			# Not removing file, since we likely want to inspect it.
-			return "Generated MTL is different: {} vs {}".format(
-				tmp_mtl, modified_mtl)
-		else:
-			os.remove(tmp_mtl)
-
-	def convert_mtl_skip(self):
-		"""Ensures that we properly skip if a built in space active."""
-		from MCprep import world_tools
-
-		src = "mtl_simple_original.mtl"
-		test_dir = os.path.dirname(__file__)
-		simple_mtl = os.path.join(test_dir, src)
-
-		# now save the texturefile somewhere
-		tmp_dir = tempfile.gettempdir()
-		tmp_mtl = os.path.join(tmp_dir, src)
-		shutil.copyfile(simple_mtl, tmp_mtl)  # leave original intact
-
-		if not os.path.isfile(tmp_mtl):
-			return "Failed to create tmp tml at " + tmp_mtl
-
-		# Need to mock:
-		# bpy.context.scene.view_settings.view_transform
-		# to be an invalid kind of attribute, to simulate an ACES or AgX space.
-		# But we can't do that since we're not (yet) using the real unittest
-		# framework, hence we'll just clear the  world_tool's vars.
-		actual_space = str(bpy.context.scene.view_settings.view_transform)
-		save_init = list(world_tools.BUILTIN_SPACES)
-		world_tools.BUILTIN_SPACES = [actual_space]
-		print("TEST: pre", world_tools.BUILTIN_SPACES)
-
-		# Resultant file
-		res = world_tools.convert_mtl(tmp_mtl)
-
-		# Restore the property we unset.
-		world_tools.BUILTIN_SPACES = save_init
-		print("TEST: post", world_tools.BUILTIN_SPACES)
-
-		if res is not None:
-			os.remove(tmp_mtl)
-			return "Should not have converter MTL for valid space"
+class mcprep_testing:
+    # {status}, func, prefunc caller (reference only)
+
+    def __init__(self):
+        self.suppress = True  # hold stdout
+        self.test_status = {}  # {func.__name__: {"check":-1, "res":-1,0,1}}
+        self.test_cases = [
+            self.enable_mcprep,
+            self.prep_materials,
+            self.prep_materials_pbr,
+            self.prep_missing_passes,
+            self.openfolder,
+            self.spawn_mob,
+            self.spawn_mob_linked,
+            self.check_blend_eligible,
+            self.check_blend_eligible_middle,
+            self.check_blend_eligible_real,
+            self.change_skin,
+            self.import_world_split,
+            self.import_world_fail,
+            self.import_jmc2obj,
+            self.import_mineways_separated,
+            self.import_mineways_combined,
+            self.name_generalize,
+            self.canonical_name_no_none,
+            self.canonical_test_mappings,
+            self.meshswap_spawner,
+            self.meshswap_jmc2obj,
+            self.meshswap_mineways_separated,
+            self.meshswap_mineways_combined,
+            self.detect_desaturated_images,
+            self.detect_extra_passes,
+            self.find_missing_images_cycles,
+            self.qa_meshswap_file,
+            self.item_spawner,
+            self.item_spawner_resize,
+            self.entity_spawner,
+            self.model_spawner,
+            self.geonode_effect_spawner,
+            self.particle_area_effect_spawner,
+            self.collection_effect_spawner,
+            self.img_sequence_effect_spawner,
+            self.particle_plane_effect_spawner,
+            self.sync_materials,
+            self.sync_materials_link,
+            self.load_material,
+            self.uv_transform_detection,
+            self.uv_transform_no_alert,
+            self.uv_transform_combined_alert,
+            self.world_tools,
+            self.test_enable_obj_importer,
+            self.test_generate_material_sequence,
+            self.qa_effects,
+            self.qa_rigs,
+            self.convert_mtl_simple,
+            self.convert_mtl_skip,
+        ]
+        self.run_only = None  # Name to give to only run this test
+
+        self.mcprep_json = {}
+
+    def run_all_tests(self):
+        """For use in command line mode, run all tests and checks"""
+        if self.run_only and self.run_only not in [
+            tst.__name__ for tst in self.test_cases
+        ]:
+            print(
+                "{}No tests ran!{} Test function not found: {}".format(
+                    COL.FAIL, COL.ENDC, self.run_only
+                )
+            )
+
+        for test in self.test_cases:
+            if self.run_only and test.__name__ != self.run_only:
+                continue
+            self.mcrprep_run_test(test)
+
+        failed_tests = [
+            tst for tst in self.test_status if self.test_status[tst]["check"] < 0
+        ]
+        passed_tests = [
+            tst for tst in self.test_status if self.test_status[tst]["check"] > 0
+        ]
+
+        print(
+            "\n{}COMPLETED, {} passed and {} failed{}".format(
+                COL.HEADER, len(passed_tests), len(failed_tests), COL.ENDC
+            )
+        )
+        if passed_tests:
+            print("{}Passed tests:{}".format(COL.OKGREEN, COL.ENDC))
+            print("\t" + ", ".join(passed_tests))
+        if failed_tests:
+            print("{}Failed tests:{}".format(COL.FAIL, COL.ENDC))
+            for tst in self.test_status:
+                if self.test_status[tst]["check"] > 0:
+                    continue
+                ert = suffix_chars(self.test_status[tst]["res"], 70)
+                print("\t{}{}{}: {}".format(COL.UNDERLINE, tst, COL.ENDC, ert))
+
+        # indicate if all tests passed for this blender version
+        if not failed_tests:
+            with open(TEST_FILE, "a") as tsv:
+                tsv.write("{}\t{}\t-\n".format(bpy.app.version, "ALL PASSED"))
+
+    def write_placeholder(self, test_name):
+        """Append placeholder, presuming if not changed then blender crashed"""
+        with open(TEST_FILE, "a") as tsv:
+            tsv.write(
+                "{}\t{}\t-\n".format(bpy.app.version, "CRASH during " + test_name)
+            )
+
+    def update_placeholder(self, test_name, test_failure):
+        """Update text of (if error) or remove placeholder row of file"""
+        with open(TEST_FILE, "r") as tsv:
+            contents = tsv.readlines()
+
+        if not test_failure:  # None or ""
+            contents = contents[:-1]
+        else:
+            this_failure = "{}\t{}\t{}\n".format(
+                bpy.app.version, test_name, suffix_chars(test_failure, 20)
+            )
+            contents[-1] = this_failure
+        with open(TEST_FILE, "w") as tsv:
+            for row in contents:
+                tsv.write(row)
+
+    def mcrprep_run_test(self, test_func):
+        """Run a single MCprep test"""
+        print("\n{}Testing {}{}".format(COL.HEADER, test_func.__name__, COL.ENDC))
+        self.write_placeholder(test_func.__name__)
+        self._clear_scene()
+        try:
+            if self.suppress:
+                stdout = io.StringIO()
+                with redirect_stdout(stdout):
+                    res = test_func()
+            else:
+                res = test_func()
+            if not res:
+                print("\t{}TEST PASSED{}".format(COL.OKGREEN, COL.ENDC))
+                self.test_status[test_func.__name__] = {"check": 1, "res": res}
+            else:
+                print("\t{}TEST FAILED:{}".format(COL.FAIL, COL.ENDC))
+                print("\t" + res)
+                self.test_status[test_func.__name__] = {"check": -1, "res": res}
+        except Exception:
+            print("\t{}TEST FAILED{}".format(COL.FAIL, COL.ENDC))
+            print(traceback.format_exc())  # other info, e.g. line number/file
+            res = traceback.format_exc()
+            self.test_status[test_func.__name__] = {"check": -1, "res": res}
+        # print("\tFinished test {}".format(test_func.__name__))
+        self.update_placeholder(test_func.__name__, res)
+
+    def setup_env_paths(self):
+        """Adds the MCprep installed addon path to sys for easier importing."""
+        to_add = None
+
+        for base in bpy.utils.script_paths():
+            init = os.path.join(base, "addons", "MCprep_addon", "__init__.py")
+            if os.path.isfile(init):
+                to_add = init
+                break
+        if not to_add:
+            raise Exception("Could not add the environment path for direct importing")
+
+        # add to path and bind so it can use relative improts (3.5 trick)
+        spec = importlib.util.spec_from_file_location("MCprep", to_add)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+
+        from MCprep import conf
+
+        conf.env = conf.MCprepEnv()
+
+    def get_mcprep_path(self):
+        """Returns the addon basepath installed in this blender instance"""
+        for base in bpy.utils.script_paths():
+            init = os.path.join(base, "addons", "MCprep_addon")  # __init__.py folder
+            if os.path.isdir(init):
+                return init
+        return None
+
+    # -----------------------------------------------------------------------------
+    # Testing utilities, not tests themselves (ie assumed to work)
+    # -----------------------------------------------------------------------------
+
+    def _clear_scene(self):
+        """Clear scene and data without printouts"""
+        # if not self.suppress:
+        # stdout = io.StringIO()
+        # with redirect_stdout(stdout):
+        bpy.ops.wm.read_homefile(app_template="")
+        for obj in bpy.data.objects:
+            bpy.data.objects.remove(obj)
+        for mat in bpy.data.materials:
+            bpy.data.materials.remove(mat)
+            # for txt in bpy.data.texts:
+            # 	bpy.data.texts.remove(txt)
+
+    def _add_character(self):
+        """Add a rigged character to the scene, specifically Alex"""
+        bpy.ops.mcprep.reload_mobs()
+        # mcmob_type='player/Simple Rig - Boxscape-TheDuckCow.blend:/:Simple Player'
+        # mcmob_type='player/Alex FancyFeet - TheDuckCow & VanguardEnni.blend:/:alex'
+        # Formatting os.path.sep below required for windows support.
+        mcmob_type = "hostile{}mobs - Rymdnisse.blend:/:silverfish".format(os.path.sep)
+        bpy.ops.mcprep.mob_spawner(mcmob_type=mcmob_type)
+
+    def _import_jmc2obj_full(self):
+        """Import the full jmc2obj test set"""
+        testdir = os.path.dirname(__file__)
+        obj_path = os.path.join(testdir, "jmc2obj", "jmc2obj_test_1_15_2.obj")
+        bpy.ops.mcprep.import_world_split(filepath=obj_path)
+
+    def _import_mineways_separated(self):
+        """Import the full jmc2obj test set"""
+        testdir = os.path.dirname(__file__)
+        obj_path = os.path.join(
+            testdir,
+            "mineways",
+            "separated_textures",
+            "mineways_test_separated_1_15_2.obj",
+        )
+        bpy.ops.mcprep.import_world_split(filepath=obj_path)
+
+    def _import_mineways_combined(self):
+        """Import the full jmc2obj test set"""
+        testdir = os.path.dirname(__file__)
+        obj_path = os.path.join(
+            testdir,
+            "mineways",
+            "combined_textures",
+            "mineways_test_combined_1_15_2.obj",
+        )
+        bpy.ops.mcprep.import_world_split(filepath=obj_path)
+
+    def _create_canon_mat(self, canon=None, test_pack=False):
+        """Creates a material that should be recognized"""
+        name = canon if canon else "dirt"
+        mat = bpy.data.materials.new(name)
+        mat.use_nodes = True
+        img_node = mat.node_tree.nodes.new(type="ShaderNodeTexImage")
+        if canon and not test_pack:
+            base = self.get_mcprep_path()
+            filepath = os.path.join(
+                base,
+                "MCprep_resources",
+                "resourcepacks",
+                "mcprep_default",
+                "assets",
+                "minecraft",
+                "textures",
+                "block",
+                canon + ".png",
+            )
+            img = bpy.data.images.load(filepath)
+        elif canon and test_pack:
+            testdir = os.path.dirname(__file__)
+            filepath = os.path.join(
+                testdir, "test_resource_pack", "textures", canon + ".png"
+            )
+            img = bpy.data.images.load(filepath)
+        else:
+            img = bpy.data.images.new(name, 16, 16)
+        img_node.image = img
+        return mat, img_node
+
+    def _set_test_mcprep_texturepack_path(self, reset=False):
+        """Assigns or resets the local texturepack path."""
+        testdir = os.path.dirname(__file__)
+        path = os.path.join(testdir, "test_resource_pack")
+        if not os.path.isdir(path):
+            raise Exception("Failed to set test texturepack path")
+        bpy.context.scene.mcprep_texturepack_path = path
+
+    # Seems that infolog doesn't update in background mode
+    def _get_last_infolog(self):
+        """Return back the latest info window log"""
+        for txt in bpy.data.texts:
+            bpy.data.texts.remove(txt)
+        _ = bpy.ops.ui.reports_to_textblock()
+        print("DEVVVV get last infolog:")
+        for ln in bpy.data.texts["Recent Reports"].lines:
+            print(ln.body)
+        print("END printlines")
+        return bpy.data.texts["Recent Reports"].lines[-1].body
+
+    def _set_exporter(self, name):
+        """Sets the exporter name"""
+        # from MCprep.util import get_user_preferences
+        if name not in ["(choose)", "jmc2obj", "Mineways"]:
+            raise Exception("Invalid exporter set tyep")
+        context = bpy.context
+        if hasattr(context, "user_preferences"):
+            prefs = context.user_preferences.addons.get("MCprep_addon", None)
+        elif hasattr(context, "preferences"):
+            prefs = context.preferences.addons.get("MCprep_addon", None)
+        prefs.preferences.MCprep_exporter_type = name
+
+    def _debug_save_file_state(self):
+        """Saves the current scene state to a test file for inspection."""
+        testdir = os.path.dirname(__file__)
+        path = os.path.join(testdir, "debug_save_state.blend")
+        bpy.ops.wm.save_as_mainfile(filepath=path)
+
+    # -----------------------------------------------------------------------------
+    # Operator unit tests
+    # -----------------------------------------------------------------------------
+
+    def enable_mcprep(self):
+        """Ensure we can both enable and disable MCprep"""
+
+        # brute force enable
+        # stdout = io.StringIO()
+        # with redirect_stdout(stdout):
+        try:
+            if hasattr(bpy.ops, "preferences") and "addon_enable" in dir(
+                bpy.ops.preferences
+            ):
+                bpy.ops.preferences.addon_enable(module="MCprep_addon")
+            else:
+                bpy.ops.wm.addon_enable(module="MCprep_addon")
+        except Exception:
+            pass
+
+        # see if we can safely toggle off and back on
+        if hasattr(bpy.ops, "preferences") and "addon_enable" in dir(
+            bpy.ops.preferences
+        ):
+            bpy.ops.preferences.addon_disable(module="MCprep_addon")
+            bpy.ops.preferences.addon_enable(module="MCprep_addon")
+        else:
+            bpy.ops.wm.addon_disable(module="MCprep_addon")
+            bpy.ops.wm.addon_enable(module="MCprep_addon")
+
+    def prep_materials(self):
+        # run once when nothing is selected, no active object
+        self._clear_scene()
+
+        status = "fail"
+        print("Checking blank usage")
+        try:
+            bpy.ops.mcprep.prep_materials(
+                animateTextures=False,
+                packFormat="simple",
+                autoFindMissingTextures=False,
+                improveUiSettings=False,
+            )
+        except RuntimeError as e:
+            if "Error: No objects selected" in str(e):
+                status = "success"
+            else:
+                return "prep_materials other err: " + str(e)
+        if status == "fail":
+            return "Prep should have failed with error on no objects"
+
+        # add object, no material. Should still fail as no materials
+        bpy.ops.mesh.primitive_plane_add()
+        obj = bpy.context.object
+        status = "fail"
+        try:
+            res = bpy.ops.mcprep.prep_materials(
+                animateTextures=False,
+                packFormat="simple",
+                autoFindMissingTextures=False,
+                improveUiSettings=False,
+            )
+        except RuntimeError as e:
+            if "No materials found" in str(e):
+                status = "success"  # Expect to fail when nothing selected.
+        if status == "fail":
+            return "mcprep.prep_materials-02 failure"
+
+        # TODO: Add test where material is added but without an image/nodes
+
+        # add object with canonical material name. Assume cycles
+        new_mat, _ = self._create_canon_mat()
+        obj.active_material = new_mat
+        status = "fail"
+        try:
+            res = bpy.ops.mcprep.prep_materials(
+                animateTextures=False,
+                packFormat="simple",
+                autoFindMissingTextures=False,
+                improveUiSettings=False,
+            )
+        except Exception as e:
+            return "Unexpected error: " + str(e)
+        # how to tell if prepping actually occured? Should say 1 material prepped
+        # print(self._get_last_infolog()) # error in 2.82+, not used anyways
+        if res != {"FINISHED"}:
+            return "Did not return finished"
+
+    def prep_materials_pbr(self):
+        # add object with canonical material name. Assume cycles
+        self._clear_scene()
+        bpy.ops.mesh.primitive_plane_add()
+
+        obj = bpy.context.object
+        new_mat, _ = self._create_canon_mat()
+        obj.active_material = new_mat
+        try:
+            res = bpy.ops.mcprep.prep_materials(
+                animateTextures=False,
+                autoFindMissingTextures=False,
+                packFormat="specular",
+                improveUiSettings=False,
+            )
+        except Exception as e:
+            return "Unexpected error: " + str(e)
+        if res != {"FINISHED"}:
+            return "Did not return finished"
+
+        self._clear_scene()
+        bpy.ops.mesh.primitive_plane_add()
+
+        obj = bpy.context.object
+        new_mat, _ = self._create_canon_mat()
+        obj.active_material = new_mat
+        try:
+            res = bpy.ops.mcprep.prep_materials(
+                animateTextures=False,
+                autoFindMissingTextures=False,
+                packFormat="seus",
+                improveUiSettings=False,
+            )
+        except Exception as e:
+            return "Unexpected error: " + str(e)
+        if res != {"FINISHED"}:
+            return "Did not return finished"
+
+    def prep_missing_passes(self):
+        """Test when prepping with passes after simple, n/s passes loaded."""
+
+        self._clear_scene()
+        bpy.ops.mesh.primitive_plane_add()
+
+        self._set_test_mcprep_texturepack_path()
+
+        obj = bpy.context.object
+        new_mat, _ = self._create_canon_mat("diamond_ore", test_pack=True)
+        obj.active_material = new_mat
+
+        # Start with simple material loaded, non pbr/no extra passes
+        try:
+            res = bpy.ops.mcprep.prep_materials(
+                animateTextures=False,
+                autoFindMissingTextures=False,
+                packFormat="simple",
+                useExtraMaps=False,
+                syncMaterials=False,
+                improveUiSettings=False,
+            )
+        except Exception as e:
+            return "Unexpected error: " + str(e)
+        if res != {"FINISHED"}:
+            return "Did not return finished"
+        count_images = 0
+        missing_images = 0
+        for node in new_mat.node_tree.nodes:
+            if node.type != "TEX_IMAGE":
+                continue
+            elif node.image:
+                count_images += 1
+            else:
+                missing_images += 1
+        if count_images != 1:
+            return "Should have only 1 pass after simple load - had {}".format(
+                count_images
+            )
+        if missing_images != 0:
+            return (
+                "Should have only 0 unloaded passes after simple load - "
+                "had {}".format(count_images)
+            )
+
+        # Now try pbr load, should find the adjacent _n and _s passes and auto
+        # load it in.
+        self._set_test_mcprep_texturepack_path()
+        # return bpy.context.scene.mcprep_texturepack_path
+        try:
+            res = bpy.ops.mcprep.prep_materials(
+                animateTextures=False,
+                autoFindMissingTextures=False,
+                packFormat="specular",
+                useExtraMaps=True,
+                syncMaterials=False,  # For some reason, had to turn off.
+                improveUiSettings=False,
+            )
+        except Exception as e:
+            return "Unexpected error: " + str(e)
+        if res != {"FINISHED"}:
+            return "Did not return finished"
+        count_images = 0
+        missing_images = 0
+        new_mat = obj.active_material
+        for node in new_mat.node_tree.nodes:
+            if node.type != "TEX_IMAGE":
+                continue
+            elif node.image:
+                count_images += 1
+            else:
+                missing_images += 1
+        self._debug_save_file_state()
+        if count_images != 3:
+            return "Should have all 3 passes after pbr load - had {}".format(
+                count_images
+            )
+        if missing_images != 0:
+            return "Should have 0 unloaded passes after pbr load - had {}".format(
+                count_images
+            )
+
+    def prep_materials_cycles(self):
+        """Cycles-specific tests"""
+
+    def find_missing_images_cycles(self):
+        """Find missing images from selected materials, cycles.
+
+        Scenarios in which we find new textures
+        One: material is empty with no image block assigned at all, though has
+                image node and material is a canonical name
+        Two: material has image block but the filepath is missing, find it
+        Three: image is there, or image is packed; ie assume is fine (don't change)
+        """
+
+        # first, import a material that has no filepath
+        self._clear_scene()
+        mat, node = self._create_canon_mat("sugar_cane")
+        bpy.ops.mesh.primitive_plane_add()
+        bpy.context.object.active_material = mat
+
+        pre_path = node.image.filepath
+        bpy.ops.mcprep.replace_missing_textures(animateTextures=False)
+        post_path = node.image.filepath
+        if pre_path != post_path:
+            return "Pre/post path differed, should be the same"
+
+        # now save the texturefile somewhere
+        tmp_dir = tempfile.gettempdir()
+        tmp_image = os.path.join(tmp_dir, "sugar_cane.png")
+        shutil.copyfile(node.image.filepath, tmp_image)  # leave original intact
+
+        # Test that path is unchanged even when with a non canonical path
+        node.image.filepath = tmp_image
+        if node.image.filepath != tmp_image:
+            os.remove(tmp_image)
+            return "fialed to setup test, node path not = " + tmp_image
+        pre_path = node.image.filepath
+        bpy.ops.mcprep.replace_missing_textures(animateTextures=False)
+        post_path = node.image.filepath
+        if pre_path != post_path:
+            os.remove(tmp_image)
+            return (
+                "Pre/post path differed in tmp dir when there should have "
+                "been no change: pre {} vs post {}".format(pre_path, post_path)
+            )
+
+        # test that an empty node within a canonically named material is fixed
+        pre_path = node.image.filepath
+        node.image = None  # remove the image from block
+        if node.image:
+            os.remove(tmp_image)
+            return "failed to setup test, image block still assigned"
+        bpy.ops.mcprep.replace_missing_textures(animateTextures=False)
+        post_path = node.image.filepath
+        if not post_path:
+            os.remove(tmp_image)
+            return "No post path found, should have loaded file"
+        elif post_path == pre_path:
+            os.remove(tmp_image)
+            return "Should have loaded image as new datablock from canon location"
+        elif not os.path.isfile(post_path):
+            os.remove(tmp_image)
+            return "New path file does not exist"
+
+        # test an image with broken texturepath is fixed for cannon material name
+
+        # node.image.filepath = tmp_image # assert it's not the canonical path
+        # pre_path = node.image.filepath # the original path before renaming
+        # os.rename(tmp_image, tmp_image+"x")
+        # if os.path.isfile(bpy.path.abspath(node.image.filepath)) or pre_path != node.image.filepath:
+        # 	os.remove(pre_path)
+        # 	os.remove(tmp_image+"x")
+        # 	return "Failed to setup test, original file exists/img path updated"
+        # bpy.ops.mcprep.replace_missing_textures(animateTextures=False)
+        # post_path = node.image.filepath
+        # if pre_path == post_path:
+        # 	os.remove(tmp_image+"x")
+        # 	return "Should have updated missing image to canonical, still is "+post_path
+        # elif post_path != canonical_path:
+        # 	os.remove(tmp_image+"x")
+        # 	return "New path not canonical: "+post_path
+        # os.rename(tmp_image+"x", tmp_image)
+
+        # Example where we save and close the blend file, move the file,
+        # and re-open. First, load the scene
+        self._clear_scene()
+        mat, node = self._create_canon_mat("sugar_cane")
+        bpy.ops.mesh.primitive_plane_add()
+        bpy.context.object.active_material = mat
+        # Then, create the textures locally
+        bpy.ops.file.pack_all()
+        bpy.ops.file.unpack_all(method="USE_LOCAL")
+        unpacked_path = bpy.path.abspath(node.image.filepath)
+        # close and open, moving the file in the meantime
+        save_tmp_file = os.path.join(tmp_dir, "tmp_test.blend")
+        os.rename(unpacked_path, unpacked_path + "x")
+        bpy.ops.wm.save_mainfile(filepath=save_tmp_file)
+        bpy.ops.wm.open_mainfile(filepath=save_tmp_file)
+        # now run the operator
+        img = bpy.data.images["sugar_cane.png"]
+        pre_path = img.filepath
+        if os.path.isfile(pre_path):
+            os.remove(unpacked_path + "x")
+            return "Failed to setup test for save/reopn move"
+        bpy.ops.mcprep.replace_missing_textures(animateTextures=False)
+        post_path = img.filepath
+        if post_path == pre_path:
+            os.remove(unpacked_path + "x")
+            return "Did not change path from " + pre_path
+        elif not os.path.isfile(post_path):
+            os.remove(unpacked_path + "x")
+            return "File for blend reloaded image does not exist: {}".format(
+                node.image.filepath
+            )
+        os.remove(unpacked_path + "x")
+
+        # address the example of sugar_cane.png.001 not being detected as canonical
+        # as a front-end name (not image file)
+        self._clear_scene()
+        mat, node = self._create_canon_mat("sugar_cane")
+        bpy.ops.mesh.primitive_plane_add()
+        bpy.context.object.active_material = mat
+
+        pre_path = node.image.filepath
+        node.image = None  # remove the image from block
+        mat.name = "sugar_cane.png.001"
+        if node.image:
+            os.remove(tmp_image)
+            return "failed to setup test, image block still assigned"
+        bpy.ops.mcprep.replace_missing_textures(animateTextures=False)
+        if not node.image:
+            os.remove(tmp_image)
+            return "Failed to load new image within mat named .png.001"
+        post_path = node.image.filepath
+        if not post_path:
+            os.remove(tmp_image)
+            return "No image loaded for " + mat.name
+        elif not os.path.isfile(node.image.filepath):
+            return "File for loaded image does not exist: " + node.image.filepath
+
+        # Example running with animateTextures too
+
+        # check on image that is packed or not, or packed but no data
+        os.remove(tmp_image)
+
+    def openfolder(self):
+        if bpy.app.background is True:
+            return ""  # can't test this in background mode
+
+        folder = bpy.utils.script_path_user()
+        if not os.path.isdir(folder):
+            return "Sample folder doesn't exist, couldn't test"
+        res = bpy.ops.mcprep.openfolder(folder)
+        if res == {"FINISHED"}:
+            return ""
+        else:
+            return "Failed, returned cancelled"
+
+    def spawn_mob(self):
+        """Spawn mobs, reload mobs, etc"""
+        self._clear_scene()
+        self._add_character()  # run the utility as it's own sort of test
+
+        self._clear_scene()
+        bpy.ops.mcprep.reload_mobs()
+
+        # sample don't specify mob, just load whatever is first
+        bpy.ops.mcprep.mob_spawner()
+
+        # spawn with linking
+        # try changing the folder
+        # try install mob and uninstall
+
+    def spawn_mob_linked(self):
+        self._clear_scene()
+        bpy.ops.mcprep.reload_mobs()
+        bpy.ops.mcprep.mob_spawner(toLink=True)
+
+    def check_blend_eligible(self):
+        from MCprep.spawner import spawn_util
+
+        fake_base = "MyMob - by Person"
+
+        suffix_new = " pre9.0.0"  # Force active blender instance as older
+        suffix_old = " pre1.0.0"  # Force active blender instance as newer.
+
+        p_none = fake_base + ".blend"
+        p_new = fake_base + suffix_new + ".blend"
+        p_old = fake_base + suffix_old + ".blend"
+        rando = "rando_name" + suffix_old + ".blend"
+
+        # Check where input file is the "non-versioned" one.
+
+        res = spawn_util.check_blend_eligible(p_none, [p_none, rando])
+        if res is not True:
+            return "Should have been true even if rando has suffix"
+
+        res = spawn_util.check_blend_eligible(p_none, [p_none, p_old])
+        if res is not True:
+            return "Should be true as curr blend eligible and checked latest"
+
+        res = spawn_util.check_blend_eligible(p_none, [p_none, p_new])
+        if res is not False:
+            print(p_none, p_new, res)
+            return "Should be false as curr blend not eligible and checked latest"
+
+        # Now check if input is a versioned file.
+
+        res = spawn_util.check_blend_eligible(p_new, [p_none, p_new])
+        if res is not True:
+            return "Should have been true since we are below min blender"
+
+        res = spawn_util.check_blend_eligible(p_old, [p_none, p_old])
+        if res is not False:
+            return "Should have been false since we are above this min blender"
+
+    def check_blend_eligible_middle(self):
+        # Warden-like example, where we have equiv of pre2.80, pre3.0, and
+        # live blender 3.0+ (presuming we want to test a 2.93-like user)
+        from MCprep.spawner import spawn_util
+
+        fake_base = "WardenExample"
+
+        # Assume the "current" version of blender is like 9.1
+        # To make test not be flakey, actual version of blender can be anything
+        # in range of 2.7.0 upwards to 8.999.
+        suffix_old = " pre2.7.0"  # Force active blender instance as older.
+        suffix_mid = " pre9.0.0"  # Force active blender instance as older.
+        suffix_new = ""  # presume "latest" version
+
+        p_old = fake_base + suffix_old + ".blend"
+        p_mid = fake_base + suffix_mid + ".blend"
+        p_new = fake_base + suffix_new + ".blend"
+
+        # Test in order
+        filelist = [p_old, p_mid, p_new]
+
+        res = spawn_util.check_blend_eligible(p_old, filelist)
+        if res is True:
+            return "Older file should not match (in order)"
+        res = spawn_util.check_blend_eligible(p_mid, filelist)
+        if res is not True:
+            return "Mid file SHOULD match (in order)"
+        res = spawn_util.check_blend_eligible(p_new, filelist)
+        if res is True:
+            return "Newer file should not match (in order)"
+
+        # Test out of order
+        filelist = [p_mid, p_new, p_old]
+
+        res = spawn_util.check_blend_eligible(p_old, filelist)
+        if res is True:
+            return "Older file should not match (out of order)"
+        res = spawn_util.check_blend_eligible(p_mid, filelist)
+        if res is not True:
+            return "Mid file SHOULD match (out of order)"
+        res = spawn_util.check_blend_eligible(p_new, filelist)
+        if res is True:
+            return "Newer file should not match (out of order)"
+
+    def check_blend_eligible_real(self):
+        # This order below matches a user's who was encountering an error
+        # (the actual in-memory python list order)
+        riglist = [
+            "bee - Boxscape.blend",
+            "Blaze - Trainguy.blend",
+            "Cave Spider - Austin Prescott.blend",
+            "creeper - TheDuckCow.blend",
+            "drowned - HissingCreeper-thefunnypie2.blend",
+            "enderman - Trainguy.blend",
+            "Ghast - Trainguy.blend",
+            "guardian - Trainguy.blend",
+            "hostile - boxscape.blend",
+            "illagers - Boxscape.blend",
+            "mobs - Rymdnisse.blend",
+            "nether hostile - Boxscape.blend",
+            "piglin zombified piglin - Boxscape.blend",
+            "PolarBear - PixelFrosty.blend",
+            "ravager - Boxscape.blend",
+            "Shulker - trainguy.blend",
+            "Skeleton - Trainguy.blend",
+            "stray - thefunnypie2.blend",
+            "Warden - DigDanAnimates pre2.80.0.blend",
+            "Warden - DigDanAnimates pre3.0.0.blend",
+            "Warden - DigDanAnimates.blend",
+            "Zombie - Hissing Creeper.blend",
+            "Zombie Villager - Hissing Creeper-thefunnypie2.blend",
+        ]
+        target_list = [
+            "Warden - DigDanAnimates pre2.80.0.blend",
+            "Warden - DigDanAnimates pre3.0.0.blend",
+            "Warden - DigDanAnimates.blend",
+        ]
+
+        from MCprep.spawner import spawn_util
+
+        if bpy.app.version < (2, 80):
+            correct = "Warden - DigDanAnimates pre2.80.0.blend"
+        elif bpy.app.version < (3, 0):
+            correct = "Warden - DigDanAnimates pre3.0.0.blend"
+        else:
+            correct = "Warden - DigDanAnimates.blend"
+
+        for rig in target_list:
+            res = spawn_util.check_blend_eligible(rig, riglist)
+            if rig == correct:
+                if res is not True:
+                    return "Did not pick {} as correct rig".format(rig)
+            else:
+                if res is True:
+                    return "Should have said {} was correct - not {}".format(
+                        correct, rig
+                    )
+
+    def change_skin(self):
+        """Test scenarios for changing skin after adding a character."""
+        self._clear_scene()
+
+        bpy.ops.mcprep.reload_skins()
+        skin_ind = bpy.context.scene.mcprep_skins_list_index
+        skin_item = bpy.context.scene.mcprep_skins_list[skin_ind]
+        tex_name = skin_item["name"]
+        skin_path = os.path.join(bpy.context.scene.mcprep_skin_path, tex_name)
+
+        status = "fail"
+        try:
+            _ = bpy.ops.mcprep.applyskin(filepath=skin_path, new_material=False)
+        except RuntimeError as e:
+            if "No materials found to update" in str(e):
+                status = "success"  # expect to fail when nothing selected
+        if status == "fail":
+            return "Should have failed to skin swap with no objects selected"
+
+        # now run on a real test character, with 1 material and 2 objects
+        self._add_character()
+
+        pre_mats = len(bpy.data.materials)
+        bpy.ops.mcprep.applyskin(filepath=skin_path, new_material=False)
+        post_mats = len(bpy.data.materials)
+        if post_mats != pre_mats:  # should be unchanged
+            return (
+                "change_skin.mat counts diff despit no new mat request, "
+                "{} before and {} after".format(pre_mats, post_mats)
+            )
+
+        # do counts of materials before and after to ensure they match
+        pre_mats = len(bpy.data.materials)
+        bpy.ops.mcprep.applyskin(filepath=skin_path, new_material=True)
+        post_mats = len(bpy.data.materials)
+        if post_mats != pre_mats * 2:  # should exactly double since in new scene
+            return (
+                "change_skin.mat counts diff mat counts, "
+                "{} before and {} after".format(pre_mats, post_mats)
+            )
+
+        pre_mats = len(bpy.data.materials)
+
+        # not diff operator name, this is popup browser
+        bpy.ops.mcprep.skin_swapper(filepath=skin_path, new_material=False)
+        post_mats = len(bpy.data.materials)
+        if post_mats != pre_mats:  # should be unchanged
+            return (
+                "change_skin.mat counts differ even though should be same, "
+                "{} before and {} after".format(pre_mats, post_mats)
+            )
+
+        # TODO: Add test for when there is a bogus filename, responds with
+        # Image file not found in err
+
+        # capture info or recent out?
+        # check that username was there before or not
+        bpy.ops.mcprep.applyusernameskin(
+            username="TheDuckCow", skip_redownload=False, new_material=True
+        )
+
+        # check that timestamp of last edit of file was longer ago than above cmd
+
+        bpy.ops.mcprep.applyusernameskin(
+            username="TheDuckCow", skip_redownload=True, new_material=True
+        )
+
+        # test deleting username skin and that file is indeed deleted
+        # and not in list anymore
+
+        # bpy.ops.mcprep.applyusernameskin(
+        # 	username='TheDuckCow',
+        # 	skip_redownload=True,
+        # 	new_material=True)
+
+        # test that the file was added back
+
+        bpy.ops.mcprep.spawn_with_skin()
+        # test changing skin to file when no existing images/textres
+        # test changing skin to file when existing material
+        # test changing skin to file for both above, cycles and internal
+        # test changing skin file for both above without, then with,
+        #   then without again, normals + spec etc.
+        return
+
+    def import_world_split(self):
+        """Test that imported world has multiple objects"""
+        self._clear_scene()
+
+        pre_objects = len(bpy.data.objects)
+        self._import_jmc2obj_full()
+        post_objects = len(bpy.data.objects)
+        if post_objects + 1 > pre_objects:
+            print(
+                "Success, had {} objs, post import {}".format(pre_objects, post_objects)
+            )
+            return
+        elif post_objects + 1 == pre_objects:
+            return "Only one new object imported"
+        else:
+            return "Nothing imported"
+
+    def import_world_fail(self):
+        """Ensure loader fails if an invalid path is loaded"""
+        testdir = os.path.dirname(__file__)
+        obj_path = os.path.join(testdir, "jmc2obj", "xx_jmc2obj_test_1_14_4.obj")
+        try:
+            bpy.ops.mcprep.import_world_split(filepath=obj_path)
+        except Exception as e:
+            print("Failed, as intended: " + str(e))
+            return
+        return "World import should have returned an error"
+
+    def import_materials_util(self, mapping_set):
+        """Reusable function for testing on different obj setups"""
+        from MCprep.materials.generate import get_mc_canonical_name
+        from MCprep.materials.generate import find_from_texturepack
+        from MCprep import util
+        from MCprep import conf
+
+        util.load_mcprep_json()  # force load json cache
+        mcprep_data = conf.env.json_data["blocks"][mapping_set]
+
+        # first detect alignment to the raw underlining mappings, nothing to
+        # do with canonical yet
+        mapped = [
+            mat.name for mat in bpy.data.materials if mat.name in mcprep_data
+        ]  # ok!
+        unmapped = [
+            mat.name for mat in bpy.data.materials if mat.name not in mcprep_data
+        ]  # not ok
+        fullset = mapped + unmapped  # ie all materials
+        unleveraged = [
+            mat for mat in mcprep_data if mat not in fullset
+        ]  # not ideal, means maybe missed check
+
+        print(
+            "Mapped: {}, unmapped: {}, unleveraged: {}".format(
+                len(mapped), len(unmapped), len(unleveraged)
+            )
+        )
+
+        if len(unmapped):
+            err = "Textures not mapped to json file"
+            print(err)
+            print(sorted(unmapped))
+            print("")
+            # return err
+        if len(unleveraged) > 20:
+            err = "Json file materials not found in obj test file, may need to update world"
+            print(err)
+            print(sorted(unleveraged))
+            # return err
+
+        if len(mapped) == 0:
+            return "No materials mapped"
+        elif mapping_set == "block_mapping_mineways" and len(mapped) > 75:
+            # Known that the "combined" atlas texture of Mineways imports
+            # has low coverge, and we're not doing anything about it.
+            # but will at least capture if coverage gets *worse*.
+            pass
+        elif len(mapped) < len(unmapped):  # too many esp. for Mineways
+            # not a very optimistic threshold, but better than none
+            return "More materials unmapped than mapped"
+        print("")
+
+        # each element is [cannon_name, form], form is none if not matched
+        mapped = [get_mc_canonical_name(mat.name) for mat in bpy.data.materials]
+
+        # no matching canon name (warn)
+        mats_not_canon = [itm[0] for itm in mapped if itm[1] is None]
+        if mats_not_canon and mapping_set != "block_mapping_mineways":
+            print("Non-canon material names found: ({})".format(len(mats_not_canon)))
+            print(mats_not_canon)
+            if len(mats_not_canon) > 30:  # arbitrary threshold
+                return "Too many materials found without canonical name ({})".format(
+                    len(mats_not_canon)
+                )
+        else:
+            print("Confirmed - no non-canon images found")
+
+        # affirm the correct mappings
+        mats_no_packimage = [
+            find_from_texturepack(itm[0]) for itm in mapped if itm[1] is not None
+        ]
+        mats_no_packimage = [path for path in mats_no_packimage if path]
+        print("Mapped paths: " + str(len(mats_no_packimage)))
+
+        # could not resolve image from resource pack (warn) even though in mapping
+        mats_no_packimage = [
+            itm[0]
+            for itm in mapped
+            if itm[1] is not None and not find_from_texturepack(itm[0])
+        ]
+        print(
+            "No resource images found for mapped items: ({})".format(
+                len(mats_no_packimage)
+            )
+        )
+        print("These would appear to have cannon mappings, but then fail on lookup")
+
+        # known number up front, e.g. chests, stone_slab_side, stone_slab_top
+        if len(mats_no_packimage) > 5:
+            return "Missing images for blocks specified in mcprep_data.json: {}".format(
+                ",".join(mats_no_packimage)
+            )
+
+        # also test that there are not raw image names not in mapping list
+        # but that otherwise could be added to the mapping list as file exists
+
+    def import_jmc2obj(self):
+        """Checks that material names in output obj match the mapping file"""
+        self._clear_scene()
+        self._import_jmc2obj_full()
+
+        res = self.import_materials_util("block_mapping_jmc")
+        return res
+
+    def import_mineways_separated(self):
+        """Checks Mineways (single-image) material name mapping to mcprep_data"""
+        self._clear_scene()
+        self._import_mineways_separated()
+
+        res = self.import_materials_util("block_mapping_mineways")
+        return res
+
+    def import_mineways_combined(self):
+        """Checks Mineways (multi-image) material name mapping to mcprep_data"""
+        self._clear_scene()
+        self._import_mineways_combined()
+
+        res = self.import_materials_util("block_mapping_mineways")
+        return res
+
+    def name_generalize(self):
+        """Tests the outputs of the generalize function"""
+        from MCprep.util import nameGeneralize
+
+        test_sets = {
+            "ab": "ab",
+            "table.001": "table",
+            "table.100": "table",
+            "table001": "table001",
+            "fire_0": "fire_0",
+            # "fire_0_0001.png":"fire_0", not current behavior, but desired?
+            "fire_0_0001": "fire_0",
+            "fire_0_0001.001": "fire_0",
+            "fire_layer_1": "fire_layer_1",
+            "cartography_table_side1": "cartography_table_side1",
+        }
+        errors = []
+        for key in list(test_sets):
+            res = nameGeneralize(key)
+            if res != test_sets[key]:
+                errors.append(
+                    "{} converts to {} and should be {}".format(
+                        key, res, test_sets[key]
+                    )
+                )
+            else:
+                print("{}:{} passed".format(key, res))
+
+        if errors:
+            return "Generalize failed: " + ", ".join(errors)
+
+    def canonical_name_no_none(self):
+        """Ensure that MC canonical name never returns none"""
+        from MCprep.materials.generate import get_mc_canonical_name
+        from MCprep.util import materialsFromObj
+
+        self._clear_scene()
+        self._import_jmc2obj_full()
+        self._import_mineways_separated()
+        self._import_mineways_combined()
+
+        bpy.ops.object.select_all(action="SELECT")
+        mats = materialsFromObj(bpy.context.selected_objects)
+        canons = [[get_mc_canonical_name(mat.name)][0] for mat in mats]
+
+        if None in canons:  # detect None response to canon input
+            return "Canon returned none value"
+        if "" in canons:
+            return "Canon returned empty str value"
+
+        # Ensure it never returns None
+        in_str, _ = get_mc_canonical_name("")
+        if in_str != "":
+            return "Empty str should return empty string, not" + str(in_str)
+
+        did_raise = False
+        try:
+            get_mc_canonical_name(None)
+        except Exception:
+            did_raise = True
+        if not did_raise:
+            return "None input SHOULD raise error"
+
+        # TODO: patch conf.env.json_data["blocks"] used by addon if possible,
+        # if this is transformed into a true py unit test. This will help
+        # check against report (-MNGGQfGGTJRqoizVCer)
+
+    def canonical_test_mappings(self):
+        """Test some specific mappings to ensure they return correctly."""
+        from MCprep.materials.generate import get_mc_canonical_name
+
+        misc = {
+            ".emit": ".emit",
+        }
+        jmc_to_canon = {
+            "grass": "grass",
+            "mushroom_red": "red_mushroom",
+            # "slime": "slime_block",  # KNOWN jmc, need to address
+        }
+        mineways_to_canon = {}
+
+        for map_type in [misc, jmc_to_canon, mineways_to_canon]:
+            for key, val in map_type.items():
+                res, mapped = get_mc_canonical_name(key)
+                if res == val:
+                    continue
+                return "Wrong mapping: {} mapped to {} ({}), not {}".format(
+                    key, res, mapped, val
+                )
+
+    def meshswap_util(self, mat_name):
+        """Run meshswap on the first object with found mat_name"""
+        from MCprep.util import select_set
+
+        if mat_name not in bpy.data.materials:
+            return "Not a material: " + mat_name
+        print("\nAttempt meshswap of " + mat_name)
+        mat = bpy.data.materials[mat_name]
+
+        obj = None
+        for ob in bpy.data.objects:
+            for slot in ob.material_slots:
+                if slot and slot.material == mat:
+                    obj = ob
+                    break
+            if obj:
+                break
+        if not obj:
+            return "Failed to find obj for " + mat_name
+        print("Found the object - " + obj.name)
+
+        bpy.ops.object.select_all(action="DESELECT")
+        select_set(obj, True)
+        res = bpy.ops.mcprep.meshswap()
+        if res != {"FINISHED"}:
+            return "Meshswap returned cancelled for " + mat_name
+
+    def meshswap_spawner(self):
+        """Tests direct meshswap spawning"""
+        self._clear_scene()
+        scn_props = bpy.context.scene.mcprep_props
+        bpy.ops.mcprep.reload_meshswap()
+        if not scn_props.meshswap_list:
+            return "No meshswap assets loaded for spawning"
+        elif len(scn_props.meshswap_list) < 15:
+            return "Too few meshswap assets available"
+
+        if bpy.app.version >= (2, 80):
+            # Add with make real = False
+            bpy.ops.mcprep.meshswap_spawner(
+                block="banner", method="collection", make_real=False
+            )
+
+            # test doing two of the same one (first won't be cached, second will)
+            # Add one with make real = True
+            bpy.ops.mcprep.meshswap_spawner(
+                block="fire", method="collection", make_real=True
+            )
+            if "fire" not in bpy.data.collections:
+                return "Fire not in collections"
+            elif not bpy.context.selected_objects:
+                return "Added made-real meshswap objects not selected"
+
+            # Test that cache is properly used. Also test that the default
+            # 'method=colleciton' is used, since that's the only mode of
+            # support for meshswap spawner at the moment.
+            bpy.ops.mcprep.meshswap_spawner(block="fire", make_real=False)
+            if "fire" not in bpy.data.collections:
+                return "Fire not in collections"
+            count = sum([1 for itm in bpy.data.collections if "fire" in itm.name])
+            if count != 1:
+                return "Imported extra fire group, should have cached instead!"
+
+            # test that added item ends up in location location=(1,2,3)
+            loc = (1, 2, 3)
+            bpy.ops.mcprep.meshswap_spawner(
+                block="fire", method="collection", make_real=False, location=loc
+            )
+            if not bpy.context.object:
+                return "Added meshswap object not added as active"
+            elif not bpy.context.selected_objects:
+                return "Added meshswap object not selected"
+            if bpy.context.object.location != Vector(loc):
+                return "Location not properly applied"
+            count = sum([1 for itm in bpy.data.collections if "fire" in itm.name])
+            if count != 1:
+                return "Should have 1 fire groups exactly, did not cache"
+        else:
+            # Add with make real = False
+            bpy.ops.mcprep.meshswap_spawner(
+                block="banner", method="collection", make_real=False
+            )
+
+            # test doing two of the same one (first won't be cached, second will)
+            # Add one with make real = True
+            bpy.ops.mcprep.meshswap_spawner(
+                block="fire", method="collection", make_real=True
+            )
+            if "fire" not in bpy.data.groups:
+                return "Fire not in groups"
+            elif not bpy.context.selected_objects:
+                return "Added made-real meshswap objects not selected"
+
+            bpy.ops.mcprep.meshswap_spawner(
+                block="fire", method="collection", make_real=False
+            )
+            if "fire" not in bpy.data.groups:
+                return "Fire not in groups"
+            count_torch = sum([1 for itm in bpy.data.groups if "fire" in itm.name])
+            if count_torch != 1:
+                return "Imported extra fire group, should have cached instead!"
+
+            # test that added item ends up in location location=(1,2,3)
+            loc = (1, 2, 3)
+            bpy.ops.mcprep.meshswap_spawner(
+                block="fire", method="collection", make_real=False, location=loc
+            )
+            if not bpy.context.object:
+                return "Added meshswap object not added as active"
+            elif not bpy.context.selected_objects:
+                return "Added meshswap object not selected"
+            if bpy.context.object.location != Vector(loc):
+                return "Location not properly applied"
+
+    def meshswap_jmc2obj(self):
+        """Tests jmc2obj meshswapping"""
+        self._clear_scene()
+        self._import_jmc2obj_full()
+        self._set_exporter("jmc2obj")
+
+        # known jmc2obj material names which we expect to be able to meshswap
+        test_materials = [
+            "torch",
+            "fire",
+            "lantern",
+            "cactus_side",
+            "vines",  # plural
+            "enchant_table_top",
+            "redstone_torch_on",
+            "glowstone",
+            "redstone_lamp_on",
+            "pumpkin_front_lit",
+            "sugarcane",
+            "chest",
+            "largechest",
+            "sunflower_bottom",
+            "sapling_birch",
+            "white_tulip",
+            "sapling_oak",
+            "sapling_acacia",
+            "sapling_jungle",
+            "blue_orchid",
+            "allium",
+        ]
+
+        errors = []
+        for mat_name in test_materials:
+            try:
+                res = self.meshswap_util(mat_name)
+            except Exception as err:
+                err = str(err)
+                if len(err) > 15:
+                    res = err[:15].replace("\n", "")
+                else:
+                    res = err
+            if res:
+                errors.append(mat_name + ":" + res)
+        if errors:
+            return "Meshswap failed: " + ", ".join(errors)
+
+    def meshswap_mineways_separated(self):
+        """Tests jmc2obj meshswapping"""
+        self._clear_scene()
+        self._import_mineways_separated()
+        self._set_exporter("Mineways")
+
+        # known Mineways (separated) material names expected for meshswap
+        test_materials = [
+            "grass",
+            "torch",
+            "fire_0",
+            "MWO_chest_top",
+            "MWO_double_chest_top_left",
+            # "lantern", not in test object
+            "cactus_side",
+            "vine",  # singular
+            "enchanting_table_top",
+            # "redstone_torch_on", no separate "on" for Mineways separated exports
+            "glowstone",
+            "redstone_torch",
+            "jack_o_lantern",
+            "sugar_cane",
+            "jungle_sapling",
+            "dark_oak_sapling",
+            "oak_sapling",
+            "campfire_log",
+            "white_tulip",
+            "blue_orchid",
+            "allium",
+        ]
+
+        errors = []
+        for mat_name in test_materials:
+            try:
+                res = self.meshswap_util(mat_name)
+            except Exception as err:
+                err = str(err)
+                if len(err) > 15:
+                    res = err[:15].replace("\n", "")
+                else:
+                    res = err
+            if res:
+                errors.append(mat_name + ":" + res)
+        if errors:
+            return "Meshswap failed: " + ", ".join(errors)
+
+    def meshswap_mineways_combined(self):
+        """Tests jmc2obj meshswapping"""
+        self._clear_scene()
+        self._import_mineways_combined()
+        self._set_exporter("Mineways")
+
+        # known Mineways (separated) material names expected for meshswap
+        test_materials = [
+            "Sunflower",
+            "Torch",
+            "Redstone_Torch_(active)",
+            "Lantern",
+            "Dark_Oak_Sapling",
+            "Sapling",  # should map to oak sapling
+            "Birch_Sapling",
+            "Cactus",
+            "White_Tulip",
+            "Vines",
+            "Ladder",
+            "Enchanting_Table",
+            "Campfire",
+            "Jungle_Sapling",
+            "Red_Tulip",
+            "Blue_Orchid",
+            "Allium",
+        ]
+
+        errors = []
+        for mat_name in test_materials:
+            try:
+                res = self.meshswap_util(mat_name)
+            except Exception as err:
+                err = str(err)
+                if len(err) > 15:
+                    res = err[:15].replace("\n", "")
+                else:
+                    res = err
+            if res:
+                errors.append(mat_name + ":" + res)
+        if errors:
+            return "Meshswap combined failed: " + ", ".join(errors)
+
+    def detect_desaturated_images(self):
+        """Checks the desaturate images function works"""
+        from MCprep.materials.generate import is_image_grayscale
+
+        base = self.get_mcprep_path()
+        print("Raw base", base)
+        base = os.path.join(
+            base,
+            "MCprep_resources",
+            "resourcepacks",
+            "mcprep_default",
+            "assets",
+            "minecraft",
+            "textures",
+            "block",
+        )
+        print("Remapped base: ", base)
+
+        # known images that ARE desaturated:
+        desaturated = ["grass_block_top.png"]
+        saturated = ["grass_block_side.png", "glowstone.png"]
+
+        for tex in saturated:
+            img = bpy.data.images.load(os.path.join(base, tex))
+            if not img:
+                raise Exception("Failed to load img " + str(tex))
+            if is_image_grayscale(img) is True:
+                raise Exception(
+                    "Image {} detected as grayscale, should be saturated".format(tex)
+                )
+        for tex in desaturated:
+            img = bpy.data.images.load(os.path.join(base, tex))
+            if not img:
+                raise Exception("Failed to load img " + str(tex))
+            if is_image_grayscale(img) is False:
+                raise Exception(
+                    "Image {} detected as saturated - should be grayscale".format(tex)
+                )
+
+        # test that it is caching as expected.. by setting a false
+        # value for cache flag and seeing it's returning the property value
+
+    def detect_extra_passes(self):
+        """Ensure only the correct pbr file matches are found for input file"""
+        from MCprep.materials.generate import find_additional_passes
+
+        tmp_dir = tempfile.gettempdir()
+
+        # physically generate these empty files, then delete
+        tmp_files = [
+            "oak_log_top.png",
+            "oak_log_top-s.png",
+            "oak_log_top_n.png",
+            "oak_log.jpg",
+            "oak_log_s.jpg",
+            "oak_log_n.jpeg",
+            "oak_log_disp.jpeg",
+            "stonecutter_saw.tiff",
+            "stonecutter_saw n.tiff",
+        ]
+
+        for tmp in tmp_files:
+            fname = os.path.join(tmp_dir, tmp)
+            with open(fname, "a"):
+                os.utime(fname)
+
+        def cleanup():
+            """Failsafe delete files before raising error within test method"""
+            for tmp in tmp_files:
+                try:
+                    os.remove(os.path.join(tmp_dir, tmp))
+                except Exception:
+                    pass
+
+        # assert setup was successful
+        for tmp in tmp_files:
+            if os.path.isfile(os.path.join(tmp_dir, tmp)):
+                continue
+            cleanup()
+            raise Exception("Failed to generate test empty files")
+
+        # the test cases; input is diffuse, output is the whole dict
+        cases = [
+            {
+                "diffuse": os.path.join(tmp_dir, "oak_log_top.png"),
+                "specular": os.path.join(tmp_dir, "oak_log_top-s.png"),
+                "normal": os.path.join(tmp_dir, "oak_log_top_n.png"),
+            },
+            {
+                "diffuse": os.path.join(tmp_dir, "oak_log.jpg"),
+                "specular": os.path.join(tmp_dir, "oak_log_s.jpg"),
+                "normal": os.path.join(tmp_dir, "oak_log_n.jpeg"),
+                "displace": os.path.join(tmp_dir, "oak_log_disp.jpeg"),
+            },
+            {
+                "diffuse": os.path.join(tmp_dir, "stonecutter_saw.tiff"),
+                "normal": os.path.join(tmp_dir, "stonecutter_saw n.tiff"),
+            },
+        ]
+
+        for test in cases:
+            res = find_additional_passes(test["diffuse"])
+            if res != test:
+                cleanup()
+                # for debug readability, basepath everything
+                for itm in res:
+                    res[itm] = os.path.basename(res[itm])
+                for itm in test:
+                    test[itm] = os.path.basename(test[itm])
+                raise Exception(
+                    "Mismatch for set {}: got {} but expected {}".format(
+                        test["diffuse"], res, test
+                    )
+                )
+
+        # test other cases intended to fail
+        res = find_additional_passes(os.path.join(tmp_dir, "not_a_file.png"))
+        if res != {}:
+            cleanup()
+            raise Exception("Fake file should not have any return")
+
+    def _qa_helper(self, basepath, allow_packed):
+        """File used to help QC an open blend file."""
+
+        # bpy.ops.file.make_paths_relative() instead of this, do manually.
+        different_base = []
+        not_relative = []
+        missing = []
+        for img in bpy.data.images:
+            if not img.filepath:
+                continue
+            abspath = os.path.abspath(bpy.path.abspath(img.filepath))
+            if not abspath.startswith(basepath):
+                if allow_packed is True and img.packed_file:
+                    pass
+                else:
+                    different_base.append(os.path.basename(img.filepath))
+            if img.filepath != bpy.path.relpath(img.filepath):
+                not_relative.append(os.path.basename(img.filepath))
+            if not os.path.isfile(abspath):
+                if allow_packed is True and img.packed_file:
+                    pass
+                else:
+                    missing.append(img.name)
+
+        if len(different_base) > 50:
+            return "Wrong basepath for image filepath comparison!"
+        if different_base:
+            return "Found {} images with different basepath from file: {}".format(
+                len(different_base), ", ".join(different_base)
+            )
+        if not_relative:
+            return "Found {} non relative img files: {}".format(
+                len(not_relative), ", ".join(not_relative)
+            )
+        if missing:
+            return "Found {} img with missing source files: {}".format(
+                len(missing), ", ".join(missing)
+            )
+
+    def qa_meshswap_file(self):
+        """Open the meshswap file, assert there are no relative paths"""
+        basepath = os.path.join("MCprep_addon", "MCprep_resources")
+        basepath = os.path.abspath(basepath)  # relative to the dev git folder
+        blendfile = os.path.join(basepath, "mcprep_meshSwap.blend")
+        if not os.path.isfile(blendfile):
+            return blendfile + ": missing tests dir local meshswap file"
+        bpy.ops.wm.open_mainfile(filepath=blendfile)
+        # do NOT save this file!
+
+        resp = self._qa_helper(basepath, allow_packed=False)
+        if resp:
+            return resp
+
+        # detect any non canonical material names?? how to exclude?
+
+        # Affirm that no materials have a principled node, should be basic only
+
+    def item_spawner(self):
+        """Test item spawning and reloading"""
+        self._clear_scene()
+        scn_props = bpy.context.scene.mcprep_props
+
+        pre_items = len(scn_props.item_list)
+        bpy.ops.mcprep.reload_items()
+        post_items = len(scn_props.item_list)
+
+        if pre_items != 0:
+            return "Should have opened new file with unloaded assets?"
+        elif post_items == 0:
+            return "No items loaded"
+        elif post_items < 50:
+            return "Too few items loaded, missing texturepack?"
+
+        # spawn with whatever default index
+        pre_objs = len(bpy.data.objects)
+        bpy.ops.mcprep.spawn_item()
+        post_objs = len(bpy.data.objects)
+
+        if post_objs == pre_objs:
+            return "No items spawned"
+        elif post_objs > pre_objs + 1:
+            return "More than one item spawned"
+
+        # test core useage on a couple of out of the box textures
+
+        # test once with custom block
+        # bpy.ops.mcprep.spawn_item_file(filepath=)
+
+        # test with different thicknesses
+        # test after changing resource pack
+        # test that with an image of more than 1k pixels, it's truncated as expected
+        # test with different
+
+    def item_spawner_resize(self):
+        """Test spawning an item that requires resizing."""
+        self._clear_scene()
+        bpy.ops.mcprep.reload_items()
+
+        # Create a tmp file
+        tmp_img = bpy.data.images.new("tmp_item_spawn", 32, 32, alpha=True)
+        tmp_img.filepath = os.path.join(bpy.app.tempdir, "tmp_item.png")
+        tmp_img.save()
+
+        # spawn with whatever default index
+        pre_objs = len(bpy.data.objects)
+        bpy.ops.mcprep.spawn_item_file(max_pixels=16, filepath=tmp_img.filepath)
+        post_objs = len(bpy.data.objects)
+
+        if post_objs == pre_objs:
+            return "No items spawned"
+        elif post_objs > pre_objs + 1:
+            return "More than one item spawned"
+
+        # Now check that this item spawned has the expected face count.
+        obj = bpy.context.object
+        polys = len(obj.data.polygons)
+        print("Poly's count: ", polys)
+        if polys > 16:
+            return "Didn't scale enough to fewer pixels, facecount: " + str(polys)
+        elif polys < 16:
+            return "Over-scaled down facecount: " + str(polys)
+
+    def entity_spawner(self):
+        """Test entity spawning and reloading"""
+        self._clear_scene()
+        scn_props = bpy.context.scene.mcprep_props
+
+        pre_count = len(scn_props.entity_list)
+        bpy.ops.mcprep.reload_entities()
+        post_count = len(scn_props.entity_list)
+
+        if pre_count != 0:
+            return "Should have opened new file with unloaded assets?"
+        elif post_count == 0:
+            return "No entities loaded"
+        elif post_count < 5:
+            return "Too few entities loaded ({}), missing texturepack?".format(
+                post_count - pre_count
+            )
+
+        # spawn with whatever default index
+        pre_objs = len(bpy.data.objects)
+        bpy.ops.mcprep.entity_spawner()
+        post_objs = len(bpy.data.objects)
+
+        if post_objs == pre_objs:
+            return "No entity spawned"
+
+        # Test collection/group added
+        # Test loading from file.
+
+    def model_spawner(self):
+        """Test model spawning and reloading"""
+        self._clear_scene()
+        scn_props = bpy.context.scene.mcprep_props
+
+        pre_count = len(scn_props.model_list)
+        bpy.ops.mcprep.reload_models()
+        post_count = len(scn_props.model_list)
+
+        if pre_count != 0:
+            return "Should have opened new file with unloaded assets?"
+        elif post_count == 0:
+            return "No models loaded"
+        elif post_count < 50:
+            return "Too few models loaded, missing texturepack?"
+
+        # spawn with whatever default index
+        pre_objs = list(bpy.data.objects)
+        bpy.ops.mcprep.spawn_model(
+            filepath=scn_props.model_list[scn_props.model_list_index].filepath
+        )
+        post_objs = bpy.data.objects
+
+        if len(post_objs) == len(pre_objs):
+            return "No models spawned"
+        elif len(post_objs) > len(pre_objs) + 1:
+            return "More than one model spawned"
+
+        # Test that materials were properly added.
+        new_objs = list(set(post_objs) - set(pre_objs))
+        model = new_objs[0]
+        if not model.active_material:
+            return "No material on model"
+
+        # TODO: fetch/check there being a texture.
+
+        # Test collection/group added
+        # Test loading from file.
+
+    def geonode_effect_spawner(self):
+        """Test the geo node variant of effect spawning works."""
+        if bpy.app.version < (3, 0):
+            return  # Not supported before 3.0 anyways.
+        self._clear_scene()
+        scn_props = bpy.context.scene.mcprep_props
+        etype = "geo_area"
+
+        pre_count = len([x for x in scn_props.effects_list if x.effect_type == etype])
+        bpy.ops.mcprep.reload_effects()
+        post_count = len([x for x in scn_props.effects_list if x.effect_type == etype])
+
+        if pre_count != 0:
+            return "Should start with no effects loaded"
+        if post_count == 0:
+            return "Should have more effects loaded after reload"
+
+        effect = [x for x in scn_props.effects_list if x.effect_type == etype][0]
+        res = bpy.ops.mcprep.spawn_global_effect(effect_id=str(effect.index))
+        if res != {"FINISHED"}:
+            return "Did not end with finished result"
+
+        # TODO: Further checks it actually loaded the effect.
+        # Check that the geonode inputs are updated.
+        obj = bpy.context.object
+        if not obj:
+            return "Geo node added object not selected"
+
+        geo_nodes = [mod for mod in obj.modifiers if mod.type == "NODES"]
+        if not geo_nodes:
+            return "No geonode modifier found"
+
+        # Now validate that one of the settings was updated.
+        # TODO: example where we assert the active effect `subpath` is non empty
+
+    def particle_area_effect_spawner(self):
+        """Test the particle area variant of effect spawning works."""
+        self._clear_scene()
+        scn_props = bpy.context.scene.mcprep_props
+        etype = "particle_area"
+
+        pre_count = len([x for x in scn_props.effects_list if x.effect_type == etype])
+        bpy.ops.mcprep.reload_effects()
+        post_count = len([x for x in scn_props.effects_list if x.effect_type == etype])
+
+        if pre_count != 0:
+            return "Should start with no effects loaded"
+        if post_count == 0:
+            return "Should have more effects loaded after reload"
+
+        effect = [x for x in scn_props.effects_list if x.effect_type == etype][0]
+        res = bpy.ops.mcprep.spawn_global_effect(effect_id=str(effect.index))
+        if res != {"FINISHED"}:
+            return "Did not end with finished result"
+
+        # TODO: Further checks it actually loaded the effect.
+
+    def collection_effect_spawner(self):
+        """Test the collection variant of effect spawning works."""
+        self._clear_scene()
+        scn_props = bpy.context.scene.mcprep_props
+        etype = "collection"
+
+        pre_count = len([x for x in scn_props.effects_list if x.effect_type == etype])
+        bpy.ops.mcprep.reload_effects()
+        post_count = len([x for x in scn_props.effects_list if x.effect_type == etype])
+
+        if pre_count != 0:
+            return "Should start with no effects loaded"
+        if post_count == 0:
+            return "Should have more effects loaded after reload"
+
+        init_objs = list(bpy.data.objects)
+
+        effect = [x for x in scn_props.effects_list if x.effect_type == etype][0]
+        res = bpy.ops.mcprep.spawn_instant_effect(effect_id=str(effect.index), frame=2)
+        if res != {"FINISHED"}:
+            return "Did not end with finished result"
+
+        final_objs = list(bpy.data.objects)
+        new_objs = list(set(final_objs) - set(init_objs))
+        if len(new_objs) == 0:
+            return "didn't crate new objects"
+        if bpy.context.object not in new_objs:
+            return "Selected obj is not a new object"
+
+        is_empty = bpy.context.object.type == "EMPTY"
+        is_coll_inst = bpy.context.object.instance_type == "COLLECTION"
+        if not is_empty or not is_coll_inst:
+            return "Didn't end up with selected collection instance"
+
+        # TODO: Further checks it actually loaded the effect.
+
+    def img_sequence_effect_spawner(self):
+        """Test the image sequence variant of effect spawning works."""
+        if bpy.app.version < (2, 81):
+            return "Disabled due to consistent crashing"
+        self._clear_scene()
+        scn_props = bpy.context.scene.mcprep_props
+        etype = "img_seq"
+
+        pre_count = len([x for x in scn_props.effects_list if x.effect_type == etype])
+        bpy.ops.mcprep.reload_effects()
+        post_count = len([x for x in scn_props.effects_list if x.effect_type == etype])
+
+        if pre_count != 0:
+            return "Should start with no effects loaded"
+        if post_count == 0:
+            return "Should have more effects loaded after reload"
+
+        # Find the one with at least 10 frames.
+        effect_name = "Big smoke"
+        effect = None
+        for this_effect in scn_props.effects_list:
+            if this_effect.effect_type != etype:
+                continue
+            if this_effect.name == effect_name:
+                effect = this_effect
+
+        if not effect:
+            return "Failed to fetch {} target effect".format(effect_name)
+
+        t0 = time.time()
+        res = bpy.ops.mcprep.spawn_instant_effect(effect_id=str(effect.index))
+        if res != {"FINISHED"}:
+            return "Did not end with finished result"
+
+        t1 = time.time()
+        if t1 - t0 > 1.0:
+            return "Spawning took over 1 second for sequence effect"
+
+        # TODO: Further checks it actually loaded the effect.
+
+    def particle_plane_effect_spawner(self):
+        """Test the particle plane variant of effect spawning works."""
+        self._clear_scene()
+
+        filepath = os.path.join(
+            bpy.context.scene.mcprep_texturepack_path,
+            "assets",
+            "minecraft",
+            "textures",
+            "block",
+            "dirt.png",
+        )
+        res = bpy.ops.mcprep.spawn_particle_planes(filepath=filepath)
+
+        if res != {"FINISHED"}:
+            return "Did not end with finished result"
+
+        # TODO: Further checks it actually loaded the effect.
+
+    def world_tools(self):
+        """Test adding skies, prepping the world, etc"""
+        from MCprep.world_tools import get_time_object
+
+        # test with both engines (cycles+eevee, or cycles+internal)
+        self._clear_scene()
+        bpy.ops.mcprep.world()
+
+        pre_objs = len(bpy.data.objects)
+        bpy.ops.mcprep.add_mc_sky(
+            world_type="world_shader",
+            # initial_time='8',
+            add_clouds=True,
+            remove_existing_suns=True,
+        )
+        post_objs = len(bpy.data.objects)
+        if pre_objs >= post_objs:
+            return "Nothing added"
+        # find the sun, ensure it's pointed partially to the side
+        obj = get_time_object()
+        if not obj:
+            return "No detected MCprepHour controller (a)"
+
+        self._clear_scene()
+        pre_objs = len(bpy.data.objects)
+        bpy.ops.mcprep.add_mc_sky(
+            world_type="world_mesh",
+            # initial_time='12',
+            add_clouds=False,
+            remove_existing_suns=True,
+        )
+        post_objs = len(bpy.data.objects)
+        if pre_objs >= post_objs:
+            return "Nothing added"
+        # find the sun, ensure it's pointed straight down
+        obj = get_time_object()
+        if not obj:
+            return "No detected MCprepHour controller (b)"
+
+        self._clear_scene()
+        pre_objs = len(bpy.data.objects)
+        bpy.ops.mcprep.add_mc_sky(
+            world_type="world_only",
+            # initial_time='18',
+            add_clouds=False,
+            remove_existing_suns=True,
+        )
+        post_objs = len(bpy.data.objects)
+        if pre_objs >= post_objs:
+            return "Nothing added"
+        # find the sun, ensure it's pointed straight down
+        obj = get_time_object()
+        if not obj:
+            return "No detected MCprepHour controller (c)"
+
+        self._clear_scene()
+        pre_objs = len(bpy.data.objects)
+        bpy.ops.mcprep.add_mc_sky(
+            world_type="world_static_mesh",
+            # initial_time='0',
+            add_clouds=False,
+            remove_existing_suns=True,
+        )
+        post_objs = len(bpy.data.objects)
+        if pre_objs >= post_objs:
+            return "Nothing added"
+        # find the sun, ensure it's pointed straight down
+
+        self._clear_scene()
+        obj = get_time_object()
+        if obj:
+            return "Found MCprepHour controller, shouldn't be one (d)"
+        pre_objs = len(bpy.data.objects)
+        bpy.ops.mcprep.add_mc_sky(
+            world_type="world_static_only",
+            # initial_time='6',
+            add_clouds=False,
+            remove_existing_suns=True,
+        )
+        post_objs = len(bpy.data.objects)
+        if pre_objs >= post_objs:
+            return "Nothing added"
+        # test that it removes existing suns by first placing one, and then
+        # affirming it's gone
+
+    def sync_materials(self):
+        """Test syncing materials works"""
+        self._clear_scene()
+
+        # test empty case
+        res = bpy.ops.mcprep.sync_materials(
+            link=False, replace_materials=False, skipUsage=True
+        )  # track here false to avoid error
+        if res != {"CANCELLED"}:
+            return "Should return cancel in empty scene"
+
+        # test that the base test material is included as shipped
+        bpy.ops.mesh.primitive_plane_add()
+        obj = bpy.context.object
+        if bpy.app.version >= (2, 80):
+            obj.select_set(True)
+        else:
+            obj.select = True
+
+        new_mat = bpy.data.materials.new("mcprep_test")
+        obj.active_material = new_mat
+
+        init_mats = bpy.data.materials[:]
+        init_len = len(bpy.data.materials)
+        res = bpy.ops.mcprep.sync_materials(link=False, replace_materials=False)
+        if res != {"FINISHED"}:
+            return "Should return finished with test file"
+
+        # check there is another material now
+        imported = set(bpy.data.materials[:]) - set(init_mats)
+        post_len = len(bpy.data.materials)
+        if not list(imported):
+            return "No new materials found"
+        elif len(list(imported)) > 1:
+            return "More than one material generated"
+        elif list(imported)[0].library:
+            return "Material linked should not be a library"
+        elif post_len - 1 != init_len:
+            return "Should have imported specifically one material"
+
+        new_mat.name = "mcprep_test"
+        init_len = len(bpy.data.materials)
+        res = bpy.ops.mcprep.sync_materials(link=False, replace_materials=True)
+        if res != {"FINISHED"}:
+            return "Should return finished with test file (replace)"
+        if len(bpy.data.materials) != init_len:
+            return "Number of materials should not have changed with replace"
+
+        # Now test it works with name generalization, stripping .###
+        new_mat.name = "mcprep_test.005"
+        init_mats = bpy.data.materials[:]
+        init_len = len(bpy.data.materials)
+        res = bpy.ops.mcprep.sync_materials(link=False, replace_materials=False)
+        if res != {"FINISHED"}:
+            return "Should return finished with test file"
+
+        # check there is another material now
+        imported = set(bpy.data.materials[:]) - set(init_mats)
+        post_len = len(bpy.data.materials)
+        if not list(imported):
+            return "No new materials found"
+        elif len(list(imported)) > 1:
+            return "More than one material generated"
+        elif list(imported)[0].library:
+            return "Material linked should not be a library"
+        elif post_len - 1 != init_len:
+            return "Should have imported specifically one material"
+
+    def sync_materials_link(self):
+        """Test syncing materials works"""
+        self._clear_scene()
+
+        # test that the base test material is included as shipped
+        bpy.ops.mesh.primitive_plane_add()
+        obj = bpy.context.object
+        if bpy.app.version >= (2, 80):
+            obj.select_set(True)
+        else:
+            obj.select = True
+
+        new_mat = bpy.data.materials.new("mcprep_test")
+        obj.active_material = new_mat
+
+        new_mat.name = "mcprep_test"
+        init_mats = bpy.data.materials[:]
+        res = bpy.ops.mcprep.sync_materials(link=True, replace_materials=False)
+        if res != {"FINISHED"}:
+            return "Should return finished with test file (link)"
+        imported = set(bpy.data.materials[:]) - set(init_mats)
+        imported = list(imported)
+        if not imported:
+            return "No new material found after linking"
+        if not list(imported)[0].library:
+            return "Material linked is not a library"
+
+    def load_material(self):
+        """Test the load material operators and related resets"""
+        self._clear_scene()
+        bpy.ops.mcprep.reload_materials()
+
+        # add object
+        bpy.ops.mesh.primitive_cube_add()
+
+        scn_props = bpy.context.scene.mcprep_props
+        itm = scn_props.material_list[scn_props.material_list_index]
+        path = itm.path
+        bpy.ops.mcprep.load_material(filepath=path)
+
+        # validate that the loaded material has a name matching current list
+        mat = bpy.context.object.active_material
+        scn_props = bpy.context.scene.mcprep_props
+        mat_item = scn_props.material_list[scn_props.material_list_index]
+        if mat_item.name not in mat.name:
+            return "Material name not loaded " + mat.name
+
+    def uv_transform_detection(self):
+        """Ensure proper detection and transforms for Mineways all-in-one images"""
+        from MCprep.materials.uv_tools import get_uv_bounds_per_material
+
+        self._clear_scene()
+
+        bpy.ops.mesh.primitive_cube_add()
+        bpy.ops.object.editmode_toggle()
+        bpy.ops.mesh.select_all(action="SELECT")
+        bpy.ops.uv.reset()
+        bpy.ops.object.editmode_toggle()
+        new_mat = bpy.data.materials.new(name="tmp")
+        bpy.context.object.active_material = new_mat
+
+        if not bpy.context.object or not bpy.context.object.active_material:
+            return "Failed set up for uv_transform_detection"
+
+        uv_bounds = get_uv_bounds_per_material(bpy.context.object)
+        mname = bpy.context.object.active_material.name
+        if uv_bounds != {mname: [0, 1, 0, 1]}:
+            return "UV transform for default cube should have max bounds"
+
+        bpy.ops.object.editmode_toggle()
+        bpy.ops.mesh.select_all(action="SELECT")
+        bpy.ops.uv.sphere_project()  # will ensure more irregular UV map, not bounded
+        bpy.ops.object.editmode_toggle()
+        uv_bounds = get_uv_bounds_per_material(bpy.context.object)
+        if uv_bounds == {mname: [0, 1, 0, 1]}:
+            return "UV mapping is irregular, should have different min/max"
+
+    def uv_transform_no_alert(self):
+        """Ensure that uv transform alert does not go off unexpectedly"""
+        from MCprep.materials.uv_tools import detect_invalid_uvs_from_objs
+
+        self._clear_scene()
+
+        self._import_mineways_separated()
+        invalid, invalid_objs = detect_invalid_uvs_from_objs(
+            bpy.context.selected_objects
+        )
+        prt = ",".join([obj.name for obj in invalid_objs])  # obj.name.split("_")[-1]
+        if invalid is True:
+            return "Mineways separated tiles export should not alert: " + prt
+
+        self._clear_scene()
+        self._import_jmc2obj_full()
+        invalid, invalid_objs = detect_invalid_uvs_from_objs(
+            bpy.context.selected_objects
+        )
+        prt = ",".join([obj.name.split("_")[-1] for obj in invalid_objs])
+        if invalid is True:
+            return "jmc2obj export should not alert: " + prt
+
+    def uv_transform_combined_alert(self):
+        """Ensure that uv transform alert goes off for Mineways all-in-one"""
+        from MCprep.materials.uv_tools import detect_invalid_uvs_from_objs
+
+        self._clear_scene()
+
+        self._import_mineways_combined()
+        invalid, invalid_objs = detect_invalid_uvs_from_objs(
+            bpy.context.selected_objects
+        )
+        if invalid is False:
+            return "Combined image export should alert"
+        if not invalid_objs:
+            return "Correctly alerted combined image, but no obj's returned"
+
+        # Do specific checks for water and lava, since they might be combined
+        # and cover more than one uv position (and falsely pass the test)
+        # in combined, water is called "Stationary_Wat" and "Stationary_Lav"
+        # (yes, appears cutoff; and yes includes the flowing too)
+        # NOTE! in 2.7x, will be named "Stationary_Water", but in 2.9 it is
+        # "Test_MCprep_1.16.4__-145_4_1271_to_-118_255_1311_Stationary_Wat"
+        water_obj = [obj for obj in bpy.data.objects if "Stationary_Wat" in obj.name][0]
+        lava_obj = [obj for obj in bpy.data.objects if "Stationary_Lav" in obj.name][0]
+
+        invalid, invalid_objs = detect_invalid_uvs_from_objs([lava_obj, water_obj])
+        if invalid is False:
+            return "Combined lava/water should still alert"
+
+    def test_generate_material_sequence(self):
+        """Ensure that generating an image sequence works as expected."""
+        from MCprep.materials.sequences import generate_material_sequence
+
+        # ALT: call animate_single_material
+        # animate_single_material(
+        # mat, engine, export_location='original', clear_cache=False)
+
+        tiled_img = os.path.join(
+            os.path.dirname(__file__),
+            "test_resource_pack",
+            "textures",
+            "campfire_fire.png",
+        )
+        fake_orig_img = tiled_img
+        result_dir = tiled_img[:-4]  # Same name, sans extension.
+
+        try:
+            shutil.rmtree(result_dir)
+        except Exception as err:
+            print("Error removing prior directory of animated campfire")
+            print(err)
+
+        # Ensure that the folder does not initially exist
+        if os.path.isdir(result_dir):
+            return "Folder pre-exists, should be removed before test"
+
+        res, err = generate_material_sequence(
+            source_path=fake_orig_img,
+            image_path=tiled_img,
+            form=None,
+            export_location="original",
+            clear_cache=True,
+        )
+
+        if err:
+            return "Generate materials had an error: " + str(err)
+        if not res:
+            return "Failed to get success resposne from generate img sequence"
+
+        if not os.path.isdir(result_dir):
+            return "Output directory does not exist"
+
+        gen_files = [img for img in os.listdir(result_dir) if img.endswith(".png")]
+        if not gen_files:
+            return "No images generated"
+
+        # Now do cleanup.
+        shutil.rmtree(result_dir)
+
+    def test_enable_obj_importer(self):
+        """Ensure module name is correct, since error won't be reported."""
+        bpy.ops.preferences.addon_enable(module="io_scene_obj")
+
+    def qa_effects(self):
+        """Ensures that effects files meet all QA needs"""
+
+        basepath = os.path.join("MCprep_addon", "MCprep_resources", "effects")
+        basepath = os.path.abspath(basepath)  # relative to the dev git folder
+
+        bfiles = []
+        for child in os.listdir(basepath):
+            fullp = os.path.join(basepath, child)
+            if os.path.isfile(fullp) and child.lower().endswith(".blend"):
+                bfiles.append(fullp)
+            elif not os.path.isdir(fullp):
+                continue
+            subblends = [
+                os.path.join(basepath, child, blend)
+                for blend in os.listdir(os.path.join(basepath, child))
+                if os.path.isfile(os.path.join(basepath, child, blend))
+                and blend.lower().endswith(".blend")
+            ]
+            bfiles.extend(subblends)
+
+        print("Checking blend files")
+        if not bfiles:
+            return "No files loaded for bfiles"
+
+        issues = []
+        checked = 0
+        for blend in bfiles:
+            print("QC'ing:", blend)
+            if not os.path.isfile(blend):
+                return "Did not exist: " + str(blend)
+            bpy.ops.wm.open_mainfile(filepath=blend)
+
+            resp = self._qa_helper(basepath, allow_packed=True)
+            if resp:
+                issues.append([blend, resp])
+            checked += 1
+
+        if issues:
+            return issues
+
+    def qa_rigs(self):
+        """Ensures that all rig files meet all QA needs.
+
+        NOTE: This test is actually surpisingly fast given the number of files
+        it needs to check against, but it's possible it can be unstable. Exit
+        early to override if needed.
+        """
+
+        basepath = os.path.join("MCprep_addon", "MCprep_resources", "rigs")
+        basepath = os.path.abspath(basepath)  # relative to the dev git folder
+
+        bfiles = []
+        for child in os.listdir(basepath):
+            fullp = os.path.join(basepath, child)
+            if os.path.isfile(fullp) and child.lower().endswith(".blend"):
+                bfiles.append(fullp)
+            elif not os.path.isdir(fullp):
+                continue
+            subblends = [
+                os.path.join(basepath, child, blend)
+                for blend in os.listdir(os.path.join(basepath, child))
+                if os.path.isfile(os.path.join(basepath, child, blend))
+                and blend.lower().endswith(".blend")
+            ]
+            bfiles.extend(subblends)
+
+        print("Checking blend files")
+        if not bfiles:
+            return "No files loaded for bfiles"
+
+        issues = []
+        checked = 0
+        for blend in bfiles:
+            print("QC'ing:", blend)
+            if not os.path.isfile(blend):
+                return "Did not exist: " + str(blend)
+            bpy.ops.wm.open_mainfile(filepath=blend)
+
+            resp = self._qa_helper(basepath, allow_packed=True)
+            if resp:
+                issues.append([blend, resp])
+            checked += 1
+
+        if issues:
+            return "Checked {} rigs, issues: {}".format(checked, issues)
+
+    def convert_mtl_simple(self):
+        """Ensures that conversion of the mtl with other color space works."""
+        from MCprep import world_tools
+
+        src = "mtl_simple_original.mtl"
+        end = "mtl_simple_modified.mtl"
+        test_dir = os.path.dirname(__file__)
+        simple_mtl = os.path.join(test_dir, src)
+        modified_mtl = os.path.join(test_dir, end)
+
+        # now save the texturefile somewhere
+        tmp_dir = tempfile.gettempdir()
+        tmp_mtl = os.path.join(tmp_dir, src)
+        shutil.copyfile(simple_mtl, tmp_mtl)  # leave original intact
+
+        if not os.path.isfile(tmp_mtl):
+            return "Failed to create tmp tml at " + tmp_mtl
+
+        # Need to mock:
+        # bpy.context.scene.view_settings.view_transform
+        # to be an invalid kind of attribute, to simulate an ACES or AgX space.
+        # But we can't do that since we're not (yet) using the real unittest
+        # framework, hence we'll just clear the  world_tool's vars.
+        save_init = list(world_tools.BUILTIN_SPACES)
+        world_tools.BUILTIN_SPACES = ["NotRealSpace"]
+        print("TEST: pre", world_tools.BUILTIN_SPACES)
+
+        # Resultant file
+        res = world_tools.convert_mtl(tmp_mtl)
+
+        # Restore the property we unset.
+        world_tools.BUILTIN_SPACES = save_init
+        print("TEST: post", world_tools.BUILTIN_SPACES)
+
+        if res is None:
+            return "Failed to mock color space and thus could not test convert_mtl"
+
+        if res is False:
+            return "Convert mtl failed with false response"
+
+        # Now check that the data is the same.
+        res = filecmp.cmp(tmp_mtl, modified_mtl, shallow=False)
+        if res is not True:
+            # Not removing file, since we likely want to inspect it.
+            return "Generated MTL is different: {} vs {}".format(tmp_mtl, modified_mtl)
+        else:
+            os.remove(tmp_mtl)
+
+    def convert_mtl_skip(self):
+        """Ensures that we properly skip if a built in space active."""
+        from MCprep import world_tools
+
+        src = "mtl_simple_original.mtl"
+        test_dir = os.path.dirname(__file__)
+        simple_mtl = os.path.join(test_dir, src)
+
+        # now save the texturefile somewhere
+        tmp_dir = tempfile.gettempdir()
+        tmp_mtl = os.path.join(tmp_dir, src)
+        shutil.copyfile(simple_mtl, tmp_mtl)  # leave original intact
+
+        if not os.path.isfile(tmp_mtl):
+            return "Failed to create tmp tml at " + tmp_mtl
+
+        # Need to mock:
+        # bpy.context.scene.view_settings.view_transform
+        # to be an invalid kind of attribute, to simulate an ACES or AgX space.
+        # But we can't do that since we're not (yet) using the real unittest
+        # framework, hence we'll just clear the  world_tool's vars.
+        actual_space = str(bpy.context.scene.view_settings.view_transform)
+        save_init = list(world_tools.BUILTIN_SPACES)
+        world_tools.BUILTIN_SPACES = [actual_space]
+        print("TEST: pre", world_tools.BUILTIN_SPACES)
+
+        # Resultant file
+        res = world_tools.convert_mtl(tmp_mtl)
+
+        # Restore the property we unset.
+        world_tools.BUILTIN_SPACES = save_init
+        print("TEST: post", world_tools.BUILTIN_SPACES)
+
+        if res is not None:
+            os.remove(tmp_mtl)
+            return "Should not have converter MTL for valid space"
 
 
 class OCOL:
-	"""override class for colors, for terminals not supporting color-out"""
-	HEADER = ''
-	OKBLUE = ''
-	OKGREEN = ''
-	WARNING = '[WARN]'
-	FAIL = '[ERR]'
-	ENDC = ''
-	BOLD = ''
-	UNDERLINE = ''
+    """override class for colors, for terminals not supporting color-out"""
+
+    HEADER = ""
+    OKBLUE = ""
+    OKGREEN = ""
+    WARNING = "[WARN]"
+    FAIL = "[ERR]"
+    ENDC = ""
+    BOLD = ""
+    UNDERLINE = ""
 
 
 class COL:
-	"""native_colors to use, if terminal supports color out"""
-	HEADER = '\033[95m'
-	OKBLUE = '\033[94m'
-	OKGREEN = '\033[92m'
-	WARNING = '\033[93m'
-	FAIL = '\033[91m'
-	ENDC = '\033[0m'
-	BOLD = '\033[1m'
-	UNDERLINE = '\033[4m'
+    """native_colors to use, if terminal supports color out"""
+
+    HEADER = "\033[95m"
+    OKBLUE = "\033[94m"
+    OKGREEN = "\033[92m"
+    WARNING = "\033[93m"
+    FAIL = "\033[91m"
+    ENDC = "\033[0m"
+    BOLD = "\033[1m"
+    UNDERLINE = "\033[4m"
 
 
 def suffix_chars(string, max_char):
-	"""Returns passed string or the last max_char characters if longer"""
-	string = string.replace('\n', '\\n ')
-	string = string.replace(',', ' ')
-	if len(string) > max_char:
-		return string[-max_char:]
-	return string
+    """Returns passed string or the last max_char characters if longer"""
+    string = string.replace("\n", "\\n ")
+    string = string.replace(",", " ")
+    if len(string) > max_char:
+        return string[-max_char:]
+    return string
+
 
 # -----------------------------------------------------------------------------
 # Testing file, to semi-auto check addon functionality is working
@@ -2385,79 +2458,82 @@ def suffix_chars(string, max_char):
 
 
 class MCPTEST_OT_test_run(bpy.types.Operator):
-	bl_label = "MCprep run test"
-	bl_idname = "mcpreptest.run_test"
-	bl_description = "Run specified test index"
+    bl_label = "MCprep run test"
+    bl_idname = "mcpreptest.run_test"
+    bl_description = "Run specified test index"
 
-	index: bpy.props.IntProperty(default=0)
+    index: bpy.props.IntProperty(default=0)
 
-	def execute(self, context):
-		# ind = context.window_manager.mcprep_test_index
-		test_class.mcrprep_run_test(self.index)
-		return {'FINISHED'}
+    def execute(self, context):
+        # ind = context.window_manager.mcprep_test_index
+        test_class.mcrprep_run_test(self.index)
+        return {"FINISHED"}
 
 
 class MCPTEST_OT_test_selfdestruct(bpy.types.Operator):
-	bl_label = "MCprep test self-destruct (dereg)"
-	bl_idname = "mcpreptest.self_destruct"
-	bl_description = "Deregister the MCprep test script, panel, and operators"
+    bl_label = "MCprep test self-destruct (dereg)"
+    bl_idname = "mcpreptest.self_destruct"
+    bl_description = "Deregister the MCprep test script, panel, and operators"
 
-	def execute(self, context):
-		print("De-registering MCprep test")
-		unregister()
-		return {'FINISHED'}
+    def execute(self, context):
+        print("De-registering MCprep test")
+        unregister()
+        return {"FINISHED"}
 
 
 class MCPTEST_PT_test_panel(bpy.types.Panel):
-	"""MCprep test panel"""
-	bl_label = "MCprep Test Panel"
-	bl_space_type = 'VIEW_3D'
-	bl_region_type = 'TOOLS' if bpy.app.version < (2, 80) else 'UI'
-	bl_category = "MCprep"
+    """MCprep test panel"""
 
-	def draw_header(self, context):
-		col = self.layout.column()
-		col.label("", icon="ERROR")
+    bl_label = "MCprep Test Panel"
+    bl_space_type = "VIEW_3D"
+    bl_region_type = "TOOLS" if bpy.app.version < (2, 80) else "UI"
+    bl_category = "MCprep"
 
-	def draw(self, context):
-		layout = self.layout
-		col = layout.column()
-		col.label(text="Select test case:")
-		col.prop(context.window_manager, "mcprep_test_index")
-		ops = col.operator("mcpreptest.run_test")
-		ops.index = context.window_manager.mcprep_test_index
-		col.prop(context.window_manager, "mcprep_test_autorun")
-		col.label(text="")
+    def draw_header(self, context):
+        col = self.layout.column()
+        col.label("", icon="ERROR")
 
-		r = col.row()
-		subc = r.column()
-		subc.scale_y = 0.8
-		# draw test results thus far:
-		for i, itm in enumerate(test_class.test_cases):
-			row = subc.row(align=True)
+    def draw(self, context):
+        layout = self.layout
+        col = layout.column()
+        col.label(text="Select test case:")
+        col.prop(context.window_manager, "mcprep_test_index")
+        ops = col.operator("mcpreptest.run_test")
+        ops.index = context.window_manager.mcprep_test_index
+        col.prop(context.window_manager, "mcprep_test_autorun")
+        col.label(text="")
 
-			if test_class.test_cases[i][1]["check"] == 1:
-				icn = "COLOR_GREEN"
-			elif test_class.test_cases[i][1]["check"] == -1:
-				icn = "COLOR_GREEN"
-			elif test_class.test_cases[i][1]["check"] == -2:
-				icn = "QUESTION"
-			else:
-				icn = "MESH_CIRCLE"
-			row.operator("mcpreptest.run_test", icon=icn, text="").index = i
-			row.label("{}-{} | {}".format(
-				test_class.test_cases[i][1]["type"],
-				test_class.test_cases[i][0],
-				test_class.test_cases[i][1]["res"]
-			))
-		col.label(text="")
-		col.operator("mcpreptest.self_destruct")
+        r = col.row()
+        subc = r.column()
+        subc.scale_y = 0.8
+        # draw test results thus far:
+        for i, itm in enumerate(test_class.test_cases):
+            row = subc.row(align=True)
+
+            if test_class.test_cases[i][1]["check"] == 1:
+                icn = "COLOR_GREEN"
+            elif test_class.test_cases[i][1]["check"] == -1:
+                icn = "COLOR_GREEN"
+            elif test_class.test_cases[i][1]["check"] == -2:
+                icn = "QUESTION"
+            else:
+                icn = "MESH_CIRCLE"
+            row.operator("mcpreptest.run_test", icon=icn, text="").index = i
+            row.label(
+                "{}-{} | {}".format(
+                    test_class.test_cases[i][1]["type"],
+                    test_class.test_cases[i][0],
+                    test_class.test_cases[i][1]["res"],
+                )
+            )
+        col.label(text="")
+        col.operator("mcpreptest.self_destruct")
 
 
 def mcprep_test_index_update(self, context):
-	if context.window_manager.mcprep_test_autorun:
-		print("Auto-run MCprep test")
-		bpy.ops.mcpreptest.run_test(index=self.mcprep_test_index)
+    if context.window_manager.mcprep_test_autorun:
+        print("Auto-run MCprep test")
+        bpy.ops.mcpreptest.run_test(index=self.mcprep_test_index)
 
 
 # -----------------------------------------------------------------------------
@@ -2465,65 +2541,62 @@ def mcprep_test_index_update(self, context):
 # -----------------------------------------------------------------------------
 
 
-classes = (
-	MCPTEST_OT_test_run,
-	MCPTEST_OT_test_selfdestruct,
-	MCPTEST_PT_test_panel
-)
+classes = (MCPTEST_OT_test_run, MCPTEST_OT_test_selfdestruct, MCPTEST_PT_test_panel)
 
 
 def register():
-	print("REGISTER MCPREP TEST")
-	maxlen = len(test_class.test_cases)
+    print("REGISTER MCPREP TEST")
+    maxlen = len(test_class.test_cases)
 
-	bpy.types.WindowManager.mcprep_test_index = bpy.props.IntProperty(
-		name="MCprep test index",
-		default=-1,
-		min=-1,
-		max=maxlen,
-		update=mcprep_test_index_update)
-	bpy.types.WindowManager.mcprep_test_autorun = bpy.props.BoolProperty(
-		name="Autorun test",
-		default=True)
+    bpy.types.WindowManager.mcprep_test_index = bpy.props.IntProperty(
+        name="MCprep test index",
+        default=-1,
+        min=-1,
+        max=maxlen,
+        update=mcprep_test_index_update,
+    )
+    bpy.types.WindowManager.mcprep_test_autorun = bpy.props.BoolProperty(
+        name="Autorun test", default=True
+    )
 
-	# context.window_manager.mcprep_test_index = -1 put into handler to reset?
-	for cls in classes:
-		bpy.utils.register_class(cls)
+    # context.window_manager.mcprep_test_index = -1 put into handler to reset?
+    for cls in classes:
+        bpy.utils.register_class(cls)
 
 
 def unregister():
-	print("DEREGISTER MCPREP TEST")
-	for cls in reversed(classes):
-		bpy.utils.unregister_class(cls)
-	del bpy.types.WindowManager.mcprep_test_index
-	del bpy.types.WindowManager.mcprep_test_autorun
+    print("DEREGISTER MCPREP TEST")
+    for cls in reversed(classes):
+        bpy.utils.unregister_class(cls)
+    del bpy.types.WindowManager.mcprep_test_index
+    del bpy.types.WindowManager.mcprep_test_autorun
 
 
 if __name__ == "__main__":
-	global test_class
-	test_class = mcprep_testing()
+    global test_class
+    test_class = mcprep_testing()
 
-	register()
+    register()
 
-	# setup paths to the target
-	test_class.setup_env_paths()
+    # setup paths to the target
+    test_class.setup_env_paths()
 
-	# check for additional args, e.g. if running from console beyond blender
-	if "--" in sys.argv:
-		argind = sys.argv.index("--")
-		args = sys.argv[argind + 1:]
-	else:
-		args = []
+    # check for additional args, e.g. if running from console beyond blender
+    if "--" in sys.argv:
+        argind = sys.argv.index("--")
+        args = sys.argv[argind + 1 :]
+    else:
+        args = []
 
-	if "-v" in args:
-		test_class.suppress = False
-	else:
-		test_class.suppress = True
+    if "-v" in args:
+        test_class.suppress = False
+    else:
+        test_class.suppress = True
 
-	if "-run" in args:
-		ind = args.index("-run")
-		if len(args) > ind:
-			test_class.run_only = args[ind + 1]
+    if "-run" in args:
+        ind = args.index("-run")
+        if len(args) > ind:
+            test_class.run_only = args[ind + 1]
 
-	if "--auto_run" in args:
-		test_class.run_all_tests()
+    if "--auto_run" in args:
+        test_class.run_all_tests()

--- a/test_files/mcmodel_test.py
+++ b/test_files/mcmodel_test.py
@@ -15,71 +15,68 @@ SPACING = 2  # Spacing between each model in meters.
 
 
 def check_models(context):
-	bpy.ops.mcprep.reload_models()
+    bpy.ops.mcprep.reload_models()
 
-	scn_props = context.scene.mcprep_props
-	scn_props.model_list_index = 0
+    scn_props = context.scene.mcprep_props
+    scn_props.model_list_index = 0
 
-	exceptions = []
-	successful = []
+    exceptions = []
+    successful = []
 
-	count = len(scn_props.model_list)
-	prior_obj = None
+    count = len(scn_props.model_list)
+    prior_obj = None
 
-	print("Total to process: ", count)
-	if count > MAX_CHECK:
-		print("Limited to ", MAX_CHECK)
-		count = MAX_CHECK
+    print("Total to process: ", count)
+    if count > MAX_CHECK:
+        print("Limited to ", MAX_CHECK)
+        count = MAX_CHECK
 
-	width = int(count**0.5)
+    width = int(count**0.5)
 
-	for index in range(len(scn_props.model_list)):
-		# scn_props.model_list_index = index
-		model = scn_props.model_list[index]
+    for index in range(len(scn_props.model_list)):
+        # scn_props.model_list_index = index
+        model = scn_props.model_list[index]
 
-		try:
-			bpy.ops.mcprep.spawn_model(filepath=model.filepath, skipUsage=True)
+        try:
+            bpy.ops.mcprep.spawn_model(filepath=model.filepath, skipUsage=True)
 
-			new_obj = context.object
-			if new_obj != prior_obj:
-				prior_obj = new_obj
-			else:
-				exceptions.append([model.name, "object was same between iteration"])
-				print("Object was the same between iterations")
-				break
-			if len(new_obj.data.vertices) < 4:
-				exceptions.append([model.name, "Not enough geo generated"])
-				print("#{} {} failed".format(
-					index, model.name))
-			else:
-				successful.append(model.name)
-		except Exception as err:
-			exceptions.append([model.name, str(err)])
-			print(f"{model.name} failed")
-		finally:
-			print("#{}/{}".format(index, count))
+            new_obj = context.object
+            if new_obj != prior_obj:
+                prior_obj = new_obj
+            else:
+                exceptions.append([model.name, "object was same between iteration"])
+                print("Object was the same between iterations")
+                break
+            if len(new_obj.data.vertices) < 4:
+                exceptions.append([model.name, "Not enough geo generated"])
+                print("#{} {} failed".format(index, model.name))
+            else:
+                successful.append(model.name)
+        except Exception as err:
+            exceptions.append([model.name, str(err)])
+            print(f"{model.name} failed")
+        finally:
+            print("#{}/{}".format(index, count))
 
-		if PLACE_IN_GRID:
-			row = index // width
-			col = index % width
-			bpy.context.object.location = (row * SPACING, col * SPACING, 0)
+        if PLACE_IN_GRID:
+            row = index // width
+            col = index % width
+            bpy.context.object.location = (row * SPACING, col * SPACING, 0)
 
-		else:
-			bpy.ops.object.delete(use_global=True)
+        else:
+            bpy.ops.object.delete(use_global=True)
 
-		if MAX_CHECK <= index:
-			break
+        if MAX_CHECK <= index:
+            break
 
-	print("Succeeded: {}, failed: {}".format(
-		len(successful),
-		len(exceptions)))
+    print("Succeeded: {}, failed: {}".format(len(successful), len(exceptions)))
 
-	if not exceptions:
-		print("No failures!")
-	else:
-		print("Those that failed:")
-		for itm in exceptions:
-			print("{}: {}".format(itm[0], itm[1]))
+    if not exceptions:
+        print("No failures!")
+    else:
+        print("Those that failed:")
+        for itm in exceptions:
+            print("{}: {}".format(itm[0], itm[1]))
 
 
 check_models(bpy.context)


### PR DESCRIPTION
In the past, I said we should use darker for only formatting changes, and while that's true, I think it makes more sense to just begin running an autoformatter and have a large "formatting commit"

For one thing, this is already a massive MCprep update, and already have Python changes from newer versions. In addition, as the author of Black says on his blog
(https://lukasz.langa.pl/36380f86-6d28-4a55-962e-91c2c959db7a/):

> When you make this single reformatting commit, everything that comes
> after is semantic changes so your commit history is clean in the sense
> that it actually shows what changed in terms of meaning, not style.
> There are tools like darker that allow you to only reformat lines that
> were touched since the last commit. However, by doing that you forever
> expose yourself to commits that are a mix of semantic changes with
> stylistic changes, making it much harder to see what changed.

In other words, if we decide to only format changes and keep the rest of the code untouched, we end up making it harder to understand changes. In addition, there would be consistency issues. I think it makes sense to just bite the bullet, create a massive formatting commit, and in the future use autoformatting as a part of our toolchain.

None of the actual underlying code has been changed, just the formatting. No renamed properties, no renamed classes, etc, so there shouldn't be any issues.