### PR TITLE
poetry: Set package mode to false

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,7 @@ description = "Blender python addon to increase workflow for creating minecraft 
 authors = ["TheDuckCow"]
 license = "GPL-3.0-only"
 readme = "README.md"
+package-mode = false
 
 [tool.poetry.dependencies]
 python = "^3.9"


### PR DESCRIPTION
Small fix to prevent Poetry from complaining that MCprep isn't a package