### PR TITLE
feat: Add centering options for single OBJ imports

### DIFF
--- a/MCprep_addon/world_tools.py
+++ b/MCprep_addon/world_tools.py
@@ -870,18 +870,45 @@ class MCPREP_OT_import_world_split(bpy.types.Operator, WorldImporterBase, Import
 		default=False,
 		options={'HIDDEN'})
 
+	center_import: bpy.props.EnumProperty(
+        name="Center Import",
+        description="Decide if the import should be centered, and if so, how",
+        items=(
+            ('NONE', "Don't Center", "Doesn't center the final assembly"),
+            ('XY', "Center by XY Plane", "Centers the final assembly by X and Y only"),
+			('XYZ', "Center by all 3 axis", "Centers the final assembly by all 3 axis"),
+        ),
+        default='XY',
+    )
+
 	track_function = "import_split"
 	track_exporter = None
 	@tracking.report_error
 	def execute(self, context):
 		path_res = self.validate_and_return_header(Path(self.filepath))
-		
+
 		if isinstance(path_res, MCprepError):
 			self.report({"ERROR"}, path_res.msg)
 			return {'CANCELLED'}
 
+		# Declare and use the offsets regardless of whether
+		# or not CommonMCOBJ is used and/or centering is
+		# chosen. In those cases, the offsets will be 0, so
+		# nothing will happen
 		path, header = path_res
-		res = self.import_obj_file(context, path, header, None)
+		offset_x, offset_y, offset_z = 0, 0, 0
+
+		if isinstance(header, ObjHeaderOptions):
+			self.report({"WARNING"}, "OBJ doesn't use the CommonMCOBJ spec, re-exporting with a modern OBJ exporter is recommended!")
+	
+		else:
+			if self.center_import == 'XY' or self.center_import == 'XYZ':
+				offset_x = (header.export_bounds_min[0] + header.export_bounds_max[0]) / 2
+				offset_z = (header.export_bounds_min[2] + header.export_bounds_max[2]) / 2
+			if self.center_import == 'XYZ':
+				offset_y = (header.export_bounds_min[1] + header.export_bounds_max[1]) / 2
+
+		res = self.import_obj_file(context, path, header, (offset_x, offset_y, offset_z))
 		if isinstance(res, MCprepError):
 			self.report({"ERROR"}, res.msg)
 			return {'CANCELLED'}

--- a/MCprep_addon/world_tools.py
+++ b/MCprep_addon/world_tools.py
@@ -874,9 +874,9 @@ class MCPREP_OT_import_world_split(bpy.types.Operator, WorldImporterBase, Import
         name="Center Import",
         description="Decide if the import should be centered, and if so, how",
         items=(
-            ('NONE', "Don't Center", "Doesn't center the final assembly"),
-            ('XY', "Center by XY Plane", "Centers the final assembly by X and Y only"),
-			('XYZ', "Center by all 3 axis", "Centers the final assembly by all 3 axis"),
+            ('NONE', "Don't Center", "Doesn't center the import"),
+            ('XY', "Center by XY Plane", "Centers the import by X and Y only"),
+			('XYZ', "Center by all 3 axis", "Centers the import by all 3 axis"),
         ),
         default='XY',
     )

--- a/MCprep_addon/world_tools.py
+++ b/MCprep_addon/world_tools.py
@@ -891,10 +891,6 @@ class MCPREP_OT_import_world_split(bpy.types.Operator, WorldImporterBase, Import
 			self.report({"ERROR"}, path_res.msg)
 			return {'CANCELLED'}
 
-		# Declare and use the offsets regardless of whether
-		# or not CommonMCOBJ is used and/or centering is
-		# chosen. In those cases, the offsets will be 0, so
-		# nothing will happen
 		path, header = path_res
 		offset_x, offset_y, offset_z = 0, 0, 0
 
@@ -907,8 +903,15 @@ class MCPREP_OT_import_world_split(bpy.types.Operator, WorldImporterBase, Import
 				offset_z = (header.export_bounds_min[2] + header.export_bounds_max[2]) / 2
 			if self.center_import == 'XYZ':
 				offset_y = (header.export_bounds_min[1] + header.export_bounds_max[1]) / 2
+		
+		# Set to None as import_obj_file raises an error
+		# if offsets are provided but the OBJ header is not
+		# a CommonMCOBJ header. The behavior is the same anyway
+		offsets = (offset_x, offset_y, offset_z)
+		if offsets == (0, 0, 0):
+			offsets = None
 
-		res = self.import_obj_file(context, path, header, (offset_x, offset_y, offset_z))
+		res = self.import_obj_file(context, path, header, offsets)
 		if isinstance(res, MCprepError):
 			self.report({"ERROR"}, res.msg)
 			return {'CANCELLED'}


### PR DESCRIPTION
This is mostly for parity with importing OBJs as chunks. Like chunk imports, this will only be performed on OBJs that export CommonMCOBJ metadata.

In addition, this also adds a warning for OBJs that don't use the CommonMCOBJ header. Given it's been almost two years, I think it's safe to begin warning users about old OBJs, since most at this point should be exported with newer exporters (usually for newer Minecraft updates).