### PR TITLE
feat: Set shading to flat for Mineways imports

### DIFF
--- a/MCprep_addon/world_tools.py
+++ b/MCprep_addon/world_tools.py
@@ -883,7 +883,7 @@ class MCPREP_OT_import_world_split(bpy.types.Operator, WorldImporterBase, Import
         name=env._("Center Import"),
         description=env._("Decide if the import should be centered, and if so, how"),
         items=(
-            ('NONE', env._("Don't Center"), env._("Doesn't center the import")),
+            ('NONE', env._("Keep Original Position"), env._("Keeps the position of the import as-is")),
             ('XY', env._("Center by XY Plane"), env._("Centers the import by X and Y only")),
 			('XYZ', env._("Center by all 3 axis"), env._("Centers the import by all 3 axis")),
         ),

--- a/MCprep_addon/world_tools.py
+++ b/MCprep_addon/world_tools.py
@@ -880,12 +880,12 @@ class MCPREP_OT_import_world_split(bpy.types.Operator, WorldImporterBase, Import
 		options={'HIDDEN'})	
 
 	center_import: bpy.props.EnumProperty(
-        name="Center Import",
-        description="Decide if the import should be centered, and if so, how",
+        name=env._("Center Import"),
+        description=env._("Decide if the import should be centered, and if so, how"),
         items=(
-            ('NONE', "Don't Center", "Doesn't center the import"),
-            ('XY', "Center by XY Plane", "Centers the import by X and Y only"),
-			('XYZ', "Center by all 3 axis", "Centers the import by all 3 axis"),
+            ('NONE', env._("Don't Center"), env._("Doesn't center the import")),
+            ('XY', env._("Center by XY Plane"), env._("Centers the import by X and Y only")),
+			('XYZ', env._("Center by all 3 axis"), env._("Centers the import by all 3 axis")),
         ),
         default='XY',
     )

--- a/MCprep_addon/world_tools.py
+++ b/MCprep_addon/world_tools.py
@@ -877,15 +877,7 @@ class MCPREP_OT_import_world_split(bpy.types.Operator, WorldImporterBase, Import
 	fileselectparams = "use_filter_blender"
 	skipUsage: bpy.props.BoolProperty(
 		default=False,
-		options={'HIDDEN'})
-
-	minewaysShadingWorkaround: bpy.props.BoolProperty(
-		name=env._("Mineways Shading Workaround"),
-		description=env._(("Mineways imports have custom vertex normals defined, which may "
-			"cause artifacts. If enabled, this option will enforce flat shading on "
-			"Mineways imports.")),
-		default=True if bpy.app.version >= (4, 5, 0) else False
-	)
+		options={'HIDDEN'})	
 
 	center_import: bpy.props.EnumProperty(
         name="Center Import",
@@ -897,6 +889,14 @@ class MCPREP_OT_import_world_split(bpy.types.Operator, WorldImporterBase, Import
         ),
         default='XY',
     )
+
+	minewaysShadingWorkaround: bpy.props.BoolProperty(
+		name=env._("Mineways Shading Workaround"),
+		description=env._(("Mineways imports have custom vertex normals defined, which may "
+			"cause artifacts. If enabled, this option will enforce flat shading on "
+			"Mineways imports.")),
+		default=True if bpy.app.version >= (4, 5, 0) else False
+	)
 
 	track_function = "import_split"
 	track_exporter = None

--- a/MCprep_addon/world_tools.py
+++ b/MCprep_addon/world_tools.py
@@ -884,7 +884,7 @@ class MCPREP_OT_import_world_split(bpy.types.Operator, WorldImporterBase, Import
 		description=env._(("Mineways imports have custom vertex normals defined, which may "
 			"cause artifacts. If enabled, this option will enforce flat shading on "
 			"Mineways imports.")),
-		default=True
+		default=True if bpy.app.version >= (4, 5, 0) else False
 	)
 
 	center_import: bpy.props.EnumProperty(

--- a/MCprep_addon/world_tools.py
+++ b/MCprep_addon/world_tools.py
@@ -881,7 +881,7 @@ class MCPREP_OT_import_world_split(bpy.types.Operator, WorldImporterBase, Import
 
 	minewaysShadingWorkaround: bpy.props.BoolProperty(
 		name=env._("Mineways Shading Workaround"),
-		description=env.(("Mineways imports have custom vertex normals defined, which may "
+		description=env._(("Mineways imports have custom vertex normals defined, which may "
 			"cause artifacts. If enabled, this option will enforce flat shading on "
 			"Mineways imports.")),
 		default=True

--- a/MCprep_addon/world_tools.py
+++ b/MCprep_addon/world_tools.py
@@ -880,10 +880,10 @@ class MCPREP_OT_import_world_split(bpy.types.Operator, WorldImporterBase, Import
 		options={'HIDDEN'})
 
 	minewaysShadingWorkaround: bpy.props.BoolProperty(
-		name="Mineways Shading Workaround",
-		description=("Mineways imports have custom vertex normals defined, which may "
+		name=env._("Mineways Shading Workaround"),
+		description=env.(("Mineways imports have custom vertex normals defined, which may "
 			"cause artifacts. If enabled, this option will enforce flat shading on "
-			"Mineways imports."),
+			"Mineways imports.")),
 		default=True
 	)
 
@@ -927,20 +927,20 @@ class MCPREP_OT_import_objs_as_chunks(bpy.types.Operator, WorldImporterBase, Imp
 		options={'HIDDEN'})
 	
 	center_assembly: bpy.props.EnumProperty(
-        name="Center Final Assembly",
-        description="Decide if the final assembly should be centered, and if so, how",
+        name=env._("Center Final Assembly"),
+        description=env._("Decide if the final assembly should be centered, and if so, how"),
         items=(
-            ('NONE', "Don't Center", "Doesn't center the final assembly"),
-            ('XY', "Center by XY Plane", "Centers the final assembly by X and Y only"),
-			('XYZ', "Center by all 3 axis", "Centers the final assembly by all 3 axis"),
+            ('NONE', env._("Don't Center"), env._("Doesn't center the final assembly")),
+            ('XY', env._("Center by XY Plane"), env._("Centers the final assembly by X and Y only")),
+			('XYZ', env._("Center by all 3 axis"), env._("Centers the final assembly by all 3 axis")),
         ),
         default='XY',
     )
 	minewaysShadingWorkaround: bpy.props.BoolProperty(
-		name="Mineways Shading Workaround",
-		description=("Mineways imports have custom vertex normals defined, which may "
+		name=env._("Mineways Shading Workaround"),
+		description=env._(("Mineways imports have custom vertex normals defined, which may "
 			"cause artifacts. If enabled, this option will enforce flat shading on "
-			"Mineways imports."),
+			"Mineways imports.")),
 		default=True
 	)
 

--- a/MCprep_addon/world_tools.py
+++ b/MCprep_addon/world_tools.py
@@ -592,7 +592,8 @@ class WorldImporterBase:
 					 context: Context,
 					 filepath: Path,
 					 header: Union[ObjHeaderOptions, CommonMCOBJ],
-					 offsets: Optional[Tuple[float, float, float]]) -> Union[None, List[MCprepError], MCprepError]:
+					 offsets: Optional[Tuple[float, float, float]],
+					 mineways_fix_smooth_shading_artifacts: bool = True) -> Union[None, List[MCprepError], MCprepError]:
 		# TODO: Create a more elegant way to handle warnings
 		propogated_warnings: List[MCprepError] = []
 		res = enable_obj_importer()
@@ -796,6 +797,10 @@ class WorldImporterBase:
 				obj.parent = empty
 				obj.matrix_parent_inverse = empty.matrix_world.inverted()  # don't transform object
 				self.track_exporter = header.exporter
+
+				# Mineways workaround for smooth shading artifacts
+				if mineways_fix_smooth_shading_artifacts and header.exporter == "mineways":
+					obj.data.polygons.foreach_set('use_smooth',  [False] * len(obj.data.polygons))
 			elif isinstance(header, ObjHeaderOptions):
 				obj["MCPREP_OBJ_HEADER"] = True
 				obj["MCPREP_OBJ_FILE_TYPE"] = header.texture_type()
@@ -809,6 +814,10 @@ class WorldImporterBase:
 				# getting the exporter
 				obj["MCPREP_OBJ_EXPORTER"] = "mineways-c" if header.exporter() == "Mineways" else "jmc2obj-c"
 				self.track_exporter = addon_prefs.MCprep_exporter_type  # Soft detect.
+				
+				# Mineways workaround for smooth shading artifacts
+				if mineways_fix_smooth_shading_artifacts and header.exporter() == "Mineways":
+					obj.data.polygons.foreach_set('use_smooth',  [False] * len(obj.data.polygons))
 
 		# One final assignment of the preferences, to avoid doing each loop
 		val = header.exporter if isinstance(header, CommonMCOBJ) else header.exporter()
@@ -870,6 +879,14 @@ class MCPREP_OT_import_world_split(bpy.types.Operator, WorldImporterBase, Import
 		default=False,
 		options={'HIDDEN'})
 
+	minewaysShadingWorkaround: bpy.props.BoolProperty(
+		name="Mineways Shading Workaround",
+		description=("Mineways imports have custom vertex normals defined, which may "
+			"cause artifacts. If enabled, this option will enforce flat shading on "
+			"Mineways imports."),
+		default=True
+	)
+
 	track_function = "import_split"
 	track_exporter = None
 	@tracking.report_error
@@ -881,7 +898,11 @@ class MCPREP_OT_import_world_split(bpy.types.Operator, WorldImporterBase, Import
 			return {'CANCELLED'}
 
 		path, header = path_res
-		res = self.import_obj_file(context, path, header, None)
+		res = self.import_obj_file(context,
+							 path,
+							 header,
+							 None,
+							 mineways_fix_smooth_shading_artifacts=self.minewaysShadingWorkaround)
 		if isinstance(res, MCprepError):
 			self.report({"ERROR"}, res.msg)
 			return {'CANCELLED'}
@@ -915,6 +936,13 @@ class MCPREP_OT_import_objs_as_chunks(bpy.types.Operator, WorldImporterBase, Imp
         ),
         default='XY',
     )
+	minewaysShadingWorkaround: bpy.props.BoolProperty(
+		name="Mineways Shading Workaround",
+		description=("Mineways imports have custom vertex normals defined, which may "
+			"cause artifacts. If enabled, this option will enforce flat shading on "
+			"Mineways imports."),
+		default=True
+	)
 
 	# necessary to support multi-file import
 	files: bpy.props.CollectionProperty(
@@ -979,7 +1007,11 @@ class MCPREP_OT_import_objs_as_chunks(bpy.types.Operator, WorldImporterBase, Imp
 			offset_y = (new_export_bounds_min[1] + new_export_bounds_max[1]) / 2
 		
 		for file, header in files_and_headers:
-			res = self.import_obj_file(context, file, header, (offset_x, offset_y, offset_z))
+			res = self.import_obj_file(context,
+							  file,
+							  header,
+							  (offset_x, offset_y, offset_z),
+							  mineways_fix_smooth_shading_artifacts=self.minewaysShadingWorkaround)
 			if isinstance(res, MCprepError):
 				self.report({"ERROR"}, res.msg)
 				return {'CANCELLED'}

--- a/MCprep_addon/world_tools.py
+++ b/MCprep_addon/world_tools.py
@@ -887,7 +887,7 @@ class MCPREP_OT_import_world_split(bpy.types.Operator, WorldImporterBase, Import
             ('XY', env._("Center by XY Plane"), env._("Centers the import by X and Y only")),
 			('XYZ', env._("Center by all 3 axis"), env._("Centers the import by all 3 axis")),
         ),
-        default='XY',
+        default='NONE',
     )
 
 	minewaysShadingWorkaround: bpy.props.BoolProperty(


### PR DESCRIPTION
Mineways OBJs seem to have weird artifacts caused by vertex normals being set (and thus in Blender being shaded smooth). While this is being tracked in erich666/Mineways#151, a workaround is needed for existing OBJs to reduce issues.

This is done by simply setting the `use_smooth` property to `False` on the active selection, which will be the OBJ after importing, only if the OBJ is a Mineways export. This behavior can be disabled by calling the function with `mineways_fix_smooth_shading_artifacts` set to `False`. As this is done through the `foreach_set` function, there shouldn't be much of a hit to import performance. However, just in case, the end user can also disable the workaround.

If future releases of Mineways resolve the smooth shading issue, we could encapsulate it with a header check, either for the version (if future versions of Mineways completely eliminate setting vertex normals) or for an export option (if setting vertex normals can be disabled in the future, which is a more likely outcome).