### PR TITLE
WIP - Other rig properties, mob type, color variant

### DIFF
--- a/MCprep_addon/materials/skin.py
+++ b/MCprep_addon/materials/skin.py
@@ -686,6 +686,24 @@ class MCPREP_OT_spawn_mob_with_skin(bpy.types.Operator):
 
 		return {'FINISHED'}
 
+class MCPREP_OT_swap_skin_variant(bpy.types.Operator):
+	"""Apply the active UIlist skin to select characters"""
+	bl_idname = "mcprep.swap_skin variant"
+	bl_label = "Apply skin"
+	bl_description = "Swap the mobs variant"
+	bl_options = {'REGISTER', 'UNDO'}
+	
+	def invoke(self, context, event):
+		return context.window_manager.invoke_props_dialog(
+			self, width=300 * util.ui_scale())
+	
+	def draw(self, context: Context):
+		obj = context.obj
+	
+	def check_villager_case(self, materials):
+		for mat in materials:
+			
+
 
 class MCPREP_OT_download_username_list(bpy.types.Operator):
 	"""Apply the active UIlist skin to select characters"""

--- a/MCprep_addon/mcprep_ui.py
+++ b/MCprep_addon/mcprep_ui.py
@@ -1983,7 +1983,18 @@ class McprepProps(bpy.types.PropertyGroup):
 	effects_list: bpy.props.CollectionProperty(type=spawn_util.ListEffectsAssets)
 	effects_list_index: bpy.props.IntProperty(default=0)
 
-
+class MCprepWindowManager(PropertyGroup):
+	
+	
+	@classmethod
+	def register(cls):
+		bpy.types.WindowManager.mcprep = bpy.props.PointerProperty(type=cls)
+	
+	@classmethod
+	def unregister(cls):
+		del bpy.types.WindowManager.mcprep
+		
+		
 # -----------------------------------------------------------------------------
 # Register functions
 # -----------------------------------------------------------------------------
@@ -1992,6 +2003,7 @@ class McprepProps(bpy.types.PropertyGroup):
 classes = (
 	McprepPreference,
 	McprepProps,
+	MCprepWindowManager,
 	MCPREP_MT_mob_spawner,
 	MCPREP_MT_meshswap_place,
 	MCPREP_MT_item_spawn,

--- a/MCprep_addon/mcprep_ui.py
+++ b/MCprep_addon/mcprep_ui.py
@@ -954,6 +954,8 @@ class MCPREP_PT_skins(bpy.types.Panel):
 
 	def draw(self, context):
 		layout = self.layout
+		wm_props = context.window_manager.mcprep
+
 		if addon_just_updated():
 			restart_layout(layout)
 			return
@@ -962,56 +964,63 @@ class MCPREP_PT_skins(bpy.types.Panel):
 		sind = context.scene.mcprep_skins_list_index
 		mob_ind = context.scene.mcprep_props.mob_list_index
 		skinname = None
-
 		row = layout.row()
 		row.label(text="Select skin")
 		row.operator(
 			"mcprep.open_help", text="", icon="QUESTION", emboss=False
 		).url = "https://theduckcow.com/dev/blender/mcprep/skin-swapping/"
-
-		# set size of UIlist
 		row = layout.row()
-		col = row.column()
+		row.prop(wm_props, "skin_modes",expand=True)
+		if wm_props.skin_modes == 'PLAYER':
+		
+			# set size of UIlist
+			row = layout.row()
+			col = row.column()
 
-		is_sortable = len(env.skin_list) > 1
-		rows = 1
-		if (is_sortable):
-			rows = 4
+			is_sortable = len(env.skin_list) > 1
+			rows = 1
+			if (is_sortable):
+				rows = 4
 
-		# any other conditions for needing reloading?
-		if not env.skin_list:
-			col = layout.column()
-			col.label(text="No skins found/loaded")
-			p = col.operator(
-				"mcprep.reload_skins", text="Press to reload", icon="ERROR")
-		elif env.skin_list and len(env.skin_list) <= sind:
-			col = layout.column()
-			col.label(text="Reload skins")
-			p = col.operator(
-				"mcprep.reload_skins", text="Press to reload", icon="ERROR")
-		else:
-			col.template_list(
-				"MCPREP_UL_skins", "",
-				context.scene, "mcprep_skins_list",
-				context.scene, "mcprep_skins_list_index",
-				rows=rows)
-
-			col = layout.column(align=True)
-
-			row = col.row(align=True)
-			row.scale_y = 1.5
-			if env.skin_list:
-				skinname = bpy.path.basename(env.skin_list[sind][0])
-				p = row.operator("mcprep.applyskin", text=f"Apply {skinname}")
-				p.filepath = env.skin_list[sind][1]
+			# any other conditions for needing reloading?
+			if not env.skin_list:
+				col = layout.column()
+				col.label(text="No skins found/loaded")
+				p = col.operator(
+					"mcprep.reload_skins", text="Press to reload", icon="ERROR")
+			elif env.skin_list and len(env.skin_list) <= sind:
+				col = layout.column()
+				col.label(text="Reload skins")
+				p = col.operator(
+					"mcprep.reload_skins", text="Press to reload", icon="ERROR")
 			else:
-				row.enabled = False
-				p = row.operator("mcprep.skin_swapper", text="No skins found")
-			row = col.row(align=True)
-			row.operator("mcprep.skin_swapper", text="Skin from file")
-			row = col.row(align=True)
-			row.operator("mcprep.applyusernameskin", text="Skin from username")
+				col.template_list(
+					"MCPREP_UL_skins", "",
+					context.scene, "mcprep_skins_list",
+					context.scene, "mcprep_skins_list_index",
+					rows=rows)
 
+				col = layout.column(align=True)
+
+				row = col.row(align=True)
+				row.scale_y = 1.5
+				if env.skin_list:
+					skinname = bpy.path.basename(env.skin_list[sind][0])
+					p = row.operator("mcprep.applyskin", text=f"Apply {skinname}")
+					p.filepath = env.skin_list[sind][1]
+				else:
+					row.enabled = False
+					p = row.operator("mcprep.skin_swapper", text="No skins found")
+				row = col.row(align=True)
+				row.operator("mcprep.skin_swapper", text="Skin from file")
+				row = col.row(align=True)
+				row.operator("mcprep.applyusernameskin", text="Skin from username")
+		else:
+			row = layout.row()
+			col = row.column()
+
+			wm_props.draw_variation_ui(context, col)
+			col.operator("mcprep.swap_skin")
 		split = layout.split()
 		col = split.column(align=True)
 		row = col.row(align=True)
@@ -1055,6 +1064,12 @@ class MCPREP_PT_skins(bpy.types.Panel):
 					# datapass = scn_props.mob_list[mob_ind].mcmob_type
 					tx = f"Spawn {name} with {skinname}"
 					row.operator("mcprep.spawn_with_skin", text=tx)
+			b_row.label(text="Resource pack")
+			subrow = b_row.row(align=True)
+			subrow.prop(context.scene, "mcprep_texturepack_path", text="")
+			subrow.operator(
+				"mcprep.reset_texture_path", icon=LOAD_FACTORY, text="")
+			
 
 
 class MCPREP_PT_materials(bpy.types.Panel):
@@ -1983,9 +1998,17 @@ class McprepProps(bpy.types.PropertyGroup):
 	effects_list: bpy.props.CollectionProperty(type=spawn_util.ListEffectsAssets)
 	effects_list_index: bpy.props.IntProperty(default=0)
 
-class MCprepWindowManager(PropertyGroup):
-	
-	
+
+class MCprepWindowManager(spawn_util.VariationProp, bpy.types.PropertyGroup):
+	skin_modes : bpy.props.EnumProperty(
+		name="Modes",
+		description="Skinswap modes",
+		items=(
+			('PLAYER', "Player", ""),
+			('MOB', "Mob/Entity", "")
+		)
+	)
+
 	@classmethod
 	def register(cls):
 		bpy.types.WindowManager.mcprep = bpy.props.PointerProperty(type=cls)

--- a/MCprep_addon/spawner/entities.py
+++ b/MCprep_addon/spawner/entities.py
@@ -21,7 +21,10 @@ from typing import Dict, List
 
 import bpy
 
-from bpy.types import Context
+from bpy.types import (
+	Context, 
+	Event
+)
 from ..conf import env, Entity
 from .. import util
 from .. import tracking

--- a/MCprep_addon/spawner/mcmodel.py
+++ b/MCprep_addon/spawner/mcmodel.py
@@ -337,9 +337,7 @@ def add_model(model_filepath: Path, obj_name: str="MinecraftModel") -> bpy.types
 	bm.to_mesh(mesh)
 	bm.free()
 	
-	# 
-	if has_color(obj.name):
-		
+	# if has_color(obj.name):
 	return obj
 
 

--- a/MCprep_addon/spawner/mcmodel.py
+++ b/MCprep_addon/spawner/mcmodel.py
@@ -336,6 +336,10 @@ def add_model(model_filepath: Path, obj_name: str="MinecraftModel") -> bpy.types
 	# make the bmesh the object's mesh
 	bm.to_mesh(mesh)
 	bm.free()
+	
+	# 
+	if has_color(obj.name):
+		
 	return obj
 
 

--- a/MCprep_addon/spawner/spawn_util.py
+++ b/MCprep_addon/spawner/spawn_util.py
@@ -65,49 +65,103 @@ class ColorVariation(Enum):
 	
 class VillagerProfession(Enum):
 	"""Preserve for villager"""
-	# def _generate_next_value_(name, start, count, last_values):
-	# 	return name
+	ARMORER = 0
+	BUTCHER = 1
+	CARTOGRAPHER = 2
+	CLERIC = 3
+	FARMER = 4
+	FISHERMAN = 5
+	FLETCHER = 6
+	LEATHERWORKER = 7
+	LIBRARIAN = 8
+	MASON = 9
+	NITWIT = 10
+	SHEPHERD = 11
+	TOOLSMITH = 12
+	WEAPONSMITH = 13
+	WANDER = 14 # Wandering Trader is not a villager 
 	
-	FARMER = auto()
-	FISHERMAN = auto()
-	SHEPHERD = auto()
-	FLETCHER = auto()
-	LIBRARIAN = auto()
-	CARTOGRAPHER = auto()
-	CLERIC = auto()
-	ARMORER = auto()
-	WEAPONSMITH = auto()
-	TOOLSMITH = auto()
-	BUTCHER = auto()
-	LEATHERWORKER = auto()
-	MASON = auto()
-	NITWIT = auto()
+class VillagerBiome(Enum):
+	PLAINS = 0 # Favour plains as default then alphabet
+	DESERT = 1
+	JUNGLE = 2
+	SAVANNA = 3
+	SNOWY = 4
+	Swamp = 5
+	Taiga = 6
 	
-class VariationProp():
-	def color_items(self, context):
+class VillagerLevel(Enum):
+	NOVICE = 0 # Stone
+	APPRENTICE = 1 # Iron
+	JOURNEYMAN = 2 # Gold
+	EXPERT = 3 # Emerald
+	MASTER = 4 # Diamond
+	
+class ZombieVariation(Enum):
+	DEFAULT = 0
+	HUSK = 1
+	DROWN = 2
+	
+class SkeletonVariation(Enum):
+	DEFAULT = 0
+	WITHER = 1
+	
+	
+class VariationProp:
+	def color_items(self):
+		"""Color variation"""
 		return [(i.value, i.name, i.name) for i in ColorVariation]
 	
-	def profession_items(self, context):
-		return [(i.value, i.name, i.name) for i in ColorVariation]
+	def profession_items(self):
+		"""Villager Professional"""
+		return [(i.value, i.name, i.name) for i in VillagerProfession]
 	
-	def level_items(self, context):
-		return [(i.value, i.name, i.name) for i in ColorVariation]
+	def level_items(self):
+		"""Villager Level method"""
+		return [(i.value, i.name, i.name) for i in VillagerLevel]
 	
-	color_variation : bpy.props.EnumProperty(name="Color Variation", items=color_items)
+	def biome_items(self):
+		return [(i.value, i.name, i.name) for i in VillagerBiome]
+		
+	def zombie_items(self):
+		return [(i.value, i.name, i.name) for i in VillagerBiome]
+		
+	def skeleton_items(self):
+		return [(i.value, i.name, i.name) for i in SkeletonVariation]
+		
+	
+	color_variation: bpy.props.EnumProperty(name="Color Variation", items=color_items)
 	# Villagers
-	profession_variation : bpy.props.EnumProperty(name="Villager Profession", items=profession_items)
-	level_variation : bpy.props.EnumProperty(name="Villager Level", items=level_items)
-	region_variation : bpy.props.EnumProperty(name="Villager Region"= items=region_items)
-	undead_variation : bpy.props.EnumProperty(name="Undead Variation")
+	profession_variation: bpy.props.EnumProperty(name="Villager Profession", items=profession_items)
+	level_variation: bpy.props.EnumProperty(name="Villager Level", items=level_items)
+	biome_variation: bpy.props.EnumProperty(name="Villager Biome", items=biome_items)
+	zombie_variation: bpy.props.EnumProperty(name="Zombie Variation", items=zombie_items)
+	skeleton_variation: bpy.props.EnumProperty(name="Skeleton Variation", items=skeleton_items)
+	is_zombiefied: BoolProperty(name="Is Zombiefied")
+	
+	def draw_ui(self, context: Context, layout: UILayout):
+		obj = context.object
+		mob_type = getmob_type(obj)
+		if mob_type in ["Villager", "Trader"]:
+			layout.prop(self, "profession_variation")
+			layout.prop(self, "level_variation")
+			layout.prop(self, "biome_variation")
+			
+		elif mob_type == "Zombie":
+			layout.prop(self, "zombie_variation")
+		elif mob_type == "Skeleton":
+			layout.prop(self, "skeleton_variation")
+		
+		if mob_type in ["Villager", "Piglin", "Pigman", "Hoglin", "Allay"]
+			text = "Is Vex" if mob_type == "Allay" else "Is Zombified"
+			layout.prop(self, "is_zombiefied", text=text)
 
 # -----------------------------------------------------------------------------
 # Reusable functions for spawners
 # -----------------------------------------------------------------------------
-def getmob_type(): 
-  return "foo"
+def getmob_type(obj: Object): 
+  return obj.get("MCPREP_RIGTYPE")
 
-def add_prop(datablock, prop, prop_value):
-  datablock[prop] = prop_value
 
 def has_color(name):
 	"""Return True if has the color in name"""
@@ -703,12 +757,17 @@ def load_append(self, context: Context, path: Path, name: str) -> None:
 		util.select_set(objs, True)
 		
 def init_entity_prop(obj: bpy.types.Object, name: str, rig_version = (0,0,0)):
+	""" An utility function for adding attribute to object, armature object rigs, collection"""
 	# Vanilla mobs name or Custom, useful for skinswap villager rig
 	rig_type = obj.get("MCPREP_RIGTYPE")
 	# This will set the current Blender version if not exist
 	rig_version = obj.get("MCPREP_RIGVERS")
 	if rig_type == None:
 		util.set_prop(obj, "MCPREP_RIGTYPE", name)
+	if rig_version == None:
+		util.set_prop(obj, "MCPREP_RIGVERS", rig_version)
+		
+		
 
 # -----------------------------------------------------------------------------
 # class definitions

--- a/MCprep_addon/spawner/spawn_util.py
+++ b/MCprep_addon/spawner/spawn_util.py
@@ -46,22 +46,22 @@ else:
 	COLL_ICON = 'GROUP'
 
 class ColorVariation(Enum):
-	WHITE = auto()
-	ORANGE = auto()
-	MAGENTA = auto()
-	LIGHTBLUE = auto()
-	YELLOW = auto()
-	LIME = auto()
-	PINK = auto()
-	GRAY = auto()
-	LIGHTGRAY = auto()
-	CYAN = auto()
-	PURPLE = auto()
-	BLUE = auto()
-	BROWN = auto()
-	GREEN = auto()
-	RED = auto()
-	BLACK = auto()
+	WHITE = 0
+	ORANGE = 1
+	MAGENTA = 2
+	LIGHTBLUE = 3
+	YELLOW = 4
+	LIME = 5
+	PINK = 6
+	GRAY = 7
+	LIGHTGRAY = 8
+	CYAN = 9
+	PURPLE = 10
+	BLUE = 11
+	BROWN = 12
+	GREEN = 13
+	RED = 14
+	BLACK = 15
 	
 class VillagerProfession(Enum):
 	"""Preserve for villager"""
@@ -83,15 +83,31 @@ class VillagerProfession(Enum):
 	MASON = auto()
 	NITWIT = auto()
 	
-class ColorVariationProp():
+class VariationProp():
 	def color_items(self, context):
 		return [(i.value, i.name, i.name) for i in ColorVariation]
 	
-	color_variation = bpy.props.EnumProperty(name="Color Variation", items=color_items)
+	def profession_items(self, context):
+		return [(i.value, i.name, i.name) for i in ColorVariation]
+	
+	def level_items(self, context):
+		return [(i.value, i.name, i.name) for i in ColorVariation]
+	
+	color_variation : bpy.props.EnumProperty(name="Color Variation", items=color_items)
+	# Villagers
+	profession_variation : bpy.props.EnumProperty(name="Villager Profession", items=profession_items)
+	level_variation : bpy.props.EnumProperty(name="Villager Level", items=level_items)
+	region_variation : bpy.props.EnumProperty(name="Villager Region"= items=region_items)
+	undead_variation : bpy.props.EnumProperty(name="Undead Variation")
 
 # -----------------------------------------------------------------------------
 # Reusable functions for spawners
 # -----------------------------------------------------------------------------
+def getmob_type(): 
+  return "foo"
+
+def add_prop(datablock, prop, prop_value):
+  datablock[prop] = prop_value
 
 def has_color(name):
 	"""Return True if has the color in name"""

--- a/MCprep_addon/spawner/spawn_util.py
+++ b/MCprep_addon/spawner/spawn_util.py
@@ -45,10 +45,57 @@ elif util.bv28():
 else:
 	COLL_ICON = 'GROUP'
 
+class ColorVariation(Enum):
+	WHITE = auto()
+	ORANGE = auto()
+	MAGENTA = auto()
+	LIGHTBLUE = auto()
+	YELLOW = auto()
+	LIME = auto()
+	PINK = auto()
+	GRAY = auto()
+	LIGHTGRAY = auto()
+	CYAN = auto()
+	PURPLE = auto()
+	BLUE = auto()
+	BROWN = auto()
+	GREEN = auto()
+	RED = auto()
+	BLACK = auto()
+	
+class VillagerProfession(Enum):
+	"""Preserve for villager"""
+	# def _generate_next_value_(name, start, count, last_values):
+	# 	return name
+	
+	FARMER = auto()
+	FISHERMAN = auto()
+	SHEPHERD = auto()
+	FLETCHER = auto()
+	LIBRARIAN = auto()
+	CARTOGRAPHER = auto()
+	CLERIC = auto()
+	ARMORER = auto()
+	WEAPONSMITH = auto()
+	TOOLSMITH = auto()
+	BUTCHER = auto()
+	LEATHERWORKER = auto()
+	MASON = auto()
+	NITWIT = auto()
+	
+class ColorVariationProp():
+	def color_items(self, context):
+		return [(i.value, i.name, i.name) for i in ColorVariation]
+	
+	color_variation = bpy.props.EnumProperty(name="Color Variation", items=color_items)
+
 # -----------------------------------------------------------------------------
 # Reusable functions for spawners
 # -----------------------------------------------------------------------------
 
+def has_color(name):
+	"""Return True if has the color in name"""
+	return name in ["white", "orange", "magenta", "light_blue", "yellow", "lime", "pink", "gray", "light_gray", "cyan", "purple", "blue", "brown", "green", "red", "black"]
 
 def filter_collections(data_from: BlendDataLibraries) -> List[str]:
 	""" TODO 2.7 groups 

--- a/MCprep_addon/spawner/spawn_util.py
+++ b/MCprep_addon/spawner/spawn_util.py
@@ -45,90 +45,88 @@ elif util.bv28():
 else:
 	COLL_ICON = 'GROUP'
 
-class ColorVariation(Enum):
-	WHITE = 0
-	ORANGE = 1
-	MAGENTA = 2
-	LIGHTBLUE = 3
-	YELLOW = 4
-	LIME = 5
-	PINK = 6
-	GRAY = 7
-	LIGHTGRAY = 8
-	CYAN = 9
-	PURPLE = 10
-	BLUE = 11
-	BROWN = 12
-	GREEN = 13
-	RED = 14
-	BLACK = 15
-	
-class VillagerProfession(Enum):
-	"""Preserve for villager"""
-	ARMORER = 0
-	BUTCHER = 1
-	CARTOGRAPHER = 2
-	CLERIC = 3
-	FARMER = 4
-	FISHERMAN = 5
-	FLETCHER = 6
-	LEATHERWORKER = 7
-	LIBRARIAN = 8
-	MASON = 9
-	NITWIT = 10
-	SHEPHERD = 11
-	TOOLSMITH = 12
-	WEAPONSMITH = 13
-	WANDER = 14 # Wandering Trader is not a villager 
-	
-class VillagerBiome(Enum):
-	PLAINS = 0 # Favour plains as default then alphabet
-	DESERT = 1
-	JUNGLE = 2
-	SAVANNA = 3
-	SNOWY = 4
-	Swamp = 5
-	Taiga = 6
-	
-class VillagerLevel(Enum):
-	NOVICE = 0 # Stone
-	APPRENTICE = 1 # Iron
-	JOURNEYMAN = 2 # Gold
-	EXPERT = 3 # Emerald
-	MASTER = 4 # Diamond
-	
-class ZombieVariation(Enum):
-	DEFAULT = 0
-	HUSK = 1
-	DROWN = 2
-	
-class SkeletonVariation(Enum):
-	DEFAULT = 0
-	WITHER = 1
-	
-	
 class VariationProp:
 	def color_items(self):
-		"""Color variation"""
-		return [(i.value, i.name, i.name) for i in ColorVariation]
+		"""Color variation in ID order"""
+		items = [
+			('WHITE', "White", ""),
+			('ORANGE', "Orange", ""),
+			('MAGENTA', "Magenta", ""),
+			('LIGHTBLUE', "Light Blue", ""),
+			('YELLOW', "Yellow", ""),
+			('LIME', "Lime", ""),
+			('PINK', "Pink", ""),
+			('GRAY', "Gray", ""), 
+			('LIGHTGRAY', "Light Gray", ""),
+			('CYAN', "Cyan", ""),
+			('PURPLE', "Purple", ""),
+			('BLUE', "Blue", ""),
+			('BROWN', "Brown", ""),
+			('GREEN', "Green", ""),
+			('RED', "Red", ""),
+			('BLACK', "Black", ""),
+		]
+		return items
 	
 	def profession_items(self):
 		"""Villager Professional"""
-		return [(i.value, i.name, i.name) for i in VillagerProfession]
+		items = [
+			('ARMORER', "Armorer", ""),
+			('BUTCHER', "Butcher", ""),
+			('CARTOGRAPHER', "Cartographer", ""),
+			('CLERIC', "Cleric", ""),
+			('FARMER', "Farmer", ""),
+			('FISHERMAN', "Fisherman", ""),
+			('FLETCHER', "FLETCHER", ""),
+			('LEATHERWORKER', "Leatherworker", ""),
+			('LIBRARIAN', "Librarian", ""),
+			('MASON', "Mason", ""),
+			('NITWIT', "Nitwit", ""),
+			('SHEPHERD', "Shepherd", ""),
+			('TOOLSMITH', "Toolsmith", ""),
+			('WEAPONSMITH', "Weaponsmith", ""),
+			('WANDER', "Wandering", ""), # Wandering Trader is not a villager but leave it there, illagers could be in the list too (witch?)
+		]
+		return items
 	
 	def level_items(self):
-		"""Villager Level method"""
-		return [(i.value, i.name, i.name) for i in VillagerLevel]
+		"""Villager Level """
+		items = [
+			('NOVICE', "NOVICE", ""), # Stone
+			('APPRENTICE', "Apprentice", ""), # Iron
+			('JOURNEYMAN', "Journeyman", ""), # Gold
+			('EXPERT', "Expert", ""), # Emerald
+			('MASTER', "Master", ""), # Diamond
+		]
+		return items
 	
 	def biome_items(self):
-		return [(i.value, i.name, i.name) for i in VillagerBiome]
-		
+		items = [
+			('DESERT', "Desert", ""),
+			('JUNGLE', "Jungle", ""),
+			('PLAINS', "Plains", ""),
+			('SAVANNA', "Savanna", ""),
+			('SNOWY', "Snowy", ""),
+			('SWAMP', "Swamp", ""),
+			('TAIGA', "Taiga", ""),
+		]
+		return items
+	
 	def zombie_items(self):
-		return [(i.value, i.name, i.name) for i in VillagerBiome]
-		
+		items = [
+			('DEFAULT', "Default", ""),
+			('DROWN', "Drown", "")
+			('HUSK', "Husk", ""),
+		]
+		return items
+	
 	def skeleton_items(self):
-		return [(i.value, i.name, i.name) for i in SkeletonVariation]
-		
+		items = [
+			('DEFAULT', "Default", ""),
+			('STRAY', "Stray", ""),
+			('WITHER', "Wither", ""),
+		]
+		return items
 	
 	color_variation: bpy.props.EnumProperty(name="Color Variation", items=color_items)
 	# Villagers
@@ -137,7 +135,7 @@ class VariationProp:
 	biome_variation: bpy.props.EnumProperty(name="Villager Biome", items=biome_items)
 	zombie_variation: bpy.props.EnumProperty(name="Zombie Variation", items=zombie_items)
 	skeleton_variation: bpy.props.EnumProperty(name="Skeleton Variation", items=skeleton_items)
-	is_zombiefied: BoolProperty(name="Is Zombiefied")
+	is_zombiefied: BoolProperty(name="Is Zombiefied") # Use this for Allay-Vex 
 	
 	def draw_ui(self, context: Context, layout: UILayout):
 		obj = context.object
@@ -152,16 +150,19 @@ class VariationProp:
 		elif mob_type == "Skeleton":
 			layout.prop(self, "skeleton_variation")
 		
-		if mob_type in ["Villager", "Piglin", "Pigman", "Hoglin", "Allay"]
+		if mob_type in ["Villager", "Piglin", "Pigman", "Hoglin", "Allay", "Vex"]
 			text = "Is Vex" if mob_type == "Allay" else "Is Zombified"
 			layout.prop(self, "is_zombiefied", text=text)
 
 # -----------------------------------------------------------------------------
 # Reusable functions for spawners
 # -----------------------------------------------------------------------------
-def getmob_type(obj: Object): 
-  return obj.get("MCPREP_RIGTYPE")
-
+def getmob_type(obj: bpy.types.Object):
+  """ Get mob type from rig
+  args
+    obj: Armature Object
+  """
+  return obj.get("MCPREP_RIGTYPE", "Custom")
 
 def has_color(name):
 	"""Return True if has the color in name"""

--- a/MCprep_addon/spawner/spawn_util.py
+++ b/MCprep_addon/spawner/spawn_util.py
@@ -479,6 +479,7 @@ def load_linked(self, context: Context, path: str, name: str) -> None:
 				{'INFO'}, "This addon works better when the root bone's name is 'MAIN'")
 
 
+# TODO: Add a way to check the version before load_append()
 def load_append(self, context: Context, path: Path, name: str) -> None:
 	"""Append an entire collection/group into this blend file and fix armature.
 
@@ -637,6 +638,14 @@ def load_append(self, context: Context, path: Path, name: str) -> None:
 	# add the original selection back
 	for objs in sel:
 		util.select_set(objs, True)
+		
+def init_entity_prop(obj: bpy.types.Object, name: str, rig_version = (0,0,0)):
+	# Vanilla mobs name or Custom, useful for skinswap villager rig
+	rig_type = obj.get("MCPREP_RIGTYPE")
+	# This will set the current Blender version if not exist
+	rig_version = obj.get("MCPREP_RIGVERS")
+	if rig_type == None:
+		util.set_prop(obj, "MCPREP_RIGTYPE", name)
 
 # -----------------------------------------------------------------------------
 # class definitions

--- a/MCprep_addon/spawner/spawn_util.py
+++ b/MCprep_addon/spawner/spawn_util.py
@@ -18,11 +18,15 @@
 
 import os
 import re
-from typing import List, Optional
+from typing import List, Optional, Tuple, Union
 from pathlib import Path
 
 import bpy
-from bpy.types import Context, Collection, BlendDataLibraries
+from bpy.types import (
+	Context, Collection, 
+	BlendDataLibraries,
+	UILayout
+)
 
 from ..conf import env
 from .. import util
@@ -38,15 +42,11 @@ SKIP_COLL = "mcskip"  # Used for geometry and particle skips too.
 SKIP_COLL_LEGACY = "noimport"  # Supporting older MCprep Meshswap lib.
 
 # Icon backwards compatibility.
-if util.bv30():
-	COLL_ICON = 'OUTLINER_COLLECTION'
-elif util.bv28():
-	COLL_ICON = 'COLLECTION_NEW'
-else:
-	COLL_ICON = 'GROUP'
+COLL_ICON = 'OUTLINER_COLLECTION' if util.bv30() else 'COLLECTION_NEW'
+
 
 class VariationProp:
-	def color_items(self):
+	def color_items(self, context: Context) -> List[Tuple[str,str,str]]:
 		"""Color variation in ID order"""
 		items = [
 			('WHITE', "White", ""),
@@ -67,8 +67,8 @@ class VariationProp:
 			('BLACK', "Black", ""),
 		]
 		return items
-	
-	def profession_items(self):
+		
+	def profession_items(self, context: Context) -> List[Tuple[str, str, str]]:
 		"""Villager Professional"""
 		items = [
 			('ARMORER', "Armorer", ""),
@@ -77,7 +77,7 @@ class VariationProp:
 			('CLERIC', "Cleric", ""),
 			('FARMER', "Farmer", ""),
 			('FISHERMAN', "Fisherman", ""),
-			('FLETCHER', "FLETCHER", ""),
+			('FLETCHER', "Fletcher", ""),
 			('LEATHERWORKER', "Leatherworker", ""),
 			('LIBRARIAN', "Librarian", ""),
 			('MASON', "Mason", ""),
@@ -89,10 +89,10 @@ class VariationProp:
 		]
 		return items
 	
-	def level_items(self):
+	def level_items(self, context: Context) -> List[Tuple[str, str, str]]:
 		"""Villager Level """
 		items = [
-			('NOVICE', "NOVICE", ""), # Stone
+			('NOVICE', "Novice", ""), # Stone
 			('APPRENTICE', "Apprentice", ""), # Iron
 			('JOURNEYMAN', "Journeyman", ""), # Gold
 			('EXPERT', "Expert", ""), # Emerald
@@ -100,7 +100,7 @@ class VariationProp:
 		]
 		return items
 	
-	def biome_items(self):
+	def biome_items(self, context: Context) -> List[Tuple[str, str, str]]:
 		items = [
 			('DESERT', "Desert", ""),
 			('JUNGLE', "Jungle", ""),
@@ -112,32 +112,179 @@ class VariationProp:
 		]
 		return items
 	
-	def zombie_items(self):
+	def zombie_items(self, context: Context) -> List[Tuple[str, str, str]]:
 		items = [
 			('DEFAULT', "Default", ""),
-			('DROWN', "Drown", "")
+			('DROWN', "Drown", ""),
 			('HUSK', "Husk", ""),
 		]
 		return items
 	
-	def skeleton_items(self):
+	def skeleton_items(self, context: Context) -> List[Tuple[str, str, str]]:
 		items = [
 			('DEFAULT', "Default", ""),
 			('STRAY', "Stray", ""),
 			('WITHER', "Wither", ""),
+			# ('BOGGED', "Bogged", "") # 1.21 Added new skeleton varia
 		]
 		return items
 	
-	color_variation: bpy.props.EnumProperty(name="Color Variation", items=color_items)
-	# Villagers
-	profession_variation: bpy.props.EnumProperty(name="Villager Profession", items=profession_items)
-	level_variation: bpy.props.EnumProperty(name="Villager Level", items=level_items)
-	biome_variation: bpy.props.EnumProperty(name="Villager Biome", items=biome_items)
+	def axolotl_items(self, context: Context) -> List[Tuple[str, str, str]]:
+		items = [
+			('BLUE', "Blue", ""),
+			('CYAN', "Cyan", ""),
+			('GOLD', "Gold", ""),
+			('LUCY', "Lucy", ""),
+			('WILD', "Wild", ""),
+		]
+		return items
+	
+	def rabbit_items(self, context: Context) -> List[Tuple[str, str, str]]:
+		items = [
+			('BLACK', "Black", ""),
+			('BROWN', "Brown", ""),
+			('CAERBANNOG', "Caerbannog", ""),
+			('GOLD', "Gold", ""),
+			('SALT', "Salt", ""),
+			('TOAST',"Toast", ""),
+			('WHITE', "White", ""),
+			('WHITE_SPLOTCHED',"White splotched", ""),
+		]
+		return items
+	
+	def frog_items(self, context: Context) -> List[Tuple[str, str, str]]:
+		items = [
+			('COLD', "Cold", ""),
+			('TEMPERATE', "Temperate", ""),
+			('WARM', "Warm", ""),
+		]
+		return items
+	
+	def parrot_items(self, context: Context) -> List[Tuple[str, str, str]]:
+		items = [
+			('BLUE', "Blue", ""),
+			('GREEN',"Green", ""),
+			('GREY', "Grey", ""), 
+			('RED_BLUE', "Red blue", ""),
+			('YELLOW_BLUE', "Yellow blue", ""),
+		]
+		return items
+		
+	def llama_items(self, context: Context) -> List[Tuple[str, str, str]]:
+		items = [
+			('BROWN',"Brown", ""),
+			('CREAMY',"Creamy",""),
+			('GRAY', "Gray", ""),
+			('WHITE', "White", ""),
+		]
+		return items
+	
+	def horse_items(self, context: Context) -> List[Tuple[str, str, str]]:
+		items = [
+			('BLACK', "Black", ""),
+			('BROWN', "BROWN", ""),
+			('CHESTNUT', "CHESTNUT", ""),
+			('CREAMY', "CREAMY", ""),
+			('DARK_BROWN', "DARK_BROWN", ""),
+			('GRAY', "GRAY", ""),
+			('ZOMBIE', "ZOMBIE", ""),
+			('SKELETON', "SKELETON", ""),
+		]
+		return items
+		
+	def cat_items(self, context: Context) -> List[Tuple[str, str, str]]:
+		items = [
+			('ALL_BLACK', "All Black",""),
+			('BLACK', "Black", ""),
+			('BRITISH_SHORTHAIR', "British Shorthair", ""),
+			('CALICO', "Calico", ""),
+			('JELLIE', "Jellie", ""),
+			('OCELOT', "Ocelot", ""),
+			('PERSIAN', "Persian", ""),
+			('RAGDOLL', "Ragdoll", ""),
+			('RED', "Red", ""),
+			('SIAMESE', "Siamese", ""),
+			('TABBY', "Tabby", ""),
+			('WHITE', "White", ""),
+			# ('CAT_COLLAR', "", "")
+		]
+		return items
+	
+	def fox_items(self, context: Context) -> List[Tuple[str, str, str]]:
+		items = [
+			('NORMAL', "Normal", ""),
+			('SNOW', "Snow", "")
+		]
+		return items
+	
+	def squid_items(self, context: Context) -> List[Tuple[str, str, str]]:
+		items = [
+			('NORMAL', "Squid", ""),
+			('GLOW', "Glow", "")
+		]
+		return items
+	
+	def tropical_pattern_items(self, context: Context) -> List[Tuple[str, str, str]]:
+		items = [
+			('PATTERN_1', "Pattern 1", ""),
+			('PATTERN_2', "Pattern 2", ""),
+			('PATTERN_3', "Pattern 3", ""),
+			('PATTERN_4', "Pattern 4", ""),
+			('PATTERN_5', "Pattern 5", ""),
+			("PATTERN_6", "Pattern 6", ""),
+		]
+		return items
+	
+	def dog_items(self, context) -> List[Tuple[str, str, str]]:
+		items = [ 
+			# ignore this just placeholder for 1.21 wolf variations
+			('DEF', "def", ""),
+			('DEA', "dea", "")
+		]
+		return items
+	
+	def get_villager_names(self) -> Tuple[str, str, str]:
+		"""Returns profession, profession level, type path in order"""
+		# (adds villager/{}.png to get the texture path, same for zombie_villager/)
+		return f"profession/{self.profession_variation}", f"profession_level/{self.level_variation}", f"type/{self.biome_variation}"
+	
+	def get_squid_name(self) -> str:
+		return self.squid_variation == 'GLOW' if 'glow_squid' else 'squid'
+	
+	def get_fox_name(self) -> Tuple[str, str]:
+		return ("snow_fox", "snow_fox_sleeping") if self.fox_variation == 'SNOW' else ("fox", "fox_sleeping")
+	
+	def get_tropical_name(self) -> str:
+		"""Returns the tropical fish type and pattern"""
+		# (adds fish/{}.png to get the texture path)
+		type = self.tropical_type_variation.lower()
+		pattern = self.tropical_pattern_variation.replace("PATTERN_", "")
+		return f"tropical_{type}_pattern_{pattern}"
+			
+	def get_texture_path(self, mob_type: str, is_zombified: bool = False) -> List[Union[str, Path]]:
+		if mob_type == "Villager":
+			names = self.get_villager_names()
+			return [f"zombie_villager/{t}.png" for t in names] if is_zombified else[f"villager/{t}.png" for t in names]
+		elif mob_type == "Zombie":
+			return [f"zombie/{self.zombie_variation.lower()}.png"]
+		elif mob_type == "Skeleton":
+			return [f"zombie/{self.skeleton_variation.lower()}.png"]
+		elif mob_type == "Allay" or mob_type == "Vex":
+			return [] if self.is_zombiefied or mob_type == "Vex" else []
+			# TODO: Add the rest of the mobs
+			
+	profession_variation: bpy.props.EnumProperty(name="Profession", items=profession_items)
+	level_variation: bpy.props.EnumProperty(name="Level", items=level_items)
+	biome_variation: bpy.props.EnumProperty(name="Biome", items=biome_items)
 	zombie_variation: bpy.props.EnumProperty(name="Zombie Variation", items=zombie_items)
 	skeleton_variation: bpy.props.EnumProperty(name="Skeleton Variation", items=skeleton_items)
-	is_zombiefied: BoolProperty(name="Is Zombiefied") # Use this for Allay-Vex 
+	is_zombiefied: bpy.props.BoolProperty(name="Is Zombiefied")  # Use this for Allay-Vex
+	fox_variation: bpy.props.EnumProperty(items=fox_items)
+	dog_variation: bpy.props.EnumProperty(items=dog_items)
+	cat_variation: bpy.props.EnumProperty(items=cat_items)
 	
-	def draw_ui(self, context: Context, layout: UILayout):
+	def draw_variation_ui(self, context: Context, layout: UILayout):
+		""" Sharable method for drawing"""
 		obj = context.object
 		mob_type = getmob_type(obj)
 		if mob_type in ["Villager", "Trader"]:
@@ -149,24 +296,46 @@ class VariationProp:
 			layout.prop(self, "zombie_variation")
 		elif mob_type == "Skeleton":
 			layout.prop(self, "skeleton_variation")
-		
-		if mob_type in ["Villager", "Piglin", "Pigman", "Hoglin", "Allay", "Vex"]
+		elif mob_type == "Axolotl":
+			layout.prop(self, "axolotl_variation")
+		elif mob_type == "Rabbit":
+			layout.prop(self, "rabbit_variation")
+		elif mob_type == "Frog":
+			layout.prop(self, "frog_variation")
+		elif mob_type == "Parrot":
+			layout.prop(self, "parrot_variation")
+		elif mob_type == "Llama":
+			layout.prop(self, "llama_variation")
+		elif mob_type == "Horse":
+			layout.prop(self, "horse_variation")
+		elif mob_type == "Cat" or mob_type == "Ocelot":
+			layout.prop(self, "cat_variation")
+		elif mob_type == "Dog" or mob_type == "Wolf":
+			layout.prop(self, "dog_variation")
+			
+		counter_variant = ["Villager", "Piglin", "Hoglin", "Allay", "Vex"]
+		if mob_type in counter_variant:
 			text = "Is Vex" if mob_type == "Allay" else "Is Zombified"
 			layout.prop(self, "is_zombiefied", text=text)
+		
+		has_variant = counter_variant + ["Zombie", "Skeleton", "Llama", "Axolotl", "Rabbit", "Llama", "Parrot", "Frog", "Horse", "Cat", "Ocelot"]
+		if mob_type == "Custom" or mob_type not in has_variant:
+			layout.label(text="This mob doesn't has any variant to swap skin yet")
+		elif mob_type == "Player":
+			layout.label(text="Please use Player for this")
 
 # -----------------------------------------------------------------------------
 # Reusable functions for spawners
 # -----------------------------------------------------------------------------
-def getmob_type(obj: bpy.types.Object):
-  """ Get mob type from rig
-  args
-    obj: Armature Object
-  """
-  return obj.get("MCPREP_RIGTYPE", "Custom")
 
-def has_color(name):
-	"""Return True if has the color in name"""
-	return name in ["white", "orange", "magenta", "light_blue", "yellow", "lime", "pink", "gray", "light_gray", "cyan", "purple", "blue", "brown", "green", "red", "black"]
+
+def getmob_type(rig: bpy.types.Object):
+	""" Get mob type from rig
+	args
+		obj: Armature Object
+	"""
+	return rig.type == 'ARMATURE' and rig.get("MCPREP_MOBTYPE", "Custom")
+
 
 def filter_collections(data_from: BlendDataLibraries) -> List[str]:
 	""" TODO 2.7 groups 
@@ -597,7 +766,6 @@ def load_linked(self, context: Context, path: str, name: str) -> None:
 				{'INFO'}, "This addon works better when the root bone's name is 'MAIN'")
 
 
-# TODO: Add a way to check the version before load_append()
 def load_append(self, context: Context, path: Path, name: str) -> None:
 	"""Append an entire collection/group into this blend file and fix armature.
 
@@ -677,17 +845,10 @@ def load_append(self, context: Context, path: Path, name: str) -> None:
 			# without deleting them, just unlinking them from the scene
 			util.obj_unlink_remove(ob, False, context)
 
-	if not util.bv28():
-		grp_added.name = "reload-blend-to-remove-this-empty-group"
-		for obj in grp_added.objects:
-			grp_added.objects.unlink(obj)
-			util.select_set(obj, True)
-		grp_added.user_clear()
-	else:
-		for obj in grp_added.objects:
-			if obj not in context.view_layer.objects[:]:
-				continue
-			util.select_set(obj, True)
+	for obj in grp_added.objects:
+		if obj not in context.view_layer.objects[:]:
+			continue
+		util.select_set(obj, True)
 
 	# try:
 	# 	util.collections().remove(grp_added)
@@ -756,19 +917,6 @@ def load_append(self, context: Context, path: Path, name: str) -> None:
 	# add the original selection back
 	for objs in sel:
 		util.select_set(objs, True)
-		
-def init_entity_prop(obj: bpy.types.Object, name: str, rig_version = (0,0,0)):
-	""" An utility function for adding attribute to object, armature object rigs, collection"""
-	# Vanilla mobs name or Custom, useful for skinswap villager rig
-	rig_type = obj.get("MCPREP_RIGTYPE")
-	# This will set the current Blender version if not exist
-	rig_version = obj.get("MCPREP_RIGVERS")
-	if rig_type == None:
-		util.set_prop(obj, "MCPREP_RIGTYPE", name)
-	if rig_version == None:
-		util.set_prop(obj, "MCPREP_RIGVERS", rig_version)
-		
-		
 
 # -----------------------------------------------------------------------------
 # class definitions

--- a/MCprep_addon/util.py
+++ b/MCprep_addon/util.py
@@ -17,7 +17,7 @@
 # ##### END GPL LICENSE BLOCK #####
 
 from subprocess import Popen, PIPE
-from typing import List, Optional, Union, Tuple, Any
+from typing import List, Optional, Union, Tuple, Any, Dict
 import enum
 import json
 import operator
@@ -35,7 +35,8 @@ from bpy.types import (
 	Material,
 	Image,
 	Node,
-	UILayout
+	UILayout,
+	ID
 )
 from mathutils import Vector, Matrix
 
@@ -809,7 +810,8 @@ def move_assets_to_excluded_layer(context: Context, collections: List[Collection
 			continue  # not linked, likely a sub-group not added to scn
 		spawner_exclude_vl.collection.children.link(grp)
 		initial_view_coll.collection.children.unlink(grp)
-		
+
+
 def set_prop(id_block: ID, key: str, value: Any, **kwargs: Dict[str, Any]):
 	"""Create or set the properties
 		3.0 got more functionalities
@@ -819,8 +821,9 @@ def set_prop(id_block: ID, key: str, value: Any, **kwargs: Dict[str, Any]):
 		id_props = id_block.id_properties_ui(key)
 		id_props.update(**kwargs)
 		overrides = kwargs.get("overridable_library", True)
-		if overrides != None:
+		if overrides is not None:
 			id_block.property_overridable_library_set(f'["{key}"]', overrides)
+
 
 def is_no_prep(mat: Material):
 	"""Check is material has no prep properties 
@@ -828,7 +831,8 @@ def is_no_prep(mat: Material):
 	not exist or 0 returns False
 	"""
 	return mat.get("MCPREP_NO_PREP", False)
-	
+
+
 def get_entity_prop(obj, prop: Optional[str] = None):
 	if prop:
 		return obj.get(prop)

--- a/MCprep_addon/util.py
+++ b/MCprep_addon/util.py
@@ -17,7 +17,7 @@
 # ##### END GPL LICENSE BLOCK #####
 
 from subprocess import Popen, PIPE
-from typing import List, Optional, Union, Tuple
+from typing import List, Optional, Union, Tuple, Any
 import enum
 import json
 import operator
@@ -809,3 +809,25 @@ def move_assets_to_excluded_layer(context: Context, collections: List[Collection
 			continue  # not linked, likely a sub-group not added to scn
 		spawner_exclude_vl.collection.children.link(grp)
 		initial_view_coll.collection.children.unlink(grp)
+		
+def set_prop(id_block: ID, key: str, value: Any, **kwargs: Dict[str, Any]):
+	"""Create or set the properties"""
+	id_block[key] = value
+	id_props = id_block.id_properties_ui(key)
+	id_props.update(**kwargs)
+	overrides = kwargs.get("overridable_library")
+	if overrides != None:
+		id_block.property_overridable_library_set(f'["{key}"]', overrides)
+
+def is_no_prep(mat: Material):
+	"""Check is material has no prep properties 
+	If no_prep is 1 returns True
+	not exist or 0 returns False
+	"""
+	return mat.get("MCPREP_NO_PREP", False)
+	
+def get_entity_prop(obj, prop: Optional[str] = None):
+	if prop:
+		return obj.get(prop)
+	else:
+		return obj.items()

--- a/MCprep_addon/util.py
+++ b/MCprep_addon/util.py
@@ -811,13 +811,16 @@ def move_assets_to_excluded_layer(context: Context, collections: List[Collection
 		initial_view_coll.collection.children.unlink(grp)
 		
 def set_prop(id_block: ID, key: str, value: Any, **kwargs: Dict[str, Any]):
-	"""Create or set the properties"""
+	"""Create or set the properties
+		3.0 got more functionalities
+	"""
 	id_block[key] = value
-	id_props = id_block.id_properties_ui(key)
-	id_props.update(**kwargs)
-	overrides = kwargs.get("overridable_library")
-	if overrides != None:
-		id_block.property_overridable_library_set(f'["{key}"]', overrides)
+	if bv30():
+		id_props = id_block.id_properties_ui(key)
+		id_props.update(**kwargs)
+		overrides = kwargs.get("overridable_library", True)
+		if overrides != None:
+			id_block.property_overridable_library_set(f'["{key}"]', overrides)
 
 def is_no_prep(mat: Material):
 	"""Check is material has no prep properties 


### PR DESCRIPTION
WIP of #440, second part of #561 
*(This is not ready for review, discuss further on how this should be implemented)*

 As in #440 this add a system for rig have `MCPREP_RIGTYPE` non "Custom" under the rig armature object to use a different skin swap tab.
 It would be an improvement [spawn_with_skin](https://github.com/Moo-Ack-Productions/MCprep/blob/c7622a626e7495db5919d63149f0cfc53fe62b14/MCprep_addon/materials/skin.py#L657C57-L658C2) since it getting directly from the resource pack path.

https://github.com/Moo-Ack-Productions/MCprep/assets/61040487/5fc96af7-5e12-4648-94da-d9de2de3611d

The UI properties is store under a class and go through store at WindowManager context.
Question:
How should it have access to the rig materials?
1) Have a  for loop iterate though the objects find matching material type property `MCPREP_MatType` (for example "Profession" "Level" "Biome" for villager)
2) Have many custom properties `MCPREP_MatVillagerProfession` `MCPREP_MatVillagerLevel` `MCPrep_MatVillagerBiome` string *name* under the armature object and `materials.get( name)` to get

and use skin swap function to set the texture inside. 

"Invert" mob type.
How or should have an "invert" or zombified type as a checkbox? 
Allay -> Vex; Piglin -> Zombified Piglin; Hoglin -> Zombified Hoglin; Zombie Villager; 

UI it would be something like Mine imator with the variant but rather upon adding the mob you do it after with an operator button to switch variant or color `MCPREP_HAS_COLOR`.

![image](https://github.com/Moo-Ack-Productions/MCprep/assets/61040487/559f20f5-5bc8-4280-83d3-081004c7a352)



