### PR TITLE
fix: Only check for scaled UVs if the OBJ does not have CommonMCOBJ data

### DIFF
--- a/MCprep_addon/materials/prep.py
+++ b/MCprep_addon/materials/prep.py
@@ -489,7 +489,12 @@ class MCPREP_OT_swap_texture_pack(
 			self.report({'ERROR'}, "No materials found on selected objects")
 			return {'CANCELLED'}
 		_ = generate.detect_form(mat_list)
-		invalid_uv, affected_objs = uv_tools.detect_invalid_uvs_from_objs(obj_list)
+		
+		# If we have a commonmcobj header, we don't need 
+		# to check for scaled UVs
+		invalid_uv, affected_objs = (False, [])
+		if not world_tools.is_commonmc_obj(context):
+			invalid_uv, affected_objs = uv_tools.detect_invalid_uvs_from_objs(obj_list)
 
 		# NOTE: This is temporary
 		addon_prefs = util.get_user_preferences(context)

--- a/MCprep_addon/world_tools.py
+++ b/MCprep_addon/world_tools.py
@@ -151,6 +151,12 @@ EXPORTER_MAPPING = {
 
 UNSUPPORTED_OR_NONE = (WorldExporter.Unknown, None)
 
+def is_commonmc_obj(context: Context) -> bool:
+	obj = context.object
+	if obj and "COMMONMCOBJ_HEADER" in obj:
+		return True
+	return False
+
 def get_exporter(context: Context) -> Optional[WorldExporter]:
 	"""
 	Return the exporter on the active object if it has


### PR DESCRIPTION
(Doesn't resolve #661 completely, but it does reduce confusion for this case)

This PR (in addition to adding a helper function to check for the existance of CommonMCOBJ data) changes the scaled UVs check so it only runs if the OBJ does not have CommonMCOBJ data, since `texture_type` is more reliable than the scaled UVs check anyway.

Maybe in the future we could compare the resource pack to the `texture_type` value and make it smarter, but for now, this simple fix will do.