### PR TITLE
fix: Check if Vivy is enabled before creating JSON file

### DIFF
--- a/MCprep_addon/conf.py
+++ b/MCprep_addon/conf.py
@@ -149,6 +149,7 @@ class MCprepEnv:
 		
 		# The JSON file for Vivy's materials
 		self.vivy_material_json: Dict = {}
+		self.vivy_enabled = False
 
 		# State for name changes in the Vivy config
 		#
@@ -157,7 +158,7 @@ class MCprepEnv:
 
 	def reload_vivy_json(self, path: Path) -> None:
 		json_path = Path(path, "vivy_materials.json")
-		if not json_path.exists():
+		if not json_path.exists() and self.vivy_enabled:
 			json_path.touch()
 			self.vivy_material_json = {
 				"version": VIVY_VERSION,

--- a/MCprep_addon/mcprep_ui.py
+++ b/MCprep_addon/mcprep_ui.py
@@ -380,6 +380,9 @@ class McprepPreference(bpy.types.AddonPreferences):
 		env.reload_vivy_json(path)
 		env.vivy_name_changes = {}
 		env.vivy_cache = None
+	
+	def update_enable_vivy(self, context):
+		env.vivy_enabled = self.exp_vivy_material_system
 
 	meshswap_path: bpy.props.StringProperty(
 		name="Meshswap path",
@@ -484,6 +487,7 @@ class McprepPreference(bpy.types.AddonPreferences):
 		name="Experimental: Experimental Material Templates (Vivy)",
 		description="Enable Vivy material templating features",
 		default=False,
+		update=update_enable_vivy
 	)
 	exp_vivy_file_path: bpy.props.StringProperty(
 		name="Vivy Folder",

--- a/MCprep_addon/mcprep_ui.py
+++ b/MCprep_addon/mcprep_ui.py
@@ -2171,6 +2171,8 @@ def register():
 		bpy.types.IMAGE_MT_uvs.append(mcprep_uv_tools)
 	# bpy.types.IMAGE_MT_image.append(mcprep_image_tools) # crashes, re-do ops	
 
+	env.vivy_enabled = addon_prefs.exp_vivy_material_system
+
 def unregister():
 	for cls in reversed(classes):
 		bpy.utils.unregister_class(cls)


### PR DESCRIPTION
Small fix to make sure the Vivy JSON isn't created if the user didn't enable it.