### PR TITLE
Fix block model overlay geometry

### DIFF
--- a/MCprep_addon/spawner/mcmodel.py
+++ b/MCprep_addon/spawner/mcmodel.py
@@ -371,7 +371,7 @@ def add_model(
 			# Give slight offset by normal for overlay geometry
 			if face_mat == "#overlay":
 				bmesh.ops.translate(bm, verts=face.verts,
-						    vec=0.05 * face.normal)
+						    vec=0.02 * face.normal)
 
 			for j in range(len(face.loops)):
 				# uv coords order is determened by the rotation of the uv,
@@ -386,7 +386,7 @@ def add_model(
 	# Quick way to clean the model, hopefully it doesn't cause any UV issues
 	# Ignore model has overlay geometry, causing issue
 	if not textures.get("overlay"):
-		bmesh.ops.remove_doubles(bm, verts=bm.verts, dist=0.01)
+		bmesh.ops.remove_doubles(bm, verts=bm.verts, dist=0.005)
 
 	# make the bmesh the object's mesh
 	bm.to_mesh(mesh)

--- a/MCprep_addon/spawner/mcmodel.py
+++ b/MCprep_addon/spawner/mcmodel.py
@@ -378,7 +378,8 @@ def add_model(
 				face.material_index = materials.index(face_mat)
 
 	# Quick way to clean the model, hopefully it doesn't cause any UV issues
-	bmesh.ops.remove_doubles(bm, verts=bm.verts, dist=0.01)
+	if not textures.get("overlay"):
+		bmesh.ops.remove_doubles(bm, verts=bm.verts, dist=0.01)
 
 	# make the bmesh the object's mesh
 	bm.to_mesh(mesh)

--- a/MCprep_addon/spawner/mcmodel.py
+++ b/MCprep_addon/spawner/mcmodel.py
@@ -367,6 +367,12 @@ def add_model(
 			)
 
 			face.normal_update()
+			
+			# Give slight offset by normal for overlay geometry
+			if textures.get("overlay"):
+				bmesh.ops.translate(bm, verts=face.verts,
+						    vec=0.05 * face.normal)
+
 			for j in range(len(face.loops)):
 				# uv coords order is determened by the rotation of the uv,
 				# e.g. if the uv is rotated by 180 degrees, the first index
@@ -378,6 +384,7 @@ def add_model(
 				face.material_index = materials.index(face_mat)
 
 	# Quick way to clean the model, hopefully it doesn't cause any UV issues
+	# Ignore model has overlay geometry, causing issue
 	if not textures.get("overlay"):
 		bmesh.ops.remove_doubles(bm, verts=bm.verts, dist=0.01)
 

--- a/MCprep_addon/spawner/mcmodel.py
+++ b/MCprep_addon/spawner/mcmodel.py
@@ -369,7 +369,7 @@ def add_model(
 			face.normal_update()
 			
 			# Give slight offset by normal for overlay geometry
-			if textures.get("overlay"):
+			if face_mat == "#overlay":
 				bmesh.ops.translate(bm, verts=face.verts,
 						    vec=0.05 * face.normal)
 


### PR DESCRIPTION
Small fix of this issue: [Image](https://media.discordapp.net/attachments/737872746700079235/1163524282618490900/image.png?ex=655b92ee&is=65491dee&hm=a97dea5690e99be313a6388ad21807b47484e1ca6c1629f0f8583bc4334e8d24&)

[Grass block json](https://github.com/InventivetalentDev/minecraft-assets/blob/1.20.1/assets/minecraft/models/block/grass_block.json)

Block like grass block has a small overlay on them ~~should be treated as a threat causing z fighting and clean it up~~ but let this one pass.