### PR TITLE
feat: Add drag and drop handler for JSON models

### DIFF
--- a/MCprep_addon/spawner/mcmodel.py
+++ b/MCprep_addon/spawner/mcmodel.py
@@ -731,12 +731,12 @@ class MCPREP_OT_place_json_model_with_gizmo(bpy.types.Operator):
 	filename_ext = ".json"
 	filepath: bpy.props.StringProperty(subtype='FILE_PATH', options={'SKIP_SAVE'})
 	def invoke(self, context, event):
-		from mathutils import Vector
+		from mathutils import Vector, Quaternion
 
 		self.has_hit = False
-		self.hit_location = Vector((0.0, 0.0, 0.0))
-		self.hit_normal = Vector((0.0, 0.0, 1.0))
-		self.update_raycast(context, event)
+		self.hit_location = Vector((0, 0, 0))
+		self.hit_normal = Vector((0, 0, 1))
+		self.rotation_quat = Quaternion()
 		self.draw_handle = bpy.types.SpaceView3D.draw_handler_add(
 			self.draw_callback, (context,), 'WINDOW', 'POST_VIEW'
 		)
@@ -746,15 +746,13 @@ class MCPREP_OT_place_json_model_with_gizmo(bpy.types.Operator):
 	def modal(self, context, event):
 		context.area.tag_redraw()
 		if event.type == 'MOUSEMOVE':
-			self.update_raycast(context, event)
+			from .spawner_gizmo import update_raycast
+			self.has_hit, self.hit_location, self.hit_normal, self.rotation_quat = update_raycast(context, event)
 		elif event.type == 'LEFTMOUSE' and event.value == 'PRESS':
 			if self.has_hit:
-				# Get the difference between Z-up and the normal of the raycast
-				up_axis = Vector((0.0, 0.0, 1.0))
-				rotation_quat = up_axis.rotation_difference(self.hit_normal)
 				bpy.ops.mcprep.import_model_file(filepath=self.filepath,
 												location=self.hit_location,
-												rotation=rotation_quat.to_euler())
+												rotation=self.rotation_quat.to_euler())
 				self.finish(context)
 				return {'FINISHED'}
 			else:
@@ -769,57 +767,13 @@ class MCPREP_OT_place_json_model_with_gizmo(bpy.types.Operator):
 		bpy.types.SpaceView3D.draw_handler_remove(self.draw_handle, 'WINDOW')
 		context.area.tag_redraw()
 
-	def update_raycast(self, context, event):
-		from bpy_extras import view3d_utils
-		from mathutils import Vector
-		from mathutils.geometry import intersect_line_plane
-
-		mouse_pos = (event.mouse_region_x, event.mouse_region_y)
-		region, region_3d = context.region, context.space_data.region_3d
-		ray_origin = view3d_utils.region_2d_to_origin_3d(region, region_3d, mouse_pos)
-		ray_direction = view3d_utils.region_2d_to_vector_3d(region, region_3d, mouse_pos)
-		depsgraph = context.evaluated_depsgraph_get()
-		result, location, normal, _, _, _ = context.scene.ray_cast(depsgraph, ray_origin, ray_direction)
-
-		if result:
-			self.has_hit = True
-			self.hit_location, self.hit_normal = location, normal
-		else:
-			intersection = intersect_line_plane(ray_origin, ray_origin + ray_direction, Vector(), Vector((0,0,1)))
-			if intersection:
-				self.has_hit = True
-				self.hit_location, self.hit_normal = intersection, Vector((0,0,1))
-			else:
-				self.has_hit = False
-
-	def draw_callback(self, context):
-		import gpu
-		from mathutils import Vector, Matrix
-
-		from .spawner_gizmo import draw_fading_grid
+	def draw_callback(self, context) -> None:
+		from .spawner_gizmo import draw_callback
 
 		if not self.has_hit:
 			return
-
-		shader_info = gpu.shader.from_builtin('UNIFORM_COLOR')
-
-		original_blend = gpu.state.blend_get()
-		original_depth_test = gpu.state.depth_test_get()
-		gpu.state.blend_set('ALPHA')
-		gpu.state.depth_test_set('NONE')
-
-		up_axis = Vector((0.0, 0.0, 1.0))
-		rotation_quat = up_axis.rotation_difference(self.hit_normal)
-		transform_matrix = Matrix.Translation(self.hit_location) @ rotation_quat.to_matrix().to_4x4()
-
-		gpu.matrix.push()
-		gpu.matrix.multiply_matrix(transform_matrix)
-
-		draw_fading_grid(shader_info, size=2.0, subdivisions=20, rings=10, base_color=(0.7, 0.7, 0.7))
-
-		gpu.matrix.pop()
-		gpu.state.blend_set(original_blend)
-		gpu.state.depth_test_set(original_depth_test)
+		
+		draw_callback(self.hit_location, self.rotation_quat)
 
 classes = (
 	MCPREP_OT_spawn_minecraft_model,

--- a/MCprep_addon/spawner/mcmodel.py
+++ b/MCprep_addon/spawner/mcmodel.py
@@ -731,12 +731,10 @@ class MCPREP_OT_place_json_model_with_gizmo(bpy.types.Operator):
 	filename_ext = ".json"
 	filepath: bpy.props.StringProperty(subtype='FILE_PATH', options={'SKIP_SAVE'})
 	def invoke(self, context, event):
-		from mathutils import Vector, Quaternion
+		from .spawner_gizmo import HitVector
 
-		self.has_hit = False
-		self.hit_location = Vector((0, 0, 0))
-		self.hit_normal = Vector((0, 0, 1))
-		self.rotation_quat = Quaternion()
+		self.hit_vector: Optional[HitVector] = None
+
 		self.draw_handle = bpy.types.SpaceView3D.draw_handler_add(
 			self.draw_callback, (context,), 'WINDOW', 'POST_VIEW'
 		)
@@ -747,9 +745,9 @@ class MCPREP_OT_place_json_model_with_gizmo(bpy.types.Operator):
 		context.area.tag_redraw()
 		if event.type == 'MOUSEMOVE':
 			from .spawner_gizmo import update_raycast
-			self.has_hit, self.hit_location, self.hit_normal, self.rotation_quat = update_raycast(context, event)
+			self.hit_vector = update_raycast(context, event)
 		elif event.type == 'LEFTMOUSE' and event.value == 'PRESS':
-			if self.has_hit:
+			if self.hit_vector:
 				bpy.ops.mcprep.import_model_file(filepath=self.filepath,
 												location=self.hit_location,
 												rotation=self.rotation_quat.to_euler())
@@ -773,7 +771,7 @@ class MCPREP_OT_place_json_model_with_gizmo(bpy.types.Operator):
 		if not self.has_hit:
 			return
 		
-		draw_callback(self.hit_location, self.rotation_quat)
+		draw_callback(self.hit_vector)
 
 classes = (
 	MCPREP_OT_spawn_minecraft_model,

--- a/MCprep_addon/spawner/mcmodel.py
+++ b/MCprep_addon/spawner/mcmodel.py
@@ -616,7 +616,7 @@ class ModelSpawnBase():
 
 	def create_and_place_json_model(self, context, filepath: Path) -> Optional[MCprepError]:
 		"""Function that does the entire model creation and placing"""
-		filename = filepath.stem[0]
+		filename = filepath.stem
 		if not filepath or not filepath.exists():
 			line, file = env.current_line_and_file()
 			return MCprepError(FileNotFoundError(), line, file, "File not found")

--- a/MCprep_addon/spawner/mcmodel.py
+++ b/MCprep_addon/spawner/mcmodel.py
@@ -33,6 +33,7 @@ from ..conf import env, VectorType
 from .. import util
 from .. import tracking
 from ..materials import generate  # TODO: Use this module for mat gen in future
+from .spawner_gizmo import draw_fading_grid
 
 TexFace = Dict[str, Dict[str, str]]
 
@@ -576,6 +577,9 @@ class ModelSpawnBase():
 	location: bpy.props.FloatVectorProperty(
 		default=(0, 0, 0),
 		name="Location")
+	rotation: bpy.props.FloatVectorProperty(
+		default=(0, 0, 0),
+		name="Rotation")
 	snapping: bpy.props.EnumProperty(
 		name="Snapping",
 		items=[
@@ -603,6 +607,8 @@ class ModelSpawnBase():
 		else:
 			obj.location = self.location
 
+		obj.rotation_euler = self.rotation
+
 	def post_spawn(self, context, new_obj):
 		"""Do final consistent cleanup after model is spawned."""
 		for ob in util.get_objects_conext(context):
@@ -620,7 +626,7 @@ class MCPREP_OT_spawn_minecraft_model(bpy.types.Operator, ModelSpawnBase):
 		default="",
 		subtype="FILE_PATH",
 		options={'HIDDEN', 'SKIP_SAVE'})
-
+	
 	track_function = "model"
 	track_param = "list"
 	@tracking.report_error
@@ -664,7 +670,7 @@ class MCPREP_OT_import_minecraft_model_file(
 		options={'HIDDEN'},
 		maxlen=255  # Max internal buffer length, longer would be clamped.
 	)
-
+	
 	track_function = "model"
 	track_param = "file"
 	@tracking.report_error
@@ -701,7 +707,7 @@ class MCPREP_OT_import_minecraft_model_file(
 class MCPREP_FH_import_minecraft_model_file(FileHandler):
 	bl_idname = "MCPREP_FH_import_minecraft_model_file"
 	bl_label = "File handler for JSON import"
-	bl_import_operator = "mcprep.import_model_file"
+	bl_import_operator = "mcprep.place_json_model_with_gizmo"
 	bl_file_extensions = ".json"
 
 	@classmethod
@@ -718,6 +724,101 @@ class MCPREP_OT_reload_models(bpy.types.Operator):
 		update_model_list(context)
 		return {'FINISHED'}
 
+class MCPREP_OT_place_json_model_with_gizmo(bpy.types.Operator):
+	bl_idname = "mcprep.place_json_model_with_gizmo"
+	bl_label = "Import Minecraf JSON model and Place"
+	bl_description = "Imports a Minecraft JSON model with location selection"
+	
+	filename_ext = ".json"
+	filepath: bpy.props.StringProperty(subtype='FILE_PATH', options={'SKIP_SAVE'})
+	def invoke(self, context, event):
+		from mathutils import Vector
+
+		self.has_hit = False
+		self.hit_location = Vector((0.0, 0.0, 0.0))
+		self.hit_normal = Vector((0.0, 0.0, 1.0))
+		self.update_raycast(context, event)
+		self.draw_handle = bpy.types.SpaceView3D.draw_handler_add(
+			self.draw_callback, (context,), 'WINDOW', 'POST_VIEW'
+		)
+		context.window_manager.modal_handler_add(self)
+		return {'RUNNING_MODAL'}
+
+	def modal(self, context, event):
+		context.area.tag_redraw()
+		if event.type == 'MOUSEMOVE':
+			self.update_raycast(context, event)
+		elif event.type == 'LEFTMOUSE' and event.value == 'PRESS':
+			if self.has_hit:
+				# Get the difference between Z-up and the normal of the raycast
+				up_axis = Vector((0.0, 0.0, 1.0))
+				rotation_quat = up_axis.rotation_difference(self.hit_normal)
+				bpy.ops.mcprep.import_model_file(filepath=self.filepath,
+												location=self.hit_location,
+												rotation=rotation_quat.to_euler())
+				self.finish(context)
+				return {'FINISHED'}
+			else:
+				self.finish(context)
+				return {'CANCELLED'}
+		elif event.type in {'RIGHTMOUSE', 'ESC'}:
+			self.finish(context)
+			return {'CANCELLED'}
+		return {'RUNNING_MODAL'}
+
+	def finish(self, context):
+		bpy.types.SpaceView3D.draw_handler_remove(self.draw_handle, 'WINDOW')
+		context.area.tag_redraw()
+
+	def update_raycast(self, context, event):
+		from bpy_extras import view3d_utils
+		from mathutils import Vector
+		from mathutils.geometry import intersect_line_plane
+
+		mouse_pos = (event.mouse_region_x, event.mouse_region_y)
+		region, region_3d = context.region, context.space_data.region_3d
+		ray_origin = view3d_utils.region_2d_to_origin_3d(region, region_3d, mouse_pos)
+		ray_direction = view3d_utils.region_2d_to_vector_3d(region, region_3d, mouse_pos)
+		depsgraph = context.evaluated_depsgraph_get()
+		result, location, normal, _, _, _ = context.scene.ray_cast(depsgraph, ray_origin, ray_direction)
+
+		if result:
+			self.has_hit = True
+			self.hit_location, self.hit_normal = location, normal
+		else:
+			intersection = intersect_line_plane(ray_origin, ray_origin + ray_direction, Vector(), Vector((0,0,1)))
+			if intersection:
+				self.has_hit = True
+				self.hit_location, self.hit_normal = intersection, Vector((0,0,1))
+			else:
+				self.has_hit = False
+
+	def draw_callback(self, context):
+		import gpu
+		from mathutils import Vector, Matrix
+
+		if not self.has_hit:
+			return
+
+		shader_info = gpu.shader.from_builtin('UNIFORM_COLOR')
+
+		original_blend = gpu.state.blend_get()
+		original_depth_test = gpu.state.depth_test_get()
+		gpu.state.blend_set('ALPHA')
+		gpu.state.depth_test_set('NONE')
+
+		up_axis = Vector((0.0, 0.0, 1.0))
+		rotation_quat = up_axis.rotation_difference(self.hit_normal)
+		transform_matrix = Matrix.Translation(self.hit_location) @ rotation_quat.to_matrix().to_4x4()
+
+		gpu.matrix.push()
+		gpu.matrix.multiply_matrix(transform_matrix)
+
+		draw_fading_grid(shader_info, size=2.0, subdivisions=20, rings=10, base_color=(0.7, 0.7, 0.7))
+
+		gpu.matrix.pop()
+		gpu.state.blend_set(original_blend)
+		gpu.state.depth_test_set(original_depth_test)
 
 classes = (
 	MCPREP_OT_spawn_minecraft_model,
@@ -732,6 +833,7 @@ def register():
 
 	if util.min_bv((4, 1)):
 		bpy.utils.register_class(MCPREP_FH_import_minecraft_model_file)
+		bpy.utils.register_class(MCPREP_OT_place_json_model_with_gizmo)
 
 	bpy.types.TOPBAR_MT_file_import.append(draw_import_mcmodel)
 
@@ -743,3 +845,4 @@ def unregister():
 	
 	if util.min_bv((4, 1)):
 		bpy.utils.unregister_class(MCPREP_FH_import_minecraft_model_file)
+		bpy.utils.unregister_class(MCPREP_OT_place_json_model_with_gizmo)

--- a/MCprep_addon/spawner/mcmodel.py
+++ b/MCprep_addon/spawner/mcmodel.py
@@ -711,8 +711,9 @@ class MCPREP_OT_reload_models(bpy.types.Operator):
 
 class MCPREP_OT_place_json_model_with_gizmo(bpy.types.Operator, ModelSpawnBase):
 	bl_idname = "mcprep.place_json_model_with_gizmo"
-	bl_label = "Import Minecraf JSON model and Place"
+	bl_label = "Import Minecraft JSON model and Place"
 	bl_description = "Imports a Minecraft JSON model with location selection"
+	bl_options = {'REGISTER', 'UNDO'}
 	
 	filename_ext = ".json"
 	filepath: bpy.props.StringProperty(subtype='FILE_PATH', options={'SKIP_SAVE'})
@@ -726,6 +727,18 @@ class MCPREP_OT_place_json_model_with_gizmo(bpy.types.Operator, ModelSpawnBase):
 		)
 		context.window_manager.modal_handler_add(self)
 		return {'RUNNING_MODAL'}
+	
+	def execute(self, context):
+		if self.hit_vector:
+			self.location = self.hit_vector.location
+			self.rotation = self.hit_vector.rotation.to_euler()
+			res = self.create_and_place_json_model(context, Path(self.filepath))
+			if res:
+				self.report({'ERROR'}, res.msg)
+				return {'CANCELLED'}
+		else:
+			return {'CANCELLED'}
+		return {'FINISHED'}
 
 	def modal(self, context, event):
 		context.area.tag_redraw()
@@ -733,18 +746,9 @@ class MCPREP_OT_place_json_model_with_gizmo(bpy.types.Operator, ModelSpawnBase):
 			from .spawner_gizmo import update_raycast
 			self.hit_vector = update_raycast(context, event)
 		elif event.type == 'LEFTMOUSE' and event.value == 'PRESS':
-			if self.hit_vector:
-				self.location = self.hit_vector.location
-				self.rotation = self.hit_vector.rotation.to_euler()
-				res = self.create_and_place_json_model(context, Path(self.filepath))
-				if res:
-					self.report({'ERROR'}, res.msg)
-					return {'CANCELLED'}
-				self.finish(context)
-				return {'FINISHED'}
-			else:
-				self.finish(context)
-				return {'CANCELLED'}
+			res = self.execute(context)			
+			self.finish(context)
+			return res
 		elif event.type in {'RIGHTMOUSE', 'ESC'}:
 			self.finish(context)
 			return {'CANCELLED'}

--- a/MCprep_addon/spawner/mcmodel.py
+++ b/MCprep_addon/spawner/mcmodel.py
@@ -29,7 +29,7 @@ import bmesh
 from bpy.types import Context, Material
 from bpy_extras.io_utils import ImportHelper
 
-from ..conf import env, VectorType
+from ..conf import MCprepError, env, VectorType
 from .. import util
 from .. import tracking
 from ..materials import generate  # TODO: Use this module for mat gen in future
@@ -614,6 +614,28 @@ class ModelSpawnBase():
 			util.select_set(ob, False)
 		util.select_set(new_obj, True)
 
+	def create_and_place_json_model(self, context, filepath: Path) -> Optional[MCprepError]:
+		"""Function that does the entire model creation and placing"""
+		filename = filepath.stem[0]
+		if not filepath or not filepath.exists():
+			line, file = env.current_line_and_file()
+			return MCprepError(FileNotFoundError(), line, file, "File not found")
+		if filepath.suffix != ".json":
+			line, file = env.current_line_and_file()
+			return MCprepError(Exception(), line, file, f"File is not JSON: {filepath}")
+
+		try:
+			r, obj = add_model(filepath, filename)
+			if r:
+				line, file = env.current_line_and_file()
+				return MCprepError(Exception(), line, file, "JSON model does not contain any actual geometry")
+		except ModelException as e:
+			line, file = env.current_line_and_file()
+			return MCprepError(ModelException(), line, file, f"Encountered error: {e}")
+
+		self.place_model(obj)
+		self.post_spawn(context, obj)
+
 
 class MCPREP_OT_spawn_minecraft_model(bpy.types.Operator, ModelSpawnBase):
 	"""Import in an MC model from a json file."""
@@ -630,30 +652,11 @@ class MCPREP_OT_spawn_minecraft_model(bpy.types.Operator, ModelSpawnBase):
 	track_param = "list"
 	@tracking.report_error
 	def execute(self, context):
-		name = os.path.basename(os.path.splitext(self.filepath)[0])
-		if not self.filepath or not os.path.isfile(self.filepath):
-			self.report({"WARNING"}, "Filepath not found")
-			bpy.ops.mcprep.prompt_reset_spawners('INVOKE_DEFAULT')
+		res = self.create_and_place_json_model(context, Path(self.filepath))
+		if res:
+			self.report({'ERROR'}, res.msg)
 			return {'CANCELLED'}
-		if not self.filepath.lower().endswith(".json"):
-			self.report(
-				{"ERROR"}, f"File is not json: {self.filepath}")
-			return {'CANCELLED'}
-
-		try:
-			r, obj = add_model(os.path.normpath(self.filepath), name)
-			if r:
-				self.report(
-					{"ERROR"}, "The JSON model does not contain any geometry elements")
-				return {'CANCELLED'}
-		except ModelException as e:
-			self.report({"ERROR"}, f"Encountered error: {e}")
-			return {'CANCELLED'}
-
-		self.place_model(obj)
-		self.post_spawn(context, obj)
 		return {'FINISHED'}
-
 
 class MCPREP_OT_import_minecraft_model_file(
 	bpy.types.Operator, ImportHelper, ModelSpawnBase):
@@ -674,27 +677,10 @@ class MCPREP_OT_import_minecraft_model_file(
 	track_param = "file"
 	@tracking.report_error
 	def execute(self, context):
-		filename = os.path.splitext(os.path.basename(self.filepath))[0]
-		if not self.filepath or not os.path.isfile(self.filepath):
-			self.report({"ERROR"}, "Filepath not found")
+		res = self.create_and_place_json_model(context, Path(self.filepath))
+		if res:
+			self.report({'ERROR'}, res.msg)
 			return {'CANCELLED'}
-		if not self.filepath.lower().endswith(".json"):
-			self.report(
-				{"ERROR"}, f"File is not json: {self.filepath}")
-			return {'CANCELLED'}
-
-		try:
-			r, obj = add_model(os.path.normpath(self.filepath), filename)
-			if r:
-				self.report(
-					{"ERROR"}, "The JSON model does not contain any geometry elements")
-				return {'CANCELLED'}
-		except ModelException as e:
-			self.report({"ERROR"}, f"Encountered error: {e}")
-			return {'CANCELLED'}
-
-		self.place_model(obj)
-		self.post_spawn(context, obj)
 		return {'FINISHED'}
 
 	def invoke(self, context, event):
@@ -723,7 +709,7 @@ class MCPREP_OT_reload_models(bpy.types.Operator):
 		update_model_list(context)
 		return {'FINISHED'}
 
-class MCPREP_OT_place_json_model_with_gizmo(bpy.types.Operator):
+class MCPREP_OT_place_json_model_with_gizmo(bpy.types.Operator, ModelSpawnBase):
 	bl_idname = "mcprep.place_json_model_with_gizmo"
 	bl_label = "Import Minecraf JSON model and Place"
 	bl_description = "Imports a Minecraft JSON model with location selection"
@@ -748,9 +734,12 @@ class MCPREP_OT_place_json_model_with_gizmo(bpy.types.Operator):
 			self.hit_vector = update_raycast(context, event)
 		elif event.type == 'LEFTMOUSE' and event.value == 'PRESS':
 			if self.hit_vector:
-				bpy.ops.mcprep.import_model_file(filepath=self.filepath,
-												location=self.hit_location,
-												rotation=self.rotation_quat.to_euler())
+				self.location = self.hit_vector.location
+				self.rotation = self.hit_vector.rotation.to_euler()
+				res = self.create_and_place_json_model(context, Path(self.filepath))
+				if res:
+					self.report({'ERROR'}, res.msg)
+					return {'CANCELLED'}
 				self.finish(context)
 				return {'FINISHED'}
 			else:
@@ -768,7 +757,7 @@ class MCPREP_OT_place_json_model_with_gizmo(bpy.types.Operator):
 	def draw_callback(self, context) -> None:
 		from .spawner_gizmo import draw_callback
 
-		if not self.has_hit:
+		if not self.hit_vector:
 			return
 		
 		draw_callback(self.hit_vector)

--- a/MCprep_addon/spawner/mcmodel.py
+++ b/MCprep_addon/spawner/mcmodel.py
@@ -39,6 +39,11 @@ TexFace = Dict[str, Dict[str, str]]
 Element = Sequence[Union[Dict[str, VectorType], TexFace]]
 Texture = Dict[str, str]
 
+# This is wrapper type that we use for FileHandler, since it's
+# only availible in Blender 4.1 and above. In older versions of
+# Blender, we just set it to the generic object type
+FileHandlerIfSupported = bpy.types.FileHandler if util.min_bv((4, 1)) else object
+
 # -----------------------------------------------------------------------------
 # Core MC model functions and implementation
 # -----------------------------------------------------------------------------
@@ -650,6 +655,7 @@ class MCPREP_OT_import_minecraft_model_file(
 	bl_options = {'REGISTER', 'UNDO'}
 
 	filename_ext = ".json"
+	filepath: bpy.props.StringProperty(subtype='FILE_PATH', options={'SKIP_SAVE'})
 	filter_glob: bpy.props.StringProperty(
 		default="*.json",
 		options={'HIDDEN'},
@@ -683,6 +689,21 @@ class MCPREP_OT_import_minecraft_model_file(
 		self.post_spawn(context, obj)
 		return {'FINISHED'}
 
+	def invoke(self, context, event):
+		if self.filepath:
+			return self.execute(context)
+		context.window_manager.fileselect_add(self)
+		return {'RUNNING_MODAL'}
+
+class MCPREP_FH_import_minecraft_model_file(FileHandlerIfSupported):
+	bl_idname = "MCPREP_FH_import_minecraft_model_file"
+	bl_label = "File handler for JSON import"
+	bl_import_operator = "mcprep.import_model_file"
+	bl_file_extensions = ".json"
+
+	@classmethod
+	def poll_drop(cls, context) -> bool:
+		return (context.area and context.area.type == 'VIEW_3D')
 
 class MCPREP_OT_reload_models(bpy.types.Operator):
 	"""Reload model spawner, use after adding/removing/renaming files in the resource pack folder"""
@@ -706,6 +727,9 @@ def register():
 	for cls in classes:
 		bpy.utils.register_class(cls)
 
+	if util.min_bv((4, 1)):
+		bpy.utils.register_class(MCPREP_FH_import_minecraft_model_file)
+
 	bpy.types.TOPBAR_MT_file_import.append(draw_import_mcmodel)
 
 
@@ -713,3 +737,6 @@ def unregister():
 	bpy.types.TOPBAR_MT_file_import.remove(draw_import_mcmodel)
 	for cls in reversed(classes):
 		bpy.utils.unregister_class(cls)
+	
+	if util.min_bv((4, 1)):
+		bpy.utils.unregister_class(MCPREP_FH_import_minecraft_model_file)

--- a/MCprep_addon/spawner/mcmodel.py
+++ b/MCprep_addon/spawner/mcmodel.py
@@ -33,7 +33,6 @@ from ..conf import env, VectorType
 from .. import util
 from .. import tracking
 from ..materials import generate  # TODO: Use this module for mat gen in future
-from .spawner_gizmo import draw_fading_grid
 
 TexFace = Dict[str, Dict[str, str]]
 
@@ -796,6 +795,8 @@ class MCPREP_OT_place_json_model_with_gizmo(bpy.types.Operator):
 	def draw_callback(self, context):
 		import gpu
 		from mathutils import Vector, Matrix
+
+		from .spawner_gizmo import draw_fading_grid
 
 		if not self.has_hit:
 			return

--- a/MCprep_addon/spawner/mcmodel.py
+++ b/MCprep_addon/spawner/mcmodel.py
@@ -39,10 +39,13 @@ TexFace = Dict[str, Dict[str, str]]
 Element = Sequence[Union[Dict[str, VectorType], TexFace]]
 Texture = Dict[str, str]
 
-# This is wrapper type that we use for FileHandler, since it's
-# only availible in Blender 4.1 and above. In older versions of
-# Blender, we just set it to the generic object type
-FileHandlerIfSupported = bpy.types.FileHandler if util.min_bv((4, 1)) else object
+try:
+	from bpy.types import FileHandler
+except ImportError:
+	# This is wrapper type that we use for FileHandler, since it's
+	# only availible in Blender 4.1 and above. In older versions of
+	# Blender, we just set it to the generic object type
+	FileHandler = object
 
 # -----------------------------------------------------------------------------
 # Core MC model functions and implementation
@@ -695,7 +698,7 @@ class MCPREP_OT_import_minecraft_model_file(
 		context.window_manager.fileselect_add(self)
 		return {'RUNNING_MODAL'}
 
-class MCPREP_FH_import_minecraft_model_file(FileHandlerIfSupported):
+class MCPREP_FH_import_minecraft_model_file(FileHandler):
 	bl_idname = "MCPREP_FH_import_minecraft_model_file"
 	bl_label = "File handler for JSON import"
 	bl_import_operator = "mcprep.import_model_file"

--- a/MCprep_addon/spawner/spawner_gizmo.py
+++ b/MCprep_addon/spawner/spawner_gizmo.py
@@ -1,0 +1,57 @@
+import bpy
+from bpy_extras import view3d_utils
+import gpu
+from gpu_extras.batch import batch_for_shader
+import math
+from mathutils import Vector, Matrix
+from mathutils.geometry import intersect_line_plane
+
+shader_info = gpu.shader.from_builtin('UNIFORM_COLOR')
+
+def draw_fading_grid(shader_info, size, subdivisions, rings, base_color):
+    """
+    Draws a grid with a circular falloff by drawing small segments
+    in concentric rings based on their distance from the center.
+    """
+    half_size = size / 2.0
+    step = size / subdivisions
+    
+    # Pre-calculate all possible small line segments for the grid
+    all_segments = []
+    for i in range(subdivisions + 1):
+        # Horizontal segments
+        for j in range(subdivisions):
+            x1 = -half_size + j * step
+            y = -half_size + i * step
+            all_segments.append(((x1, y, 0.0), (x1 + step, y, 0.0)))
+        # Vertical segments
+        for j in range(subdivisions):
+            x = -half_size + i * step
+            y1 = -half_size + j * step
+            all_segments.append(((x, y1, 0.0), (x, y1 + step, 0.0)))
+
+    # Draw the segments in rings with different alpha values
+    for r in range(rings):
+        alpha = ((1.0 - (r / rings)) ** 1.5) * 0.8
+        color = (*base_color, alpha)
+        
+        inner_radius = (r / rings) * half_size
+        outer_radius = ((r + 1) / rings) * half_size
+        
+        coords = []
+        for p1, p2 in all_segments:
+            # Check if the midpoint of the segment is in the current ring
+            mid_x = (p1[0] + p2[0]) / 2
+            mid_y = (p1[1] + p2[1]) / 2
+            dist = math.sqrt(mid_x**2 + mid_y**2)
+            
+            if dist >= inner_radius and dist < outer_radius:
+                coords.extend([p1, p2])
+        
+        if not coords:
+            continue
+            
+        batch = batch_for_shader(shader_info, 'LINES', {"pos": coords})
+        shader_info.bind()
+        shader_info.uniform_float("color", color)
+        batch.draw(shader_info)

--- a/MCprep_addon/spawner/spawner_gizmo.py
+++ b/MCprep_addon/spawner/spawner_gizmo.py
@@ -1,13 +1,17 @@
+from typing import Tuple
 import bpy
+from bpy_extras import view3d_utils
 import gpu
 from gpu_extras.batch import batch_for_shader
 import math
+from mathutils import Matrix, Quaternion, Vector
+from mathutils.geometry import intersect_line_plane
+
+ZERO_VECTOR = Vector((0, 0, 0))
+UP_VECTOR = Vector((0, 0, 1))
 
 def draw_fading_grid(shader_info, size, subdivisions, rings, base_color):
-    """
-    Draws a grid with a circular falloff by drawing small segments
-    in concentric rings based on their distance from the center.
-    """
+    """Creates a grid with a fading circle gradient"""
     half_size = size / 2.0
     step = size / subdivisions
 
@@ -50,3 +54,41 @@ def draw_fading_grid(shader_info, size, subdivisions, rings, base_color):
         shader_info.bind()
         shader_info.uniform_float("color", color)
         batch.draw(shader_info)
+
+def draw_callback(hit_location: Vector, rotation_quat: Quaternion) -> None:
+    """Callback function to call when drawing the gizmo"""
+    shader_info = gpu.shader.from_builtin('UNIFORM_COLOR')
+
+    original_blend = gpu.state.blend_get()
+    original_depth_test = gpu.state.depth_test_get()
+    gpu.state.blend_set('ALPHA')
+    gpu.state.depth_test_set('NONE')
+
+    transform_matrix = Matrix.Translation(hit_location) @ rotation_quat.to_matrix().to_4x4()
+
+    gpu.matrix.push()
+    gpu.matrix.multiply_matrix(transform_matrix)
+
+    draw_fading_grid(shader_info, size=2.0, subdivisions=20, rings=10, base_color=(0.7, 0.7, 0.7))
+
+    gpu.matrix.pop()
+    gpu.state.blend_set(original_blend)
+    gpu.state.depth_test_set(original_depth_test)
+
+def update_raycast(context, event) -> Tuple[bool, Vector, Vector, Quaternion]:
+    """Given the context of the scene, update the location, normal, and rotation of the ray"""
+    mouse_pos = (event.mouse_region_x, event.mouse_region_y)
+    region, region_3d = context.region, context.space_data.region_3d
+    ray_origin = view3d_utils.region_2d_to_origin_3d(region, region_3d, mouse_pos)
+    ray_direction = view3d_utils.region_2d_to_vector_3d(region, region_3d, mouse_pos)
+    depsgraph = context.evaluated_depsgraph_get()
+    result, location, normal, _, _, _ = context.scene.ray_cast(depsgraph, ray_origin, ray_direction)
+
+    if result:
+        return True, location, normal, UP_VECTOR.rotation_difference(normal)
+    else:
+        intersection = intersect_line_plane(ray_origin, ray_origin + ray_direction, ZERO_VECTOR, UP_VECTOR)
+        if intersection:
+            return True, intersection, UP_VECTOR, Quaternion()
+        else:
+            return False, ZERO_VECTOR, UP_VECTOR, Quaternion()

--- a/MCprep_addon/spawner/spawner_gizmo.py
+++ b/MCprep_addon/spawner/spawner_gizmo.py
@@ -1,12 +1,7 @@
 import bpy
-from bpy_extras import view3d_utils
 import gpu
 from gpu_extras.batch import batch_for_shader
 import math
-from mathutils import Vector, Matrix
-from mathutils.geometry import intersect_line_plane
-
-shader_info = gpu.shader.from_builtin('UNIFORM_COLOR')
 
 def draw_fading_grid(shader_info, size, subdivisions, rings, base_color):
     """
@@ -15,7 +10,7 @@ def draw_fading_grid(shader_info, size, subdivisions, rings, base_color):
     """
     half_size = size / 2.0
     step = size / subdivisions
-    
+
     # Pre-calculate all possible small line segments for the grid
     all_segments = []
     for i in range(subdivisions + 1):
@@ -34,23 +29,23 @@ def draw_fading_grid(shader_info, size, subdivisions, rings, base_color):
     for r in range(rings):
         alpha = ((1.0 - (r / rings)) ** 1.5) * 0.8
         color = (*base_color, alpha)
-        
+
         inner_radius = (r / rings) * half_size
         outer_radius = ((r + 1) / rings) * half_size
-        
+
         coords = []
         for p1, p2 in all_segments:
             # Check if the midpoint of the segment is in the current ring
             mid_x = (p1[0] + p2[0]) / 2
             mid_y = (p1[1] + p2[1]) / 2
             dist = math.sqrt(mid_x**2 + mid_y**2)
-            
+
             if dist >= inner_radius and dist < outer_radius:
                 coords.extend([p1, p2])
-        
+
         if not coords:
             continue
-            
+
         batch = batch_for_shader(shader_info, 'LINES', {"pos": coords})
         shader_info.bind()
         shader_info.uniform_float("color", color)

--- a/MCprep_addon/spawner/spawner_gizmo.py
+++ b/MCprep_addon/spawner/spawner_gizmo.py
@@ -11,11 +11,13 @@ from mathutils.geometry import intersect_line_plane
 ZERO_VECTOR = Vector((0, 0, 0))
 UP_VECTOR = Vector((0, 0, 1))
 
+
 @dataclass
 class HitVector:
     location: Vector
     normal: Vector
     rotation: Quaternion
+
 
 def draw_fading_grid(shader_info, size, subdivisions, rings, base_color):
     """Creates a grid with a fading circle gradient"""
@@ -57,30 +59,37 @@ def draw_fading_grid(shader_info, size, subdivisions, rings, base_color):
         if not coords:
             continue
 
-        batch = batch_for_shader(shader_info, 'LINES', {"pos": coords})
+        batch = batch_for_shader(shader_info, "LINES", {"pos": coords})
         shader_info.bind()
         shader_info.uniform_float("color", color)
         batch.draw(shader_info)
 
+
 def draw_callback(hit_vector: HitVector) -> None:
     """Callback function to call when drawing the gizmo"""
-    shader_info = gpu.shader.from_builtin('UNIFORM_COLOR')
+    shader_info = gpu.shader.from_builtin("UNIFORM_COLOR")
 
     original_blend = gpu.state.blend_get()
     original_depth_test = gpu.state.depth_test_get()
-    gpu.state.blend_set('ALPHA')
-    gpu.state.depth_test_set('NONE')
+    gpu.state.blend_set("ALPHA")
+    gpu.state.depth_test_set("NONE")
 
-    transform_matrix = Matrix.Translation(hit_vector.location) @ hit_vector.rotation.to_matrix().to_4x4()
+    transform_matrix = (
+        Matrix.Translation(hit_vector.location)
+        @ hit_vector.rotation.to_matrix().to_4x4()
+    )
 
     gpu.matrix.push()
     gpu.matrix.multiply_matrix(transform_matrix)
 
-    draw_fading_grid(shader_info, size=2.0, subdivisions=20, rings=10, base_color=(0.7, 0.7, 0.7))
+    draw_fading_grid(
+        shader_info, size=2.0, subdivisions=20, rings=10, base_color=(0.7, 0.7, 0.7)
+    )
 
     gpu.matrix.pop()
     gpu.state.blend_set(original_blend)
     gpu.state.depth_test_set(original_depth_test)
+
 
 def update_raycast(context, event) -> Optional[HitVector]:
     """Given the context of the scene, update the location, normal, and rotation of the ray"""
@@ -89,12 +98,16 @@ def update_raycast(context, event) -> Optional[HitVector]:
     ray_origin = view3d_utils.region_2d_to_origin_3d(region, region_3d, mouse_pos)
     ray_direction = view3d_utils.region_2d_to_vector_3d(region, region_3d, mouse_pos)
     depsgraph = context.evaluated_depsgraph_get()
-    result, location, normal, _, _, _ = context.scene.ray_cast(depsgraph, ray_origin, ray_direction)
+    result, location, normal, _, _, _ = context.scene.ray_cast(
+        depsgraph, ray_origin, ray_direction
+    )
 
     if result:
         return HitVector(location, normal, UP_VECTOR.rotation_difference(normal))
     else:
-        intersection = intersect_line_plane(ray_origin, ray_origin + ray_direction, ZERO_VECTOR, UP_VECTOR)
+        intersection = intersect_line_plane(
+            ray_origin, ray_origin + ray_direction, ZERO_VECTOR, UP_VECTOR
+        )
         if intersection:
             return HitVector(intersection, UP_VECTOR, Quaternion())
     # If there is no hit, then don't return a HitVector

--- a/MCprep_addon/spawner/spawner_gizmo.py
+++ b/MCprep_addon/spawner/spawner_gizmo.py
@@ -1,4 +1,5 @@
-from typing import Tuple
+from dataclasses import dataclass
+from typing import Optional
 import bpy
 from bpy_extras import view3d_utils
 import gpu
@@ -9,6 +10,12 @@ from mathutils.geometry import intersect_line_plane
 
 ZERO_VECTOR = Vector((0, 0, 0))
 UP_VECTOR = Vector((0, 0, 1))
+
+@dataclass
+class HitVector:
+    location: Vector
+    normal: Vector
+    rotation: Quaternion
 
 def draw_fading_grid(shader_info, size, subdivisions, rings, base_color):
     """Creates a grid with a fading circle gradient"""
@@ -55,7 +62,7 @@ def draw_fading_grid(shader_info, size, subdivisions, rings, base_color):
         shader_info.uniform_float("color", color)
         batch.draw(shader_info)
 
-def draw_callback(hit_location: Vector, rotation_quat: Quaternion) -> None:
+def draw_callback(hit_vector: HitVector) -> None:
     """Callback function to call when drawing the gizmo"""
     shader_info = gpu.shader.from_builtin('UNIFORM_COLOR')
 
@@ -64,7 +71,7 @@ def draw_callback(hit_location: Vector, rotation_quat: Quaternion) -> None:
     gpu.state.blend_set('ALPHA')
     gpu.state.depth_test_set('NONE')
 
-    transform_matrix = Matrix.Translation(hit_location) @ rotation_quat.to_matrix().to_4x4()
+    transform_matrix = Matrix.Translation(hit_vector.location) @ hit_vector.rotation.to_matrix().to_4x4()
 
     gpu.matrix.push()
     gpu.matrix.multiply_matrix(transform_matrix)
@@ -75,7 +82,7 @@ def draw_callback(hit_location: Vector, rotation_quat: Quaternion) -> None:
     gpu.state.blend_set(original_blend)
     gpu.state.depth_test_set(original_depth_test)
 
-def update_raycast(context, event) -> Tuple[bool, Vector, Vector, Quaternion]:
+def update_raycast(context, event) -> Optional[HitVector]:
     """Given the context of the scene, update the location, normal, and rotation of the ray"""
     mouse_pos = (event.mouse_region_x, event.mouse_region_y)
     region, region_3d = context.region, context.space_data.region_3d
@@ -85,10 +92,10 @@ def update_raycast(context, event) -> Tuple[bool, Vector, Vector, Quaternion]:
     result, location, normal, _, _, _ = context.scene.ray_cast(depsgraph, ray_origin, ray_direction)
 
     if result:
-        return True, location, normal, UP_VECTOR.rotation_difference(normal)
+        return HitVector(location, normal, UP_VECTOR.rotation_difference(normal))
     else:
         intersection = intersect_line_plane(ray_origin, ray_origin + ray_direction, ZERO_VECTOR, UP_VECTOR)
         if intersection:
-            return True, intersection, UP_VECTOR, Quaternion()
-        else:
-            return False, ZERO_VECTOR, UP_VECTOR, Quaternion()
+            return HitVector(intersection, UP_VECTOR, Quaternion())
+    # If there is no hit, then don't return a HitVector
+    return None


### PR DESCRIPTION
This is a small thing, but Blender 4.1 introduced the new FileHandler API, which allows defining custom drag and drop behavior. Since we already have an operator for importing JSON models, we can extend it relatively easily by creating a subclass of `FileHandler`.

Since it's exclusive to 4.1 and above, we wrap the `FileHandler` type around another type called `FileHandlerIfSupported`, which otherwise will simply be a dummy type at runtime if the Blender version is 4.0 or below. In addition, we also only register the `MCPREP_FH_import_minecraft_model_file` class if Blender 4.1 and above is being used.