### PR TITLE
fix: Don't try to read Vivy JSON file if Vivy isn't enabled

### DIFF
--- a/MCprep_addon/conf.py
+++ b/MCprep_addon/conf.py
@@ -166,6 +166,8 @@ class MCprepEnv:
 			}
 			with open(json_path, 'w') as f:
 				json.dump(self.vivy_material_json, f)
+		elif not self.vivy_enabled:
+			return
 		else: 
 			with open(json_path, 'r') as f:
 				self.vivy_material_json = json.load(f) if json_path.stat().st_size != 0 else {}


### PR DESCRIPTION
Previously, we only checked if both the JSON existed and if Vivy was enabled. If one of those conditions was `False`, then MCprep would attempt to read the Vivy JSON, which won't exist if Vivy was disabled.

This adds a simple check for whether Vivy is enabled or not, and if it isn't, to just return early from the `reload_vivy_json` function.