### PR TITLE
refactor: Move custom node properties to PropertyGroup

### DIFF
--- a/MCprep_addon/materials/generate.py
+++ b/MCprep_addon/materials/generate.py
@@ -34,6 +34,12 @@ AnimatedTex = Dict[str, int]
 NO_DIFFUSE_NODE = 1
 IMG_MISSING = 2
 
+MCPREP_DIFFUSE = "MCPREP_diffuse"
+MCPREP_SPECULAR = "MCPREP_specular"
+MCPREP_NORMAL = "MCPREP_normal"
+MCPREP_DISPLACE = "MCPREP_displace"
+SATURATE = "SATURATE"
+
 
 class PackFormat(Enum):
 	SIMPLE = 0
@@ -433,7 +439,7 @@ def set_cycles_texture(
 		is_grayscale = is_image_grayscale(image)
 
 	for node in material.node_tree.nodes:
-		if node.type == "MIX_RGB" and util.np_is_mcprep_node_prop(node, "SATURATE"):
+		if node.type == "MIX_RGB" and util.np_is_mcprep_node_prop(node, SATURATE):
 			node.mute = not is_grayscale
 			node.hide = not is_grayscale
 			env.log(" mix_rgb to saturate texture")
@@ -442,11 +448,11 @@ def set_cycles_texture(
 		# saved as an attribute on the node
 		if node.type != 'TEX_IMAGE':
 			continue
-		elif util.np_is_mcprep_node_prop(node, "MCPREP_diffuse"):
+		elif util.np_is_mcprep_node_prop(node, MCPREP_DIFFUSE):
 			node.image = image
 			node.mute = False
 			node.hide = False
-		elif util.np_is_mcprep_node_prop(node, "MCPREP_normal"):
+		elif util.np_is_mcprep_node_prop(node, MCPREP_NORMAL):
 			if "normal" in img_sets:
 				new_img = util.loadTexture(img_sets["normal"])
 				node.image = new_img
@@ -464,7 +470,7 @@ def set_cycles_texture(
 				# normal_map = node.outputs[0].links[0].to_node
 				# principled = ...
 
-		elif util.np_is_mcprep_node_prop(node, "MCPREP_specular"):
+		elif util.np_is_mcprep_node_prop(node, MCPREP_SPECULAR):
 			if "specular" in img_sets:
 				new_img = util.loadTexture(img_sets["specular"])
 				node.image = new_img
@@ -508,13 +514,13 @@ def get_node_for_pass(material: Material, pass_name: str) -> Optional[Node]:
 	for node in material.node_tree.nodes:
 		if node.type != "TEX_IMAGE":
 			continue
-		elif util.np_is_mcprep_node_prop(node, "MCPREP_diffuse") and pass_name == "diffuse":
+		elif util.np_is_mcprep_node_prop(node, MCPREP_DIFFUSE) and pass_name == "diffuse":
 			return_node = node
-		elif util.np_is_mcprep_node_prop(node, "MCPREP_normal") and pass_name == "normal":
+		elif util.np_is_mcprep_node_prop(node, MCPREP_NORMAL) and pass_name == "normal":
 			return_node = node
-		elif util.np_is_mcprep_node_prop(node, "MCPREP_specular") and pass_name == "specular":
+		elif util.np_is_mcprep_node_prop(node, MCPREP_SPECULAR) and pass_name == "specular":
 			return_node = node
-		elif util.np_is_mcprep_node_prop(node, "MCPREP_displace") and pass_name == "displace":
+		elif util.np_is_mcprep_node_prop(node, MCPREP_DISPLACE) and pass_name == "displace":
 			return_node = node
 		else:
 			if not return_node:
@@ -561,11 +567,11 @@ def get_textures(material: Material) -> Dict[str, Image]:
 		for node in material.node_tree.nodes:
 			if node.type != "TEX_IMAGE":
 				continue
-			elif util.np_is_mcprep_node_prop(node, "MCPREP_diffuse"):
+			elif util.np_is_mcprep_node_prop(node, MCPREP_DIFFUSE):
 				passes["diffuse"] = node.image
-			elif util.np_is_mcprep_node_prop(node, "MCPREP_normal"):
+			elif util.np_is_mcprep_node_prop(node, MCPREP_NORMAL):
 				passes["normal"] = node.image
-			elif util.np_is_mcprep_node_prop(node, "MCPREP_specular"):
+			elif util.np_is_mcprep_node_prop(node, MCPREP_SPECULAR):
 				passes["specular"] = node.image
 			else:
 				if not passes["diffuse"]:
@@ -786,7 +792,7 @@ def set_saturation_material(mat: Material) -> None:
 	desat_color = env.json_data['blocks']['desaturated'][canon]
 	sat_node = None
 	for node in mat.node_tree.nodes:
-		if not util.np_is_mcprep_node_prop(node, "SATURATE"):
+		if not util.np_is_mcprep_node_prop(node, SATURATE):
 			continue
 		sat_node = node
 		break
@@ -868,13 +874,13 @@ def copy_texture_animation_pass_settings(mat: Material) -> AnimatedTex:
 			continue
 		if not node.image.source == 'SEQUENCE':
 			continue
-		if util.np_is_mcprep_node_prop(node, "MCPREP_diffuse"):
+		if util.np_is_mcprep_node_prop(node, MCPREP_DIFFUSE):
 			passname = "diffuse"
-		elif util.np_is_mcprep_node_prop(node, "MCPREP_normal"):
+		elif util.np_is_mcprep_node_prop(node, MCPREP_NORMAL):
 			passname = "normal"
-		elif util.np_is_mcprep_node_prop(node, "MCPREP_specular"):
+		elif util.np_is_mcprep_node_prop(node, MCPREP_SPECULAR):
 			passname = "specular"
-		elif util.np_is_mcprep_node_prop(node, "MCPREP_displace"):
+		elif util.np_is_mcprep_node_prop(node, MCPREP_DISPLACE):
 			passname = "displace"
 		else:
 			if not animated_data.get("diffuse"):

--- a/MCprep_addon/materials/generate.py
+++ b/MCprep_addon/materials/generate.py
@@ -433,7 +433,7 @@ def set_cycles_texture(
 		is_grayscale = is_image_grayscale(image)
 
 	for node in material.node_tree.nodes:
-		if node.type == "MIX_RGB" and "SATURATE" in node:
+		if node.type == "MIX_RGB" and util.np_is_mcprep_node_prop(node, "SATURATE"):
 			node.mute = not is_grayscale
 			node.hide = not is_grayscale
 			env.log(" mix_rgb to saturate texture")
@@ -442,11 +442,11 @@ def set_cycles_texture(
 		# saved as an attribute on the node
 		if node.type != 'TEX_IMAGE':
 			continue
-		elif "MCPREP_diffuse" in node:
+		elif util.np_is_mcprep_node_prop(node, "MCPREP_diffuse"):
 			node.image = image
 			node.mute = False
 			node.hide = False
-		elif "MCPREP_normal" in node:
+		elif util.np_is_mcprep_node_prop(node, "MCPREP_normal"):
 			if "normal" in img_sets:
 				new_img = util.loadTexture(img_sets["normal"])
 				node.image = new_img
@@ -464,7 +464,7 @@ def set_cycles_texture(
 				# normal_map = node.outputs[0].links[0].to_node
 				# principled = ...
 
-		elif "MCPREP_specular" in node:
+		elif util.np_is_mcprep_node_prop(node, "MCPREP_specular"):
 			if "specular" in img_sets:
 				new_img = util.loadTexture(img_sets["specular"])
 				node.image = new_img
@@ -486,7 +486,7 @@ def set_cycles_texture(
 
 		elif swap_all_imgs is True:
 			# assume all unlabeled texture nodes should be the diffuse pass
-			node["MCPREP_diffuse"] = True  # annotate node for future reference
+			node.mnp.MCPREP_diffuse = True  # annotate node for future reference
 			node.image = image
 			node.mute = False
 			node.hide = False
@@ -508,13 +508,13 @@ def get_node_for_pass(material: Material, pass_name: str) -> Optional[Node]:
 	for node in material.node_tree.nodes:
 		if node.type != "TEX_IMAGE":
 			continue
-		elif "MCPREP_diffuse" in node and pass_name == "diffuse":
+		elif util.np_is_mcprep_node_prop(node, "MCPREP_diffuse") and pass_name == "diffuse":
 			return_node = node
-		elif "MCPREP_normal" in node and pass_name == "normal":
+		elif util.np_is_mcprep_node_prop(node, "MCPREP_normal") and pass_name == "normal":
 			return_node = node
-		elif "MCPREP_specular" in node and pass_name == "specular":
+		elif util.np_is_mcprep_node_prop(node, "MCPREP_specular") and pass_name == "specular":
 			return_node = node
-		elif "MCPREP_displace" in node and pass_name == "displace":
+		elif util.np_is_mcprep_node_prop(node, "MCPREP_displace") and pass_name == "displace":
 			return_node = node
 		else:
 			if not return_node:
@@ -561,11 +561,11 @@ def get_textures(material: Material) -> Dict[str, Image]:
 		for node in material.node_tree.nodes:
 			if node.type != "TEX_IMAGE":
 				continue
-			elif "MCPREP_diffuse" in node:
+			elif util.np_is_mcprep_node_prop(node, "MCPREP_diffuse"):
 				passes["diffuse"] = node.image
-			elif "MCPREP_normal" in node:
+			elif util.np_is_mcprep_node_prop(node, "MCPREP_normal"):
 				passes["normal"] = node.image
-			elif "MCPREP_specular" in node:
+			elif util.np_is_mcprep_node_prop(node, "MCPREP_specular"):
 				passes["specular"] = node.image
 			else:
 				if not passes["diffuse"]:
@@ -786,7 +786,7 @@ def set_saturation_material(mat: Material) -> None:
 	desat_color = env.json_data['blocks']['desaturated'][canon]
 	sat_node = None
 	for node in mat.node_tree.nodes:
-		if "SATURATE" not in node:
+		if not util.np_is_mcprep_node_prop(node, "SATURATE"):
 			continue
 		sat_node = node
 		break
@@ -868,13 +868,13 @@ def copy_texture_animation_pass_settings(mat: Material) -> AnimatedTex:
 			continue
 		if not node.image.source == 'SEQUENCE':
 			continue
-		if "MCPREP_diffuse" in node:
+		if util.np_is_mcprep_node_prop(node, "MCPREP_diffuse"):
 			passname = "diffuse"
-		elif "MCPREP_normal" in node:
+		elif util.np_is_mcprep_node_prop(node, "MCPREP_normal"):
 			passname = "normal"
-		elif "MCPREP_specular" in node:
+		elif util.np_is_mcprep_node_prop(node, "MCPREP_specular"):
 			passname = "specular"
-		elif "MCPREP_displace" in node:
+		elif util.np_is_mcprep_node_prop(node, "MCPREP_displace"):
 			passname = "displace"
 		else:
 			if not animated_data.get("diffuse"):
@@ -1035,12 +1035,12 @@ def texgen_specular(mat: Material, passes: Dict[str, Image], nodeInputs: List, u
 		nodeSaturateMix.hide = False
 
 	# annotate special nodes for finding later, and load images if available
-	nodeTexDiff["MCPREP_diffuse"] = True
-	nodeTexSpec["MCPREP_specular"] = True
-	nodeTexNorm["MCPREP_normal"] = True
+	nodeTexDiff.mnp.MCPREP_diffuse = True
+	nodeTexSpec.mnp.MCPREP_specular = True
+	nodeTexNorm.mnp.MCPREP_normal = True
 	# to also be also muted if no normal tex
-	nodeNormal["MCPREP_normal"] = True
-	nodeSaturateMix["SATURATE"] = True
+	nodeNormal.mnp.MCPREP_normal = True
+	nodeSaturateMix.mnp.MCPREP_saturate = True
 	# nodeTexDisp["MCPREP_disp"] = True
 	nodeTexDiff.image = image_diff
 
@@ -1180,14 +1180,14 @@ def texgen_seus(mat: Material, passes: Dict[str, Image], nodeInputs: List, use_r
 		nodeSaturateMix.inputs[saturateMixIn[2]].default_value = desat_color
 		nodeSaturateMix.mute = False
 		nodeSaturateMix.hide = False
-
+		
 	# annotate special nodes for finding later, and load images if available
-	nodeTexDiff["MCPREP_diffuse"] = True
-	nodeTexSpec["MCPREP_specular"] = True
-	nodeTexNorm["MCPREP_normal"] = True
+	nodeTexDiff.mnp.MCPREP_diffuse = True
+	nodeTexSpec.mnp.MCPREP_specular = True
+	nodeTexNorm.mnp.MCPREP_normal = True
 	# to also be also muted if no normal tex
-	nodeNormal["MCPREP_normal"] = True
-	nodeSaturateMix["SATURATE"] = True
+	nodeNormal.mnp.MCPREP_normal = True
+	nodeSaturateMix.mnp.MCPREP_saturate = True
 	# nodeTexDisp["MCPREP_disp"] = True
 	nodeTexDiff.image = image_diff
 
@@ -1218,7 +1218,7 @@ def generate_base_material(
 			interpolation='Closest',
 			image=image
 		)
-		node_diff["MCPREP_diffuse"] = True
+		node_diff.mnp.MCPREP_diffuse = True
 
 		# The offset and link diffuse is for default no texture setup
 		links = mat.node_tree.links
@@ -1232,9 +1232,9 @@ def generate_base_material(
 		# Initialize extra passes as well
 		if image:
 			node_spec = create_node(nodes, 'ShaderNodeTexImage')
-			node_spec["MCPREP_specular"] = True
+			node_spec.mnp.MCPREP_specular = True
 			node_nrm = create_node(nodes, 'ShaderNodeTexImage')
-			node_nrm["MCPREP_normal"] = True
+			node_nrm.mnp.MCPREP_normal = True
 			# now use standard method to update textures
 			set_cycles_texture(image, mat, extra_passes=useExtraMaps)
 
@@ -1358,8 +1358,8 @@ def matgen_cycles_simple(mat: Material, options: PrepOptions) -> Optional[bool]:
 		nodeSaturateMix.hide = False
 
 	# annotate special nodes for finding later, and load images if available
-	nodeTexDiff["MCPREP_diffuse"] = True
-	nodeSaturateMix["SATURATE"] = True
+	nodeTexDiff.mnp.MCPREP_diffuse = True
+	nodeSaturateMix.mnp.MCPREP_saturate = True
 
 	return 0
 
@@ -1897,9 +1897,9 @@ def matgen_special_water(mat: Material, passes: Dict[str, Image]) -> Optional[bo
 		nodeSaturateMix.hide = False
 
 	# annotate special nodes for finding later, and load images if available
-	nodeTexDiff["MCPREP_diffuse"] = True
-	nodeTexNorm["MCPREP_normal"] = True
-	nodeNormal["MCPREP_normal"] = True  # to also be also muted if no normal tex
+	nodeTexDiff.mnp.MCPREP_diffuse = True
+	nodeTexNorm.mnp.MCPREP_specular = True
+	nodeNormal.mnp.MCPREP_normal = True
 	# nodeTexDisp["MCPREP_disp"] = True
 
 	return 0
@@ -2017,11 +2017,11 @@ def matgen_special_glass(mat: Material, passes: Dict[str, Image]) -> Optional[bo
 
 	# reapply animation data if any to generated nodes
 	apply_texture_animation_pass_settings(mat, animated_data)
-
+	
 	# annotate special nodes for finding later, and load images if available
-	nodeTexDiff["MCPREP_diffuse"] = True
-	nodeTexNorm["MCPREP_normal"] = True
-	nodeNormal["MCPREP_normal"] = True  # to also be also muted if no normal tex
+	nodeTexDiff.mnp.MCPREP_diffuse = True
+	nodeTexNorm.mnp.MCPREP_specular = True
+	nodeNormal.mnp.MCPREP_normal = True
 	# nodeTexDisp["MCPREP_disp"] = True
 
 	return 0  # return 0 once implemented

--- a/MCprep_addon/mcprep_ui.py
+++ b/MCprep_addon/mcprep_ui.py
@@ -2058,6 +2058,15 @@ class McprepProps(bpy.types.PropertyGroup):
 	effects_list_index: bpy.props.IntProperty(default=0)
 
 
+# Create a new "namespace" for node properties
+class MCprepNodeProps(bpy.types.PropertyGroup):
+	MCPREP_diffuse: bpy.props.BoolProperty(default=False)
+	MCPREP_specular: bpy.props.BoolProperty(default=False)
+	MCPREP_normal: bpy.props.BoolProperty(default=False)
+	MCPREP_displace: bpy.props.BoolProperty(default=False)
+	MCPREP_saturate: bpy.props.BoolProperty(default=False)
+
+
 # -----------------------------------------------------------------------------
 # Register functions
 # -----------------------------------------------------------------------------
@@ -2066,6 +2075,7 @@ class McprepProps(bpy.types.PropertyGroup):
 classes = (
 	McprepPreference,
 	McprepProps,
+	MCprepNodeProps,
 	MCPREP_MT_mob_spawner,
 	MCPREP_MT_meshswap_place,
 	MCPREP_MT_item_spawn,
@@ -2103,6 +2113,13 @@ def register():
 		bpy.utils.register_class(cls)
 
 	bpy.types.Scene.mcprep_props = bpy.props.PointerProperty(type=McprepProps)
+
+	# Apply node props to all nodes to make adding new properties
+	# simpler for developers, and to allow colsoledating eerything
+	# into one class.
+	#
+	# We also abbreviate it to reduce the amount of typing needed
+	bpy.types.Node.mnp = bpy.props.PointerProperty(type=MCprepNodeProps)
 	bpy.app.handlers.load_post.append(defer_vivy_init)
 
 	# scene settings (later re-attempt to put into props group)
@@ -2182,6 +2199,7 @@ def unregister():
 	# bpy.types.IMAGE_MT_image.remove(mcprep_image_tools)
 
 	del bpy.types.Scene.mcprep_props
+	del bpy.types.Node.mnp
 	del bpy.types.Scene.mcprep_mob_path
 	del bpy.types.Scene.meshswap_path
 	del bpy.types.Scene.entity_path

--- a/MCprep_addon/util.py
+++ b/MCprep_addon/util.py
@@ -18,7 +18,7 @@
 
 from pathlib import Path
 from subprocess import Popen, PIPE
-from typing import List, Optional, Union, Tuple
+from typing import List, Optional, Union, Tuple # TODO: Add Literal when we can use Python 3.8
 import enum
 import json
 import operator
@@ -83,6 +83,38 @@ def is_experimental(context) -> bool:
 def is_vivy_enabled(context) -> bool:
 	addon_prefs = get_user_preferences(context)
 	return is_experimental(context) and addon_prefs.exp_vivy_material_system
+
+# TODO: Use Literal["MCPREP_diffuse", "MCPREP_specular", 
+# "MCPREP_normal","MCPREP_displace", "SATURATE"] when
+# we the min version of Blender changes to a version
+# with Python 3.8
+def np_is_mcprep_node_prop(node: Node, prop: str) -> bool:
+	"""
+	Check if the given prop is true on a node.
+	This also handles backwards compatibility by
+	retroactively appying old properties to new ones,
+	and returning the value of the new property.
+
+	Only use this if you're working with MCPREP_diffuse,
+	MCPREP_specular, MCPREP_normal, MCPREP_displace, or SATURATE
+	"""
+	new_prop = prop if prop != "SATURATE" else "MCPREP_saturate"
+	if bv50():
+		# Blender 5.0 removes the old dict-like access
+		# to properties (hence why we moved to the new
+		# system).
+		#
+		# To make things future proof, we enclose
+		# this in a try-except statement
+		try:
+			old_props = tuple(node.bl_system_properties_get().keys())	
+			if prop in old_props:
+				setattr(node.mnp, new_prop, True)	
+		except Exception:
+			print(f"Could not get old {prop} prop")
+	else:
+		setattr(node.mnp, new_prop, prop in node)
+	return getattr(node.mnp, new_prop)
 
 def apply_noncolor_data(node: Node) -> Optional[MCprepError]:
 	"""
@@ -263,9 +295,12 @@ def min_bv(version: Tuple, *, inclusive: bool = True) -> bool:
 
 
 def bv30() -> bool:
-	"""Check if we're dealing with Blender 3.0"""
+	"""Check if we're dealing with Blender 3.X"""
 	return min_bv((3, 00))
 
+def bv50() -> bool:
+	"""Check if we're dealing with Blender 5.X"""
+	return min_bv((5, 00))
 
 def is_atlas_export(context: Context) -> bool:
 	"""Check if the selected objects are textureswap/animate tex compatible.


### PR DESCRIPTION
Closes #668

Previously, for the last 7 years, MCprep added custom properties to nodes directly. However, in Blender 5.0, this was changed (see https://projects.blender.org/blender/blender/commit/7276b2009a8819619263a1b897389662307b0ee0), causing MCprep to break when using the `generate` function.

To fix this, this patch moves those custom properties to a `PropertyGroup` called `MCprepNodeProps`, which is then registered and added as part of `bpy.types.Node`. Apparently this is the intended way for custom properties to be added to nodes, so it should work in previous versions of Blender.

As part of backwards compatibility with old files, the `np_is_mcprep_node_prop` function was added to `util`, which performs 3 steps:

- Check if the old properties exist on the node
- If old property exists, set the new equivilent
- Return new equivilent of property

When ran, this function will act as both a compatibility layer and migration function.

Credit goes to [snzhongcheng](https://github.com/snzhongcheng) on the MCprep Discord server for suggesting this solution, and [BradyAJonston](https://github.com/BradyAJohnston) from the Erindale server for confirming this is the intended way of adding custom properties to nodes (and thus shouldn't break in future releases of Blender)