### PR TITLE
Added Pixel Hashing to Image Consolidation

### DIFF
--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -288,11 +288,6 @@ class MCPREP_OT_combine_images(bpy.types.Operator):
 	def execute(self, context):
 		removeold = True
 
-		if bpy.app.version < (2, 78):
-			self.report(
-				{'ERROR'}, "Must use blender 2.78 or higher to use this operator")
-			return {'CANCELLED'}
-
 		if self.selection_only and len(context.selected_objects) == 0:
 			self.report(
 				{'ERROR'},

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -21,7 +21,6 @@ import os
 
 import bpy
 
-import hashlib
 import numpy as np
 
 from . import generate
@@ -370,7 +369,7 @@ class MCPREP_OT_combine_images(bpy.types.Operator):
 
 	def get_image_hash(self, img: bpy.types.Image, w: int, h: int, buffer: np.ndarray = None) -> str:
 		"""
-		Generates a MD5 hash from image pixel data
+		Generates a byte-string hash from sampled image pixel data.
 		"""
 		if not img.has_data:
 			return None
@@ -381,12 +380,10 @@ class MCPREP_OT_combine_images(bpy.types.Operator):
 
 			img.pixels.foreach_get(pixels)
 
-			# Calculate stride (sample every Nth pixel), only start when image is larger than 4096 pixels (bigger than 64 x 64)
+			# Calculate stride: if pixels > 4096, sample every Nth pixel
 			stride = max(1, total_pixels // 4096)
 
-			sample = np.ascontiguousarray(pixels[::stride * 4])
-
-			return hashlib.md5(sample.data).hexdigest()
+			return pixels[::stride * 4].tobytes()
 
 		except Exception as e:
 			env.log(f"Failed to hash {img.name}: {e}", vv_only=True)

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -32,6 +32,14 @@ from .. import util
 
 from ..conf import MCprepError, env
 
+# 4096 * 4, used to cap the amount of
+# pixels summed when not using the fast
+# prefilter with the Combine Images operator
+#
+# 4096 is the amount of pixels capped to,
+# and 4 is the RGBA channels
+RGBA_PIXELS_4096_MAX = 16384
+
 
 # -----------------------------------------------------------------------------
 # UI and utility functions
@@ -331,6 +339,9 @@ class MCPREP_OT_combine_images(bpy.types.Operator):
 		precount = len(bpy.data.images)
 
 		# Group images
+		#
+		# Here we use a list, since we're just trying to get the
+		# raw images at this point for comparison
 		groups: List[Tuple[str, int, int, bpy.types.Image]] = []
 		for img in images_to_check:
 			if img.type in ('RENDER_RESULT', 'COMPOSITING') or img.use_fake_user:
@@ -348,25 +359,29 @@ class MCPREP_OT_combine_images(bpy.types.Operator):
 		# Value: List of (image_obj, comparison_array, sum)
 		# store both the image (for remapping later on), the pixel array,
 		# and pixel array sum for super fast prefilter
-		unique_images: Dict[Tuple[str, int, int], List[Tuple[bpy.types.Image, NDArray[np.float32], float]]] = {}
+		unique_images: Dict[Tuple[str, int, int], List[Tuple[bpy.types.Image, NDArray[np.float32], Optional[np.float64]]]] = {}
 		images_to_remove = []
 
 		for base_name, w, h, img in groups:
 			cur_img_key = (base_name, w, h)
 
-			num_pixels = w * h * 4
-			img_array = np.empty(num_pixels, dtype=np.float32)
-			img.pixels.foreach_get(img_array)	# faster than `np.asarray(img.pixels)`
+			img_array = np.asarray(img.pixels)
+			pix_sum: Optional[np.float64] = None
 
-			# Use sampling unless strict is enabled
-			# 16384 = 4096 * 4
-			stride = max(1, num_pixels // 16384) if not self.strict_comparison else 1
-			cur_img_data = img_array[::stride] if stride > 1 else img_array
+			# Approximation of a image content check used
+			# if strict comparison is disabled. Unlike strict
+			# comparison, which checks the actual pixels, this
+			# sums up the pixels and uses that to represent the
+			# image contents
+			if not self.strict_comparison:
+				num_pixels = w * h * 4
+				stride = max(1, num_pixels // RGBA_PIXELS_4096_MAX)
+				cur_img_data = img_array[::stride] if stride > 1 else img_array
 
-			pix_sum = np.sum(cur_img_data)
-
+				pix_sum = np.sum(cur_img_data)
+	
 			if cur_img_key not in unique_images:
-				unique_images[cur_img_key] = [(img, cur_img_data, pix_sum)]
+				unique_images[cur_img_key] = [(img, img_array, pix_sum)]
 				continue
 
 			image_present = False
@@ -374,10 +389,11 @@ class MCPREP_OT_combine_images(bpy.types.Operator):
 
 			# Look through existing items in this Name/Size group
 			for uni_image, uni_data, uni_sum in unique_images[cur_img_key]:
-				# FAST PREFILTER
-				if not pix_sum == uni_sum:
+				# Fast prefilter, used as an alternative
+				# to strict comparison
+				if not self.strict_comparison and not pix_sum == uni_sum:
 					continue
-				elif not np.array_equal(uni_data, cur_img_data):
+				elif not np.array_equal(uni_data, img_array):
 					continue
 				image_present = True
 				present_image = uni_image
@@ -392,7 +408,7 @@ class MCPREP_OT_combine_images(bpy.types.Operator):
 				continue
 
 			# If the image is not present, add it to the list
-			unique_images[cur_img_key].append((img, cur_img_data, pix_sum))
+			unique_images[cur_img_key].append((img, img_array, pix_sum))
 
 		# Cleanup
 		to_delete = [

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -294,6 +294,7 @@ class MCPREP_OT_combine_images(bpy.types.Operator):
 	track_function = "combine_images"
 	@tracking.report_error
 	def execute(self, context):
+		start_time = time.time()
 		# Setup image list
 		if self.selection_only:
 			if not context.selected_objects:
@@ -354,9 +355,13 @@ class MCPREP_OT_combine_images(bpy.types.Operator):
 			fingerprints = {}
 			is_empty = (w == 0 or h == 0)
 			pixel_buffer = None if is_empty else np.empty(w * h * 4, dtype=np.float32)	#RGBA
+			
+			total_pixels = w * h
+
+			stride = max(1, total_pixels // 4096) if not self.strict_comparison and total_pixels > 4096 else 1
 
 			for img in img_list:
-				hash = b"EMPTY" if is_empty else self.get_image_hash(img, w, h, buffer=pixel_buffer)
+				hash = b"EMPTY" if is_empty else self.get_image_hash(img, w, h, buffer=pixel_buffer, stride = stride)
 
 				if not hash:
 					continue
@@ -391,9 +396,11 @@ class MCPREP_OT_combine_images(bpy.types.Operator):
 			self.report({"INFO"}, f"Consolidated {consolidated_count} duplicate image{'s' if consolidated_count != 1 else ''} (Total: {precount} -> {postcount})")
 		else:
 			self.report({"INFO"}, "No duplicates found")
+		
+		print(f"{time.time() - start_time}s")
 		return {'FINISHED'}
 
-	def get_image_hash(self, img: bpy.types.Image, w: int, h: int, buffer: np.ndarray = None) -> bytes:
+	def get_image_hash(self, img: bpy.types.Image, w: int, h: int, buffer: np.ndarray = None, stride: int = 1) -> bytes:
 		"""
 		Generates a byte hash from sampled image pixel data.
 		"""
@@ -409,12 +416,7 @@ class MCPREP_OT_combine_images(bpy.types.Operator):
 			env.log(f"Failed to hash {img.name}: {e}", vv_only=True)
 			return None
 
-		if self.strict_comparison:
-			return pixels.tobytes()
-		else:
-			#Calculate stride: if pixels > 4096, sample every Nth pixel
-			stride = max(1, total_pixels // 4096)
-			return pixels[::stride * 4].tobytes()
+		return pixels.reshape(-1, 4)[::stride].tobytes()
 
 
 class MCPREP_OT_replace_missing_textures(bpy.types.Operator):

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -294,7 +294,6 @@ class MCPREP_OT_combine_images(bpy.types.Operator):
 	track_function = "combine_images"
 	@tracking.report_error
 	def execute(self, context):
-		start_time = time.time()
 		# Setup image list
 		if self.selection_only:
 			if not context.selected_objects:
@@ -396,8 +395,6 @@ class MCPREP_OT_combine_images(bpy.types.Operator):
 			self.report({"INFO"}, f"Consolidated {consolidated_count} duplicate image{'s' if consolidated_count != 1 else ''} (Total: {precount} -> {postcount})")
 		else:
 			self.report({"INFO"}, "No duplicates found")
-		
-		print(f"{time.time() - start_time}s")
 		return {'FINISHED'}
 
 	def get_image_hash(self, img: bpy.types.Image, w: int, h: int, buffer: np.ndarray = None, stride: int = 1) -> bytes:

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -343,7 +343,7 @@ class MCPREP_OT_combine_images(bpy.types.Operator):
 
 		images_to_remove = []
 
-		# Hashing and Remapping
+		# Comparison and Remapping
 		for (base_name, w, h), img_list in groups.items():
 			if len(img_list) < 2:
 				continue
@@ -351,7 +351,7 @@ class MCPREP_OT_combine_images(bpy.types.Operator):
 			img_list.sort(key=lambda x: x.name)
 
 			# Internal cache for this group
-			fingerprints = {}
+			unique_contents = {}
 			is_empty = (w == 0 or h == 0)
 			pixel_buffer = None if is_empty else np.empty(w * h * 4, dtype=np.float32)	#RGBA
 			
@@ -360,18 +360,25 @@ class MCPREP_OT_combine_images(bpy.types.Operator):
 			stride = max(1, total_pixels // 4096) if not self.strict_comparison and total_pixels > 4096 else 1
 
 			for img in img_list:
-				hash = b"EMPTY" if is_empty else self.get_image_hash(img, w, h, buffer=pixel_buffer, stride = stride)
-
-				if not hash:
+				if pixel_buffer is None:
+					content_key = "EMPTY"
+				elif not img.has_data:
 					continue
+				else:
+					try:
+						img.pixels.foreach_get(pixel_buffer)
+						content_key = pixel_buffer.reshape(-1, 4)[::stride].tobytes()
+					except RuntimeError as e:
+						env.log(f"Failed to hash {img.name}: {e}", vv_only=True)
+						continue
 
-				if hash in fingerprints:
+				if content_key in unique_contents:
 					# Duplicate: remap to first image instance of hash
-					img.user_remap(fingerprints[hash])
+					img.user_remap(unique_contents[content_key])
 					images_to_remove.append(img)
 				else:
 					# Unique image: store as the master image for this hash
-					fingerprints[hash] = img
+					unique_contents[content_key] = img
 					# Clean up name of master image ONLY if grouping by name
 					if self.group_by_name and img.name != base_name and base_name not in bpy.data.images:
 						img.name = base_name
@@ -396,24 +403,6 @@ class MCPREP_OT_combine_images(bpy.types.Operator):
 		else:
 			self.report({"INFO"}, "No duplicates found")
 		return {'FINISHED'}
-
-	def get_image_hash(self, img: bpy.types.Image, w: int, h: int, buffer: np.ndarray = None, stride: int = 1) -> bytes:
-		"""
-		Generates a byte hash from sampled image pixel data.
-		"""
-		if not img.has_data:
-			return None
-
-		total_pixels = w * h
-		pixels = buffer if buffer is not None else np.empty(total_pixels * 4, dtype=np.float32)
-
-		try:
-			img.pixels.foreach_get(pixels)
-		except RuntimeError as e:
-			env.log(f"Failed to hash {img.name}: {e}", vv_only=True)
-			return None
-
-		return pixels.reshape(-1, 4)[::stride].tobytes()
 
 
 class MCPREP_OT_replace_missing_textures(bpy.types.Operator):

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -271,7 +271,8 @@ class MCPREP_OT_combine_materials(bpy.types.Operator):
 class MCPREP_OT_combine_images(bpy.types.Operator):
 	bl_idname = "mcprep.combine_images"
 	bl_label = "Combine images"
-	bl_description = "Consolidate the same images together e.g. img.001 and img.002"
+	bl_description = "Consolidate images with the same name (e.g. img.001 & img.002) and identical pixel data"
+	bl_options = {'REGISTER', 'UNDO'}
 
 	# arg to auto-force remove old? versus just keep as 0-users
 	selection_only: bpy.props.BoolProperty(
@@ -288,80 +289,104 @@ class MCPREP_OT_combine_images(bpy.types.Operator):
 	def execute(self, context):
 		removeold = True
 
-		if self.selection_only is True and len(context.selected_objects) == 0:
-			self.report(
-				{'ERROR'},
-				"Either turn selection only off or select objects with materials/images")
-			return {'CANCELLED'}
-
-		# 2-level structure to hold base name and all
-		# images blocks with the same base
 		if bpy.app.version < (2, 78):
 			self.report(
 				{'ERROR'}, "Must use blender 2.78 or higher to use this operator")
 			return {'CANCELLED'}
 
-		if self.selection_only is True:
+		if self.selection_only and len(context.selected_objects) == 0:
+			self.report(
+				{'ERROR'},
+				"Either turn selection only off or select objects with materials/images")
+			return {'CANCELLED'}
+
+		if self.selection_only:
 			self.report({'ERROR'}, (
 				"Combine images does not yet work for selection only, retry "
 				"with option disabled"))
 			return {'CANCELLED'}
 
-		name_cat = {}
 		data = bpy.data.images
-
 		precount = len(data)
 
-		# get and categorize all image names
-		for im in bpy.data.images:
-			base = util.nameGeneralize(im.name)
-			if base not in name_cat:
-				name_cat[base] = [im.name]
-			elif im.name not in name_cat[base]:
-				name_cat[base].append(im.name)
-			else:
-				env.log("Skipping, already added image", vv_only=True)
+		# Group images
+		groups = {}
+		for im in data:
+			if im.type == 'RENDER_RESULT': continue
 
-			postcount = len(["x" for x in bpy.data.materials if x.users > 0])
-			self.report(
-				{"INFO"},
-				f"Consolidated {precount - postcount} materials, down to {postcount} overall")
-			return {'FINISHED'}
+			base_name = util.nameGeneralize(im.name)
+			group_key = (base_name, im.size[0], im.size[1])
 
-		# perform the consolidation with one basename set at a time
-		for base in name_cat:
-			if len(base) < 2:
+			if group_key not in groups:
+				groups[group_key] = []
+			groups[group_key].append(im)
+
+		# Process groups
+		for key, im_list in groups.items():
+			if len(im_list) < 2:
 				continue
-			name_cat[base].sort()  # in-place sorting
-			baseImg = bpy.data.images[name_cat[base][0]]
 
-			for imgname in name_cat[base][1:]:
+			im_list.sort(key=lambda x: x.name)
+
+			target_img = im_list[0]
+			target_hash = self.get_image_hash(target_img)
+
+			if not target_hash:
+				continue
+
+			for i in range(1, len(im_list)):
+				current_img = im_list[i]
+
 				# skip if fake user set
-				if bpy.data.images[imgname].use_fake_user is True:
+				if current_img.use_fake_user:
 					continue
-				# otherwise, remap
-				data[imgname].user_remap(baseImg)
-				old = bpy.data.images[imgname]
-				if removeold is True and old.users == 0:
-					bpy.data.images.remove(bpy.data.images[imgname])
 
-			# Final step.. rename to not have .001 if it does
-			if baseImg.name != util.nameGeneralize(baseImg.name):
-				gen = util.nameGeneralize(baseImg.name)
-				in_data = gen in data
-				has_users = in_data and bpy.data.images[gen].users != 0
-				if has_users:
-					pass
+				current_hash = self.get_image_hash(current_img)
+
+				if current_hash == target_hash:
+					current_img.user_remap(target_img)
+					if removeold and current_img.users == 0:
+						data.remove(current_img)
 				else:
-					baseImg.name = util.nameGeneralize(baseImg.name)
-			else:
-				baseImg.name = util.nameGeneralize(baseImg.name)
+					continue
 
-		postcount = len(["x" for x in bpy.data.images if x.users > 0])
-		self.report(
-			{"INFO"}, f"Consolidated {precount} images down to {postcount}")
+			# Rename target to clean base name
+			clean_name = key[0]
+			if target_img.name != clean_name:
+				if clean_name not in data or data[clean_name].users == 0:
+					target_img.name = clean_name
+
+		postcount = len(data)
+		if precount - postcount > 0:
+			self.report({"INFO"}, f"Consolidated {precount} images down to {postcount}")
+		else:
+			self.report({"INFO"}, "No images found to condense")
 
 		return {'FINISHED'}
+
+	def get_image_hash(self, img):
+		"""Generates a MD5 hash from image pixel data"""
+		
+		if not img.has_data or sum(img.size) == 0:
+			return None
+
+		try:
+			width, height = img.size
+			pixels = np.empty(width * height * 4, dtype=np.float32)
+			img.pixels.foreach_get(pixels)
+			
+			# Calculate buffer (sample every Nth pixel), only start buffering when image is larger than 4096 pixels (bigger than 64 x 64)
+			buffer = max(1, (width * height) // 4096)
+
+			# Reshape so buffer skips WHOLE pixels, keeping RGBA grouped
+			sampled = pixels.view().reshape(-1, 4)[::buffer]
+			
+			return hashlib.md5(sampled.tobytes()).hexdigest()
+			
+		except Exception as e:
+			print(f"Failed to hash {img.name}: {e}")
+			return None
+
 
 
 class MCPREP_OT_replace_missing_textures(bpy.types.Operator):

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -270,46 +270,73 @@ class MCPREP_OT_combine_materials(bpy.types.Operator):
 class MCPREP_OT_combine_images(bpy.types.Operator):
 	bl_idname = "mcprep.combine_images"
 	bl_label = "Combine images"
-	bl_description = "Consolidate images with the same name (e.g. img.001 & img.002) and identical pixel data"
+	bl_description = "Merge duplicate images"
 	bl_options = {'REGISTER', 'UNDO'}
 
-	# arg to auto-force remove old? versus just keep as 0-users
+	group_by_name: bpy.props.BoolProperty(
+		name="Group Method: Image Name",
+		description="Finds images with the same name (ignoring extensions like .001)",
+		default=True)
+
 	selection_only: bpy.props.BoolProperty(
 		name="Selection only",
-		description=(
-			"Build images to consolidate based on selected objects' materials only"),
+		description="Build images to consolidate based on selected objects' materials only",
 		default=False)
-	skipUsage: bpy.props.BoolProperty(
-		default=False,
-		options={'HIDDEN'})
+
+	strict_comparison: bpy.props.BoolProperty(
+		name="Strict Comparison",
+		description="Check every single pixel. Slower, but 100% accurate",
+		default=False)
+
+	def invoke(self, context, event):
+		return context.window_manager.invoke_props_dialog(self)
 
 	track_function = "combine_images"
 	@tracking.report_error
 	def execute(self, context):
-		removeold = True
-
-		if self.selection_only and len(context.selected_objects) == 0:
-			self.report(
-				{'ERROR'},
-				"Either turn selection only off or select objects with materials/images")
-			return {'CANCELLED'}
+		# Setup image list
 		if self.selection_only:
-			self.report({'ERROR'}, (
-				"Combine images does not yet work for selection only, retry "
-				"with option disabled"))
-			return {'CANCELLED'}
+			if not context.selected_objects:
+				self.report({'ERROR'}, "Select objects with materials/images first")
+				return {'CANCELLED'}
 
-		images = bpy.data.images
-		precount = len(images)
+			target_images = set()
+			processed_materials = set()
+
+			for obj in context.selected_objects:
+				if not hasattr(obj.data, "materials"):
+					continue
+
+				for mat in obj.data.materials:
+					if not mat or mat in processed_materials:
+						continue
+
+					processed_materials.add(mat)
+					if mat.use_nodes and mat.node_tree:
+						for node in mat.node_tree.nodes:
+							if node.type == 'TEX_IMAGE' and node.image:
+								target_images.add(node.image)
+
+			if not target_images:
+				self.report({'INFO'}, "No images found in selection")
+				return {'FINISHED'}
+
+			images_to_check = list(target_images)
+		else:
+			images_to_check = list(bpy.data.images)
+
+		precount = len(bpy.data.images)
 
 		# Group images
 		groups = {}
-		for img in images:
+		for img in images_to_check:
 			if img.type in {'RENDER_RESULT', 'COMPOSITING'} or img.use_fake_user:
 				continue
 
-			base_name = util.nameGeneralize(img.name)
 			w, h = img.size
+
+			base_name = util.nameGeneralize(img.name) if self.group_by_name else "GLOBAL"
+
 			key = (base_name, w, h)
 			groups.setdefault(key, []).append(img)
 
@@ -324,42 +351,50 @@ class MCPREP_OT_combine_images(bpy.types.Operator):
 
 			# Internal cache for this group
 			fingerprints = {}
-			pixel_buffer = np.empty(w * h * 4, dtype=np.float32)	 #RGBA
+			is_empty = (w == 0 or h == 0)
+			pixel_buffer = None if is_empty else np.empty(w * h * 4, dtype=np.float32)	#RGBA
 
 			for img in img_list:
-				hash = self.get_image_hash(img, w, h, buffer=pixel_buffer)
+				hash = b"EMPTY" if is_empty else self.get_image_hash(img, w, h, buffer=pixel_buffer)
 
 				if not hash:
 					continue
 
 				if hash in fingerprints:
 					# Duplicate: remap to first image instance of hash
-					master_image = fingerprints[hash]
-					img.user_remap(master_image)
+					img.user_remap(fingerprints[hash])
 					images_to_remove.append(img)
 				else:
 					# Unique image: store as the master image for this hash
 					fingerprints[hash] = img
-					# Clean up the name of master image
-					if img.name != base_name and base_name not in images:
+					# Clean up name of master image ONLY if grouping by name
+					if self.group_by_name and img.name != base_name and base_name not in bpy.data.images:
 						img.name = base_name
 
 		# Cleanup
-		for img in images_to_remove:
-			if img.users == 0:
-				images.remove(img)
+		to_delete = [
+			img for img in images_to_remove
+			if img.users == 0 and not img.use_fake_user and not img.is_library_indirect]
 
-		postcount = len(images)
-		if precount - postcount > 0:
-			self.report({"INFO"}, f"Consolidated {precount} images down to {postcount}")
+		if to_delete:
+			for img in to_delete:
+				img.gl_free()
+				img.buffers_free()
+			bpy.data.batch_remove(ids=to_delete)
+
+		# Report
+		postcount = len(bpy.data.images)
+		consolidated_count = precount - postcount
+
+		if consolidated_count > 0:
+			self.report({"INFO"}, f"Consolidated {consolidated_count} image{'s' if consolidated_count > 1 else ''} (Total: {precount} -> {postcount})")
 		else:
-			self.report({"INFO"}, "No images found to condense")
-
+			self.report({"INFO"}, "No duplicates found")
 		return {'FINISHED'}
 
-	def get_image_hash(self, img: bpy.types.Image, w: int, h: int, buffer: np.ndarray = None) -> str:
+	def get_image_hash(self, img: bpy.types.Image, w: int, h: int, buffer: np.ndarray = None) -> bytes:
 		"""
-		Generates a byte-string hash from sampled image pixel data.
+		Generates a byte hash from sampled image pixel data.
 		"""
 		if not img.has_data:
 			return None
@@ -371,11 +406,14 @@ class MCPREP_OT_combine_images(bpy.types.Operator):
 			img.pixels.foreach_get(pixels)
 		except RuntimeError as e:
 			env.log(f"Failed to hash {img.name}: {e}", vv_only=True)
-			return None		
-		
-		#Calculate stride: if pixels > 4096, sample every Nth pixel
-		stride = max(1, total_pixels // 4096)
-		return pixels.reshape(-1, 4)[::stride * 4].tobytes()
+			return None
+
+		if self.strict_comparison:
+			return pixels.tobytes()
+		else:
+			#Calculate stride: if pixels > 4096, sample every Nth pixel
+			stride = max(1, total_pixels // 4096)
+			return pixels[::stride * 4].tobytes()
 
 
 class MCPREP_OT_replace_missing_textures(bpy.types.Operator):

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -270,22 +270,22 @@ class MCPREP_OT_combine_materials(bpy.types.Operator):
 class MCPREP_OT_combine_images(bpy.types.Operator):
 	bl_idname = "mcprep.combine_images"
 	bl_label = "Combine images"
-	bl_description = "Merge duplicate images"
+	bl_description = "Find and merge duplicate images, remapping users to a single image"
 	bl_options = {'REGISTER', 'UNDO'}
 
 	group_by_name: bpy.props.BoolProperty(
-		name="Group Method: Image Name",
-		description="Finds images with the same name (ignoring extensions like .001)",
+		name="Group by Name",
+		description="Compare duplicates using base names (e.g., 'Texture.001' matches 'Texture')",
 		default=True)
 
 	selection_only: bpy.props.BoolProperty(
 		name="Selection only",
-		description="Build images to consolidate based on selected objects' materials only",
+		description="Only check images used by materials on selected objects",
 		default=False)
 
 	strict_comparison: bpy.props.BoolProperty(
 		name="Strict Comparison",
-		description="Check every single pixel. Slower, but 100% accurate",
+		description="Compare full image content instead of samples. More accurate, but slower for large images",
 		default=False)
 
 	def invoke(self, context, event):
@@ -297,7 +297,7 @@ class MCPREP_OT_combine_images(bpy.types.Operator):
 		# Setup image list
 		if self.selection_only:
 			if not context.selected_objects:
-				self.report({'ERROR'}, "Select objects with materials/images first")
+				self.report({'ERROR'}, "No objects selected")
 				return {'CANCELLED'}
 
 			target_images = set()
@@ -388,7 +388,7 @@ class MCPREP_OT_combine_images(bpy.types.Operator):
 		consolidated_count = precount - postcount
 
 		if consolidated_count > 0:
-			self.report({"INFO"}, f"Consolidated {consolidated_count} image{'s' if consolidated_count > 1 else ''} (Total: {precount} -> {postcount})")
+			self.report({"INFO"}, f"Consolidated {consolidated_count} duplicate image{'s' if consolidated_count != 1 else ''} (Total: {precount} -> {postcount})")
 		else:
 			self.report({"INFO"}, "No duplicates found")
 		return {'FINISHED'}

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -293,7 +293,6 @@ class MCPREP_OT_combine_images(bpy.types.Operator):
 				{'ERROR'},
 				"Either turn selection only off or select objects with materials/images")
 			return {'CANCELLED'}
-
 		if self.selection_only:
 			self.report({'ERROR'}, (
 				"Combine images does not yet work for selection only, retry "
@@ -312,10 +311,9 @@ class MCPREP_OT_combine_images(bpy.types.Operator):
 			base_name = util.nameGeneralize(img.name)
 			w, h = img.size
 			key = (base_name, w, h)
-
 			groups.setdefault(key, []).append(img)
-		images_to_remove = []
 
+		images_to_remove = []
 
 		# Hashing and Remapping
 		for (base_name, w, h), img_list in groups.items():
@@ -325,9 +323,7 @@ class MCPREP_OT_combine_images(bpy.types.Operator):
 			img_list.sort(key=lambda x: x.name)
 
 			# Internal cache for this group
-			# {hash: image}
 			fingerprints = {}
-
 			pixel_buffer = np.empty(w * h * 4, dtype=np.float32)	 #RGBA
 
 			for img in img_list:
@@ -344,7 +340,6 @@ class MCPREP_OT_combine_images(bpy.types.Operator):
 				else:
 					# Unique image: store as the master image for this hash
 					fingerprints[hash] = img
-
 					# Clean up the name of master image
 					if img.name != base_name and base_name not in images:
 						img.name = base_name
@@ -369,21 +364,18 @@ class MCPREP_OT_combine_images(bpy.types.Operator):
 		if not img.has_data:
 			return None
 
+		total_pixels = w * h
+		pixels = buffer if buffer is not None else np.empty(total_pixels * 4, dtype=np.float32)
+
 		try:
-			total_pixels = w * h
-			pixels = buffer if buffer is not None else np.empty(total_pixels * 4, dtype=np.float32)
-
 			img.pixels.foreach_get(pixels)
-
-			# Calculate stride: if pixels > 4096, sample every Nth pixel
-			stride = max(1, total_pixels // 4096)
-
-			return pixels[::stride * 4].tobytes()
-
-		except Exception as e:
+		except RuntimeError as e:
 			env.log(f"Failed to hash {img.name}: {e}", vv_only=True)
-			return None
-
+			return None		
+		
+		#Calculate stride: if pixels > 4096, sample every Nth pixel
+		stride = max(1, total_pixels // 4096)
+		return pixels[::stride * 4].tobytes()
 
 
 class MCPREP_OT_replace_missing_textures(bpy.types.Operator):

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -306,57 +306,61 @@ class MCPREP_OT_combine_images(bpy.types.Operator):
 				"with option disabled"))
 			return {'CANCELLED'}
 
-		data = bpy.data.images
-		precount = len(data)
+		images = bpy.data.images
+		precount = len(images)
 
 		# Group images
 		groups = {}
-		for im in data:
-			if im.type == 'RENDER_RESULT': continue
-
-			base_name = util.nameGeneralize(im.name)
-			group_key = (base_name, im.size[0], im.size[1])
-
-			if group_key not in groups:
-				groups[group_key] = []
-			groups[group_key].append(im)
-
-		# Process groups
-		for key, im_list in groups.items():
-			if len(im_list) < 2:
+		for img in images:
+			if img.type in {'RENDER_RESULT', 'COMPOSITING'} or img.use_fake_user:
 				continue
 
-			im_list.sort(key=lambda x: x.name)
+			base_name = util.nameGeneralize(img.name)
+			w, h = img.size
+			key = (base_name, w, h)
 
-			target_img = im_list[0]
-			target_hash = self.get_image_hash(target_img)
+			groups.setdefault(key, []).append(img)
+		images_to_remove = []
 
-			if not target_hash:
+
+		# Hashing and Remapping
+		for (base_name, w, h), img_list in groups.items():
+			if len(img_list) < 2:
 				continue
 
-			for i in range(1, len(im_list)):
-				current_img = im_list[i]
+			img_list.sort(key=lambda x: x.name)
 
-				# skip if fake user set
-				if current_img.use_fake_user:
+			# Internal cache for this group
+			# {hash: image}
+			fingerprints = {}
+
+			pixel_buffer = np.empty(w * h * 4, dtype=np.float32)	 #RGBA
+
+			for img in img_list:
+				hash = self.get_image_hash(img, w, h, buffer=pixel_buffer)
+
+				if not hash:
 					continue
 
-				current_hash = self.get_image_hash(current_img)
-
-				if current_hash == target_hash:
-					current_img.user_remap(target_img)
-					if removeold and current_img.users == 0:
-						data.remove(current_img)
+				if hash in fingerprints:
+					# Duplicate: remap to first image instance of hash
+					master_image = fingerprints[hash]
+					img.user_remap(master_image)
+					images_to_remove.append(img)
 				else:
-					continue
+					# Unique image: store as the master image for this hash
+					fingerprints[hash] = img
 
-			# Rename target to clean base name
-			clean_name = key[0]
-			if target_img.name != clean_name:
-				if clean_name not in data or data[clean_name].users == 0:
-					target_img.name = clean_name
+					# Clean up the name of master image
+					if img.name != base_name and base_name not in images:
+						img.name = base_name
 
-		postcount = len(data)
+		# Cleanup
+		for img in images_to_remove:
+			if img.users == 0:
+				images.remove(img)
+
+		postcount = len(images)
 		if precount - postcount > 0:
 			self.report({"INFO"}, f"Consolidated {precount} images down to {postcount}")
 		else:
@@ -364,27 +368,28 @@ class MCPREP_OT_combine_images(bpy.types.Operator):
 
 		return {'FINISHED'}
 
-	def get_image_hash(self, img):
-		"""Generates a MD5 hash from image pixel data"""
-		
-		if not img.has_data or sum(img.size) == 0:
+	def get_image_hash(self, img: bpy.types.Image, w: int, h: int, buffer: np.ndarray = None) -> str:
+		"""
+		Generates a MD5 hash from image pixel data
+		"""
+		if not img.has_data:
 			return None
 
 		try:
-			width, height = img.size
-			pixels = np.empty(width * height * 4, dtype=np.float32)
-			img.pixels.foreach_get(pixels)
-			
-			# Calculate buffer (sample every Nth pixel), only start buffering when image is larger than 4096 pixels (bigger than 64 x 64)
-			buffer = max(1, (width * height) // 4096)
+			total_pixels = w * h
+			pixels = buffer if buffer is not None else np.empty(total_pixels * 4, dtype=np.float32)
 
-			# Reshape so buffer skips WHOLE pixels, keeping RGBA grouped
-			sampled = pixels.view().reshape(-1, 4)[::buffer]
-			
-			return hashlib.md5(sampled.tobytes()).hexdigest()
-			
+			img.pixels.foreach_get(pixels)
+
+			# Calculate stride (sample every Nth pixel), only start when image is larger than 4096 pixels (bigger than 64 x 64)
+			stride = max(1, total_pixels // 4096)
+
+			sample = np.ascontiguousarray(pixels[::stride * 4])
+
+			return hashlib.md5(sample.data).hexdigest()
+
 		except Exception as e:
-			print(f"Failed to hash {img.name}: {e}")
+			env.log(f"Failed to hash {img.name}: {e}", vv_only=True)
 			return None
 
 

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -314,8 +314,9 @@ class MCPREP_OT_combine_images(bpy.types.Operator):
 					processed_materials.add(mat)
 					if mat.use_nodes and mat.node_tree:
 						for node in mat.node_tree.nodes:
-							if node.type == 'TEX_IMAGE' and node.image:
-								target_images.add(node.image)
+							if node.type != 'TEX_IMAGE' or not node.image:
+								continue
+							target_images.add(node.image)
 
 			if not target_images:
 				self.report({'INFO'}, "No images found in selection")
@@ -330,7 +331,7 @@ class MCPREP_OT_combine_images(bpy.types.Operator):
 		# Group images
 		groups = {}
 		for img in images_to_check:
-			if img.type in {'RENDER_RESULT', 'COMPOSITING'} or img.use_fake_user:
+			if img.type in ('RENDER_RESULT', 'COMPOSITING') or img.use_fake_user:
 				continue
 
 			w, h = img.size

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -375,7 +375,7 @@ class MCPREP_OT_combine_images(bpy.types.Operator):
 		
 		#Calculate stride: if pixels > 4096, sample every Nth pixel
 		stride = max(1, total_pixels // 4096)
-		return pixels[::stride * 4].tobytes()
+		return pixels.reshape(-1, 4)[::stride * 4].tobytes()
 
 
 class MCPREP_OT_replace_missing_textures(bpy.types.Operator):

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -21,6 +21,9 @@ import os
 
 import bpy
 
+import hashlib
+import numpy as np
+
 from . import generate
 from . import sequences
 from .. import tracking
@@ -318,15 +321,6 @@ class MCPREP_OT_combine_images(bpy.types.Operator):
 				name_cat[base].append(im.name)
 			else:
 				env.log("Skipping, already added image", vv_only=True)
-
-		# pre 2.78 solution, deep loop
-		if bpy.app.version < (2, 78):
-			for ob in bpy.data.objects:
-				for sl in ob.material_slots:
-					if sl is None or sl.material is None or sl.material not in data:
-						continue  # selection only
-					sl.material = data[name_cat[util.nameGeneralize(sl.material.name)][0]]
-			# doesn't remove old textures, but gets it to zero users
 
 			postcount = len(["x" for x in bpy.data.materials if x.users > 0])
 			self.report(

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -331,64 +331,69 @@ class MCPREP_OT_combine_images(bpy.types.Operator):
 		precount = len(bpy.data.images)
 
 		# Group images
-		#
-		# Here we use a list, since we're just trying to get the
-		# raw images at this point for comparison
 		groups: List[Tuple[str, int, int, bpy.types.Image]] = []
 		for img in images_to_check:
 			if img.type in ('RENDER_RESULT', 'COMPOSITING') or img.use_fake_user:
 				continue
-
 			w, h = img.size
-			
+			# No data or empty image, nothing to compare, skip
+			if w == 0 or h == 0 or not img.has_data:
+				continue
+
 			base_name = util.nameGeneralize(img.name) if self.group_by_name else "GLOBAL"
 			groups.append((base_name, w, h, img))
 
 		# Comparison and Remapping
-		#
-		# We store both the image (for remapping later on)
-		# and the array, mainly to avoid constant conversion
-		unique_images: Dict[Tuple[str, int, int], List[Tuple[bpy.types.Image, NDArray[np.float64]]]] = {}
+		# Key: (base_name, w, h)
+		# Value: List of (image_obj, comparison_array, sum)
+		# store both the image (for remapping later on), the pixel array,
+		# and pixel array sum for super fast prefilter
+		unique_images: Dict[Tuple[str, int, int], List[Tuple[bpy.types.Image, NDArray[np.float32], float]]] = {}
 		images_to_remove = []
+
 		for base_name, w, h, img in groups:
-			# If the tuple is not accounted for yet, then add to 
-			# unique images and continue
-			#
-			# Images with the same base name but different widths
-			# and heights are considered unique images since their
-			# resolutions are different
-			if (base_name, w, h) not in unique_images:
-				unique_images[(base_name, w, h)] = [(img, np.asarray(img.pixels))]
-				continue
-			# No data, then don't bother, there's nothing to compare
-			elif not img.has_data:
-				continue
-			# Empty images can't be compared, don't do anything
-			# with them
-			elif w == 0 or h == 0:
+			cur_img_key = (base_name, w, h)
+
+			num_pixels = w * h * 4
+			img_array = np.empty(num_pixels, dtype=np.float32)
+			img.pixels.foreach_get(img_array)	# faster than `np.asarray(img.pixels)`
+
+			# Use sampling unless strict is enabled
+			# 16384 = 4096 * 4
+			stride = max(1, num_pixels // 16384) if not self.strict_comparison else 1
+			cur_img_data = img_array[::stride] if stride > 1 else img_array
+
+			pix_sum = np.sum(cur_img_data)
+
+			if cur_img_key not in unique_images:
+				unique_images[cur_img_key] = [(img, cur_img_data, pix_sum)]
 				continue
 
 			image_present = False
 			present_image: Optional[bpy.types.Image] = None
-			img_array = np.asarray(img.pixels)
-			for uni_image, uni_image_array in unique_images[(base_name, w, h)]:
-				if not np.array_equal(uni_image_array, img_array):
+
+			# Look through existing items in this Name/Size group
+			for uni_image, uni_data, uni_sum in unique_images[cur_img_key]:
+				# FAST PREFILTER
+				if not pix_sum == uni_sum:
+					continue
+				elif not np.array_equal(uni_data, cur_img_data):
 					continue
 				image_present = True
 				present_image = uni_image
 				break
 
+
 			# If the image is present already, mark it
-			# for removal, remap, and continue to the next
-			# image
+			# for removal, remap, and continue to the next image
 			if image_present:
 				images_to_remove.append(img)
-				img.user_remap(present_image)	
+				img.user_remap(present_image)
 				continue
 
 			# If the image is not present, add it to the list
-			unique_images[(base_name, w, h)].append((img, img_array))
-			
+			unique_images[cur_img_key].append((img, cur_img_data, pix_sum))
+
 		# Cleanup
 		to_delete = [
 			img for img in images_to_remove

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -149,7 +149,7 @@ class MCPREP_OT_combine_materials(bpy.types.Operator):
 	# arg to auto-force remove old? versus just keep as 0-users
 	selection_only: bpy.props.BoolProperty(
 		name="Selection only",
-		description="Build materials to consoldiate based on selected objects only",
+		description="Build materials to consolidate based on selected objects only",
 		default=True)
 	skipUsage: bpy.props.BoolProperty(default=False, options={'HIDDEN'})
 
@@ -277,7 +277,7 @@ class MCPREP_OT_combine_images(bpy.types.Operator):
 	selection_only: bpy.props.BoolProperty(
 		name="Selection only",
 		description=(
-			"Build images to consoldiate based on selected objects' materials only"),
+			"Build images to consolidate based on selected objects' materials only"),
 		default=False)
 	skipUsage: bpy.props.BoolProperty(
 		default=False,

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -18,10 +18,12 @@
 
 
 import os
+from typing import Dict, List, Optional, Tuple
 
 import bpy
 
 import numpy as np
+from numpy.typing import NDArray
 
 from . import generate
 from . import sequences
@@ -329,60 +331,64 @@ class MCPREP_OT_combine_images(bpy.types.Operator):
 		precount = len(bpy.data.images)
 
 		# Group images
-		groups = {}
+		#
+		# Here we use a list, since we're just trying to get the
+		# raw images at this point for comparison
+		groups: List[Tuple[str, int, int, bpy.types.Image]] = []
 		for img in images_to_check:
 			if img.type in ('RENDER_RESULT', 'COMPOSITING') or img.use_fake_user:
 				continue
 
 			w, h = img.size
-
+			
 			base_name = util.nameGeneralize(img.name) if self.group_by_name else "GLOBAL"
-
-			key = (base_name, w, h)
-			groups.setdefault(key, []).append(img)
-
-		images_to_remove = []
+			groups.append((base_name, w, h, img))
 
 		# Comparison and Remapping
-		for (base_name, w, h), img_list in groups.items():
-			if len(img_list) < 2:
+		#
+		# We store both the image (for remapping later on)
+		# and the array, mainly to avoid constant conversion
+		unique_images: Dict[Tuple[str, int, int], List[Tuple[bpy.types.Image, NDArray[np.float64]]]] = {}
+		images_to_remove = []
+		for base_name, w, h, img in groups:
+			# If the tuple is not accounted for yet, then add to 
+			# unique images and continue
+			#
+			# Images with the same base name but different widths
+			# and heights are considered unique images since their
+			# resolutions are different
+			if (base_name, w, h) not in unique_images:
+				unique_images[(base_name, w, h)] = [(img, np.asarray(img.pixels))]
+				continue
+			# No data, then don't bother, there's nothing to compare
+			elif not img.has_data:
+				continue
+			# Empty images can't be compared, don't do anything
+			# with them
+			elif w == 0 or h == 0:
 				continue
 
-			img_list.sort(key=lambda x: x.name)
-
-			# Internal cache for this group
-			unique_contents = {}
-			is_empty = (w == 0 or h == 0)
-			pixel_buffer = None if is_empty else np.empty(w * h * 4, dtype=np.float32)	#RGBA
-			
-			total_pixels = w * h
-
-			stride = max(1, total_pixels // 4096) if not self.strict_comparison and total_pixels > 4096 else 1
-
-			for img in img_list:
-				if pixel_buffer is None:
-					content_key = "EMPTY"
-				elif not img.has_data:
+			image_present = False
+			present_image: Optional[bpy.types.Image] = None
+			img_array = np.asarray(img.pixels)
+			for uni_image, uni_image_array in unique_images[(base_name, w, h)]:
+				if not np.array_equal(uni_image_array, img_array):
 					continue
-				else:
-					try:
-						img.pixels.foreach_get(pixel_buffer)
-						content_key = pixel_buffer.reshape(-1, 4)[::stride].tobytes()
-					except RuntimeError as e:
-						env.log(f"Failed to hash {img.name}: {e}", vv_only=True)
-						continue
+				image_present = True
+				present_image = uni_image
+				break
 
-				if content_key in unique_contents:
-					# Duplicate: remap to first image instance of hash
-					img.user_remap(unique_contents[content_key])
-					images_to_remove.append(img)
-				else:
-					# Unique image: store as the master image for this hash
-					unique_contents[content_key] = img
-					# Clean up name of master image ONLY if grouping by name
-					if self.group_by_name and img.name != base_name and base_name not in bpy.data.images:
-						img.name = base_name
+			# If the image is present already, mark it
+			# for removal, remap, and continue to the next
+			# image
+			if image_present:
+				images_to_remove.append(img)
+				img.user_remap(present_image)	
+				continue
 
+			# If the image is not present, add it to the list
+			unique_images[(base_name, w, h)].append((img, img_array))
+			
 		# Cleanup
 		to_delete = [
 			img for img in images_to_remove

--- a/test_files/materials_test.py
+++ b/test_files/materials_test.py
@@ -982,6 +982,14 @@ class MaterialsTest(unittest.TestCase):
         bpy.ops.mcprep.combine_images()
         self.assertEqual(init_count, len(bpy.data.images))
 
+    def test_combine_images_strict_comparision(self):
+        img1 = bpy.data.images.new("CombineImages", width=1, height=1)
+        init_count = len(bpy.data.images)
+        img2 = bpy.data.images.new("CombineImages", width=1, height=1)
+        self.assertNotEqual(img1.id_data, img2.id_data)
+        bpy.ops.mcprep.combine_images(strict_comparison=True)
+        self.assertEqual(init_count, len(bpy.data.images))
+
     def test_uv_scale(self):
         bpy.ops.mesh.primitive_plane_add()
         bpy.ops.object.editmode_toggle()


### PR DESCRIPTION
The current `Combine Images` operator can accidentally merge different image textures, which can sometimes cause a headache. So I upgraded the operator to use MD5 Pixel Hashing and compare the actual image data to verify they are identical before merging.

Also added 'UNDO' to the bl_options so Blender does not crash if the user undoes that step.