### PR TITLE
Add additional checkmark to asset submisison form

### DIFF
--- a/.github/ISSUE_TEMPLATE/Asset-Submission.yaml
+++ b/.github/ISSUE_TEMPLATE/Asset-Submission.yaml
@@ -29,6 +29,8 @@ body:
           required: true
         - label: I am the sole creator of this rig, other than any textures by Mojang. Any custom textures I created myself.
           required: true
+        - label: That I, submitter of this rig, will be active in all discussion on this submission, and understand that not *responding to comments on this submission could result in this submission being rejected*.
+          required: true
 
   - type: textarea
     id: usage-details


### PR DESCRIPTION
We've had a few people just submit rigs and then call it a day, without commenting back at all. To counteract this, I've added a checkbox where the submitter affirms that yes, they understand that as submitter of a rig, they must be active in any discussion on said submission.

This also allows us to better justify closing submissions where the submitters haven't commented at all since submission.