### PR TITLE
build(rc): Make download_resources.sh restore Languages and JSON

### DIFF
--- a/rc-files/download_resources.sh
+++ b/rc-files/download_resources.sh
@@ -2,7 +2,7 @@
 # 
 # TODO: Automatically get the latest tag and download link. Perhaps 
 # through the GitHub API?
-wget "https://github.com/Moo-Ack-Productions/MCprep/releases/download/3.5.3/MCprep_addon_3.5.3.zip"
+wget "https://github.com/Moo-Ack-Productions/MCprep/releases/download/3.6.1.2/MCprep_addon_3.6.1.2.zip"
 mkdir MCprep_stable_release
 unzip ./MCprep_addon_*.zip -d MCprep_stable_release
 

--- a/rc-files/download_resources.sh
+++ b/rc-files/download_resources.sh
@@ -12,3 +12,6 @@ rm -rf ./MCprep_addon/MCprep_resources/**
 mv -f ./MCprep_stable_release/MCprep_addon/MCprep_resources/** ./MCprep_addon/MCprep_resources 
 # Remove the stable release
 rm -rf ./MCprep_stable_release MCprep_addon_*.zip
+
+git restore MCprep_addon/MCprep_resources/Languages
+git restore MCprep_addon/MCprep_resources/mcprep_data_update.json

--- a/rc-files/download_resources.sh
+++ b/rc-files/download_resources.sh
@@ -1,8 +1,10 @@
+#!/bin/sh
 # Get the latest stable release and unzip
 # 
 # TODO: Automatically get the latest tag and download link. Perhaps 
 # through the GitHub API?
-wget "https://github.com/Moo-Ack-Productions/MCprep/releases/download/3.6.1.2/MCprep_addon_3.6.1.2.zip"
+VERSION="3.6.1.2"
+wget "https://github.com/Moo-Ack-Productions/MCprep/releases/download/$VERSION/MCprep_addon_$VERSION.zip"
 mkdir MCprep_stable_release
 unzip ./MCprep_addon_*.zip -d MCprep_stable_release
 


### PR DESCRIPTION
To avoid issues when building MCprep (and for convinience reasons), the
download_resources.sh script has been updated to restore the `Languages`
and `mcprep_data_update.json` files after introducing the other assets.