### PR TITLE
Improved Material Consolidation with Node Tree Analysis

### DIFF
--- a/MCprep_addon/__init__.py
+++ b/MCprep_addon/__init__.py
@@ -36,7 +36,7 @@ Disclaimer: This is not an official Google product
 
 # ----------------------------- For any developer ---------------------------- #
 # Increment this number for each time you get a "inconsistent use of spaces and tab error"
-# 								error = 51
+# 								error = 52
 
 bl_info = {
 	"name": "MCprep",

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -232,36 +232,36 @@ class MaterialFingerprint:
 
 # --- SERIALIZATION HELPERS ---
 
-def serialize_fcurve(fcurve: bpy.types.FCurve) -> FCurveData:
+def serialize_fcurve(precision: int, fcurve: bpy.types.FCurve) -> FCurveData:
 	"""
 	Converts an F-Curve data-block into a dictionary of primitive values for structural comparison.
 	"""
 	fcurve.keyframe_points.sort()
 
 	return FCurveData(
-        array_index=fcurve.array_index,
-        extrapolation=fcurve.extrapolation,
-        auto_smoothing=fcurve.auto_smoothing,
-        mute=fcurve.mute,
-        keyframes=[serialize_keyframe(kp) for kp in fcurve.keyframe_points]
-    )
+		array_index=fcurve.array_index,
+		extrapolation=fcurve.extrapolation,
+		auto_smoothing=fcurve.auto_smoothing,
+		mute=fcurve.mute,
+		keyframes=[serialize_keyframe(precision, kp) for kp in fcurve.keyframe_points]
+	)
 
-def serialize_keyframe(kp: bpy.types.Keyframe) -> KeyframeData:
+def serialize_keyframe(precision: int, kp: bpy.types.Keyframe) -> KeyframeData:
 	"""
 	Serializes individual keyframe points, rounding float values to ensure consistent hashing.
 	"""
 	return KeyframeData(
-        co=(round(kp.co[0]), round(kp.co[1])),
-        handles=(
-            round(kp.handle_left[0]), round(kp.handle_left[1]),
-            round(kp.handle_right[0]), round(kp.handle_right[1])
-        ),
-        types=(kp.handle_left_type, kp.handle_right_type, kp.interpolation, kp.easing),
-        dynamics=(round(kp.back), round(kp.amplitude), round(kp.period))
-    )
+		co=(round(kp.co[0], precision), round(kp.co[1], precision)),
+		handles=(
+			round(kp.handle_left[0], precision), round(kp.handle_left[1], precision),
+			round(kp.handle_right[0], precision), round(kp.handle_right[1], precision)
+		),
+		types=(kp.handle_left_type, kp.handle_right_type, kp.interpolation, kp.easing),
+		dynamics=(round(kp.back, precision), round(kp.amplitude, precision), round(kp.period, precision))
+	)
 
 # --- ANIMATION & DRIVER LOGIC ---
-def get_animation_fingerprint(id_data: bpy.types.ID, data_path: Optional[str] = None, array_index: Optional[int] = None) -> Optional[List[FCurveData]]:
+def get_animation_fingerprint(precision: int, id_data: bpy.types.ID, data_path: Optional[str] = None, array_index: Optional[int] = None) -> Optional[List[FCurveData]]:
 	"""
 	Retrieves the animation data for a specific property or data-block as a serializable fingerprint.
 	"""
@@ -273,12 +273,12 @@ def get_animation_fingerprint(id_data: bpy.types.ID, data_path: Optional[str] = 
 	if data_path:
 		fcurve = next((f for f in action.fcurves if f.data_path == data_path and
 					  (array_index is None or f.array_index == array_index)), None)
-		return [serialize_fcurve(fcurve)] if fcurve else None
+		return [serialize_fcurve(precision, fcurve)] if fcurve else None
 
 	fcurves = sorted(action.fcurves, key=lambda f: (f.data_path, f.array_index))
-	return [serialize_fcurve(f) for f in fcurves]
+	return [serialize_fcurve(precision, f) for f in fcurves]
 
-def get_driver_fingerprint(id_data: bpy.types.ID, data_path: str, array_index: Optional[int] = None) -> Optional[DriverFingerprint]:
+def get_driver_fingerprint(precision: int, id_data: bpy.types.ID, data_path: str, array_index: Optional[int] = None) -> Optional[DriverFingerprint]:
 	"""
 	Captures driver expressions, variables, and modifier stacks into a serializable structure.
 	"""
@@ -336,7 +336,7 @@ def get_driver_fingerprint(id_data: bpy.types.ID, data_path: str, array_index: O
 		m_data: Dict[str, Primitive] = {}
 		for prop in mod.bl_rna.properties:
 			if not prop.is_readonly and prop.identifier not in {'name', 'type', 'is_active'}:
-				m_data[prop.identifier] = to_primitive(getattr(mod, prop.identifier))
+				m_data[prop.identifier] = to_primitive(getattr(mod, prop.identifier), precision)
 		
 		modifiers.append(DriverModifierData(mod_type=mod.type, settings=m_data))
 
@@ -350,7 +350,7 @@ def get_driver_fingerprint(id_data: bpy.types.ID, data_path: str, array_index: O
 
 # --- NODE TREE ANALYSIS ---
 
-def get_material_fingerprint(material: bpy.types.Material, exclude_settings: bool, use_action_names: bool) -> MaterialFingerprint:
+def get_material_fingerprint(material: bpy.types.Material, exclude_settings: bool, use_action_names: bool,	precision: int) -> MaterialFingerprint:
 	"""
 	Generates a unique signature of a material's node tree and render settings to identify duplicates.
 	"""
@@ -367,12 +367,12 @@ def get_material_fingerprint(material: bpy.types.Material, exclude_settings: boo
 
 	if not material.node_tree:
 		mat_type = "FIXED_MAT"
-		diffuse = to_primitive(material.diffuse_color)
-		roughness = to_primitive(material.roughness)
-		metallic = to_primitive(material.metallic)
+		diffuse = to_primitive(material.diffuse_color, precision)
+		roughness = to_primitive(material.roughness, precision)
+		metallic = to_primitive(material.metallic, precision)
 	else:
 		mat_type = "NODE_TREE"
-		node_tree_data = get_node_group_fingerprint(material.node_tree)
+		node_tree_data = get_node_group_fingerprint(material.node_tree, precision)
 
 	# Gather Animation
 	if use_action_names:
@@ -394,7 +394,7 @@ def get_material_fingerprint(material: bpy.types.Material, exclude_settings: boo
 			if prop.is_readonly or prop.identifier in IGNORE_MAT_SETTINGS:
 				continue
 
-			val_data = PropertyEntry(val=to_primitive(getattr(material, prop.identifier)))
+			val_data = PropertyEntry(val=to_primitive(getattr(material, prop.identifier), precision))
 
 			# Check for driver
 			driver = get_driver_fingerprint(precision, material, prop.identifier)
@@ -413,9 +413,9 @@ def get_material_fingerprint(material: bpy.types.Material, exclude_settings: boo
 
 				value = getattr(la, prop.identifier)
 				if hasattr(value, "__iter__") and not isinstance(value, (str, bytes)):
-					value = [to_primitive(v) for v in value]
+					value = [to_primitive(v, precision) for v in value]
 				else:
-					value = to_primitive(value)
+					value = to_primitive(value, precision)
 
 				val_data = PropertyEntry(val=value)
 
@@ -439,7 +439,7 @@ def get_material_fingerprint(material: bpy.types.Material, exclude_settings: boo
 		line_art_settings=line_art_settings
 	)
 
-def get_node_group_fingerprint(node_tree: bpy.types.NodeTree) -> Optional[NodeTreeFingerprint]
+def get_node_group_fingerprint(node_tree: bpy.types.NodeTree, precision: int) -> Optional[NodeTreeFingerprint]:
 	"""
 	Recursively maps the connected node network, properties, and internal group contents.
 	"""
@@ -457,11 +457,11 @@ def get_node_group_fingerprint(node_tree: bpy.types.NodeTree) -> Optional[NodeTr
 			if prop.identifier in IGNORE_PROPS or prop.is_readonly: continue
 			data_path = f'nodes["{node.name}"].{prop.identifier}'
 
-			prop_entry = {"val": to_primitive(getattr(node, prop.identifier))}
+			prop_entry = {"val": to_primitive(getattr(node, prop.identifier), precision)}
 
 			# Check Driver & Anim
-			driver = get_driver_fingerprint(node_tree, data_path)
-			anim = get_animation_fingerprint(node_tree, data_path)
+			driver = get_driver_fingerprint(precision, node_tree, data_path)
+			anim = get_animation_fingerprint(precision, node_tree, data_path)
 			if driver: prop_entry["driver"] = driver
 			if anim: prop_entry["animation"] = anim
 
@@ -477,11 +477,11 @@ def get_node_group_fingerprint(node_tree: bpy.types.NodeTree) -> Optional[NodeTr
 
 			# Scalar
 			if isinstance(default_val, (int, float)):
-				input_data = {"idx": socket_idx, "val": to_primitive(default_val)}
+				input_data = {"idx": socket_idx, "val": to_primitive(default_val, precision)}
 
 				# Check Driver & Anim
-				driver = get_driver_fingerprint(node_tree, data_path)
-				anim = get_animation_fingerprint(node_tree, data_path)
+				driver = get_driver_fingerprint(precision, node_tree, data_path)
+				anim = get_animation_fingerprint(precision, node_tree, data_path)
 				if driver: input_data["driver"] = driver
 				if anim: input_data["animation"] = anim
 
@@ -497,8 +497,8 @@ def get_node_group_fingerprint(node_tree: bpy.types.NodeTree) -> Optional[NodeTr
 						"val": value if isinstance(value, str) else round(value, 6)}
 
 					# Check Driver & Anim
-					driver = get_driver_fingerprint(node_tree, data_path, array_idx)
-					anim = get_animation_fingerprint(node_tree, data_path, array_idx)
+					driver = get_driver_fingerprint(precision, node_tree, data_path, array_idx)
+					anim = get_animation_fingerprint(precision, node_tree, data_path, array_idx)
 					if driver: input_data["driver"] = driver
 					if anim: input_data["animation"] = anim
 
@@ -506,7 +506,7 @@ def get_node_group_fingerprint(node_tree: bpy.types.NodeTree) -> Optional[NodeTr
 
 
 		if node.bl_idname in ('ShaderNodeGroup', 'GeometryNodeGroup') and node.node_tree: # 'GeometryNodeGroup' included for future merge geoNode operator
-			node_data["group_content"] = get_node_group_fingerprint(node.node_tree)
+			node_data["group_content"] = get_node_group_fingerprint(node.node_tree, precision)
 		nodes_data.append(node_data)
 
 	links_data = []
@@ -542,18 +542,18 @@ def count_total_nodes(material: bpy.types.Material) -> int:
 
 	return _recursive_count(material.node_tree)
 
-def to_primitive(val: Any) -> Primitive:
+def to_primitive(val, decimals: int = 4) -> Primitive:
 	"""
 	Converts Blender-specific data types into standard Python primitives for serialization.
 	"""
 	if isinstance(val, (int, float)):
-		return round(val, 6)
+		return round(val, decimals)
 	elif isinstance(val, (str, bool, type(None))):
 		return val
 	elif hasattr(val, "to_list"):
-		return [round(x, 6) for x in val.to_list()]
+		return [round(x, decimals) for x in val.to_list()]
 	elif hasattr(val, "__iter__"):
-		return [to_primitive(x) for x in val]
+		return [to_primitive(x, decimals) for x in val]
 	return str(val)
 
 def trace_socket(socket: bpy.types.NodeSocket) -> bpy.types.NodeSocket:
@@ -648,6 +648,12 @@ class MCPREP_OT_combine_materials(bpy.types.Operator):
 		description="If true, materials with identical animation but different Action names will be kept separate",
 		default=False)
 
+	precision: bpy.props.IntProperty(
+		name="Matching Precision",
+		description="Number of decimal places to round values to when comparing. Higher = stricter",
+		min=0, max=6,
+		default=4)
+
 	def invoke(self, context, event):
 		return context.window_manager.invoke_props_dialog(self)
 
@@ -682,7 +688,7 @@ class MCPREP_OT_combine_materials(bpy.types.Operator):
 
 		for mat in materials_to_check:
 			group_key = util.nameGeneralize(mat.name) if self.group_by_name else "GLOBAL"
-			fp = get_material_fingerprint(mat, self.exclude_mat_settings, self.use_action_names)
+			fp = get_material_fingerprint(mat, self.exclude_mat_settings, self.use_action_names, self.precision)
 
 			if group_key not in fingerprint_groups:
 				fingerprint_groups[group_key] = []

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -135,7 +135,7 @@ class ListMaterials(bpy.types.PropertyGroup):
 	# inherited: name
 	description: bpy.props.StringProperty()
 	path: bpy.props.StringProperty(subtype='FILE_PATH')
-	index: bpy.props.IntProperty(min=0, default=0)  # for icon drawing
+	index: bpy.props.IntProperty(min=0, default=0)	# for icon drawing
 
 
 # -----------------------------------------------------------------------------
@@ -323,7 +323,7 @@ def get_animation_fingerprint(precision: int, id_data: bpy.types.ID, data_path: 
 	# Return None if no valid (multi-keyframe) curves were found
 	return results if results else None
 
-def get_driver_fingerprint(precision: int, id_data: bpy.types.ID, data_path: str, array_index: int = 0) -> Optional[DriverFingerprint]:
+def get_driver_fingerprint(precision: int, id_data: bpy.types.ID, data_path: str, array_index: int = -1) -> Optional[DriverFingerprint]:
 	"""Captures drivers math (expression), inputs (variables), and modifiers."""
 
 	if not id_data.animation_data or not id_data.animation_data.drivers:
@@ -348,7 +348,7 @@ def get_driver_fingerprint(precision: int, id_data: bpy.types.ID, data_path: str
 				id_name=getattr(tar.id, "name_full", tar.id.name) if tar.id else ""
 			)
 
-			# 4. Contextual Logic: Only capture attributes relevant to the variable type.
+			# - Contextual Logic: Only capture attributes relevant to the variable type.
 			# This prevents "noise" / irrelevant unused attributes in the driver results
 			
 			# - Property based variables (getting a value from a UI field)
@@ -537,10 +537,29 @@ def get_node_group_fingerprint(node_tree: bpy.types.NodeTree, precision: int) ->
 	# doesn't change if the user re-wired nodes in a different sequence.
 	return NodeTreeFingerprint(nodes=nodes_data, links=sorted(links_data, key=lambda x: str(x)))
 
-def count_total_nodes(material: bpy.types.Material) -> int:
+def node_tree_counter(node_tree: bpy.types.NodeTree) -> int:
 	"""
 	Counts all functional nodes. If a NodeGroup is found, 
 	it enters that sub-tree and adds those nodes to the total count.
+	"""
+	count = 0
+	for node in node_tree.nodes:
+		# Frames and Reroutes are organizational, not functional
+		if node.bl_idname in ('NodeFrame', 'NodeReroute'):
+			continue
+		count += 1
+
+		# If it's a group, count its internal nodes too
+		if node.bl_idname == 'ShaderNodeGroup' and node.node_tree:
+			count += node_tree_counter(node.node_tree)
+	return count
+
+def count_nodes_in_material(material: bpy.types.Material) -> int:
+	"""Wrapper that performs a recursive count of all functional nodes within a material and its nested node groups."""
+	if not material.node_tree:
+		return 0
+	return node_tree_counter(material.node_tree)
+
 def serialize_value(val, decimals: int = 4) -> Primitive:
 	"""
 	Standardizes Blender's internal math types into Python-native primitives.
@@ -568,20 +587,25 @@ def serialize_value(val, decimals: int = 4) -> Primitive:
 		
 	return val
 
-def trace_socket(socket: bpy.types.NodeSocket) -> bpy.types.NodeSocket:
+def trace_socket(dest_socket: bpy.types.NodeSocket) -> bpy.types.NodeSocket:
 	"""Follows a node socket link back to its source, traversing reroute nodes."""
-	Follows a node socket link back to its source, traversing reroute nodes.
-	"""
-	if not socket or not socket.is_linked:
-		return socket
-	current_link = socket.links[0]
+	if not dest_socket or not dest_socket.is_linked:
+		return dest_socket
+	
+	# Start at the first link connected to the destination socket
+	current_link = dest_socket.links[0]
 	source_node = current_link.from_node
+
+	# If the source is a reroute, we need to walk "behind" it recursively
 	while source_node and source_node.bl_idname == 'NodeReroute':
-		if source_node.inputs[0].is_linked:
-			current_link = source_node.inputs[0].links[0]
-			source_node = current_link.from_node
-		else:
-			return source_node.inputs[0]
+		reroute_input = source_node.inputs[0]
+		if not reroute_input.is_linked:
+			return reroute_input
+		
+		current_link = reroute_input.links[0]
+		source_node = current_link.from_node
+
+	# Once we hit a non-reroute node, return the actual source output socket
 	return current_link.from_socket
 
 def get_connected_nodes(node_tree: bpy.types.NodeTree) -> Set[bpy.types.Node]:
@@ -592,18 +616,22 @@ def get_connected_nodes(node_tree: bpy.types.NodeTree) -> Set[bpy.types.Node]:
 	"""
 	if not node_tree:
 		return set()
-	outputNodes = [n for n in node_tree.nodes if n.bl_idname in ('ShaderNodeOutputMaterial', 'NodeGroupOutput')]
+	
+	# Identify the starting output node of the data flow - typically the Material Output node, but also Group Outputs for nested groups
+	outputs = [n for n in node_tree.nodes if n.bl_idname in ('ShaderNodeOutputMaterial', 'NodeGroupOutput')]
 	connected = set()
-	queue = deque(outputNodes)
+	queue = deque(outputs)
+
+	# Breadth-first search through the node tree, following links backwards from outputs to inputs
 	while queue:
 		node = queue.popleft()
-		if node in connected: continue
+		if node in connected:
+			continue
 		connected.add(node)
-		for input_socket in node.inputs:
-			for link in input_socket.links:
-				from_node = link.from_node
-				if from_node not in connected:
-					queue.append(from_node)
+		for socket in node.inputs:
+			for link in socket.links:
+				if link.from_node not in connected:
+					queue.append(link.from_node)
 	return connected
 
 # -----------------------------------------------------------------------------
@@ -668,6 +696,8 @@ class MCPREP_OT_combine_materials(bpy.types.Operator):
 		min=0, max=6,
 		default=4)
 
+	skipUsage: bpy.props.BoolProperty(default=False, options={'HIDDEN'})
+
 	def invoke(self, context, event):
 		return context.window_manager.invoke_props_dialog(self)
 
@@ -682,10 +712,13 @@ class MCPREP_OT_combine_materials(bpy.types.Operator):
 		if self.selection_only:
 			materials_to_check = set()
 			for obj in context.selected_objects:
-				if hasattr(obj.data, "materials"):
-					for mat in obj.data.materials:
-						if mat and not mat.library and not mat.is_library_indirect:
-							materials_to_check.add(mat)
+				if not hasattr(obj.data, "materials"):
+					continue
+				
+				for mat in obj.data.materials:
+					if not mat or mat.library or mat.is_library_indirect:
+						continue
+					materials_to_check.add(mat)
 			materials_to_check = list(materials_to_check)
 		else:
 			materials_to_check = [m for m in bpy.data.materials if not m.library and not m.is_library_indirect]
@@ -728,6 +761,7 @@ class MCPREP_OT_combine_materials(bpy.types.Operator):
 
 				# Sort materials by total node count (add option for user to decide, least or greatest node count. What about number of users?), then by name length as a tie-breaker
 				mats.sort(key=lambda m: (count_total_nodes(m), len(m.name)))
+				mats.sort(key=lambda m: (count_nodes_in_material(m), len(m.name)))
 
 				master_mat = mats[0] # The one with the least nodes
 				for i in range(1, len(mats)):
@@ -760,7 +794,6 @@ class MCPREP_OT_combine_materials(bpy.types.Operator):
 		else:
 			self.report({"INFO"}, "No duplicates found")
 		return {'FINISHED'}
-
 
 
 class MCPREP_OT_combine_images(bpy.types.Operator):
@@ -865,7 +898,7 @@ class MCPREP_OT_combine_images(bpy.types.Operator):
 				cur_img_data = img_array[::stride] if stride > 1 else img_array
 
 				pix_sum = np.sum(cur_img_data)
-	
+
 			if cur_img_key not in unique_images:
 				unique_images[cur_img_key] = [(img, img_array, pix_sum)]
 				continue

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -150,6 +150,11 @@ class AnimState(Enum):
 	NONE = 'None'
 	ACTIVE = 'Active'
 
+class MaterialType(Enum):
+	"""Basically represents if a material use nodes or not."""
+	FIXED = "FIXED_MAT"
+	NODES = "NODE_TREE"
+
 @dataclass
 class KeyframeData:
 	"""Stores keyframe coordinate, handle, and dynamic data."""
@@ -235,7 +240,7 @@ class NodeTreeFingerprint:
 @dataclass
 class MaterialFingerprint:
 	"""Stores a unique signature of a material for structural comparison."""
-	mat_type: str = "FIXED_MAT"
+	mat_type: MaterialType = MaterialType.FIXED
 	diffuse: Optional[Primitive] = None
 	roughness: Optional[Primitive] = None
 	metallic: Optional[Primitive] = None
@@ -424,19 +429,19 @@ def get_material_fingerprint(material: bpy.types.Material, compare_settings: boo
 
 	# 1. Handle Surface Type
 	if not material.node_tree:
-		fp.mat_type = "FIXED_MAT"
+		fp.mat_type = MaterialType.FIXED
 		fp.diffuse = round_value(material.diffuse_color, precision)
 		fp.roughness = round_value(material.roughness, precision)
 		fp.metallic = round_value(material.metallic, precision)
 	else:
-		fp.mat_type = "NODE_TREE"
+		fp.mat_type = MaterialType.NODES
 		fp.node_tree_data = get_node_group_fingerprint(material.node_tree, precision)
 
 	# 2. Gather Action Names (Optional metadata)
 	if use_action_names:
 		if material.animation_data and material.animation_data.action:
 			fp.mat_action_name = material.animation_data.action.name
-		
+
 		nt = material.node_tree
 		if nt and nt.animation_data and nt.animation_data.action:
 			fp.node_tree_action_name = nt.animation_data.action.name

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -29,6 +29,7 @@ from numpy.typing import NDArray
 from dataclasses import dataclass
 
 import numpy as np
+from enum import Enum
 
 from . import generate
 from . import sequences
@@ -142,7 +143,11 @@ class ListMaterials(bpy.types.PropertyGroup):
 # Dataclasses for material comparison 
 # -----------------------------------------------------------------------------
 
-Primitive = Union[int, float, str, bool, list, None]
+
+class AnimState(Enum):
+	"""Represents the presence or absence of animation data."""
+	NONE = 'None'
+	ACTIVE = 'Active'
 
 @dataclass
 class KeyframeData:
@@ -221,8 +226,8 @@ class MaterialFingerprint:
 	roughness: Optional[float] = None
 	metallic: Optional[float] = None
 	node_tree_data: Optional[NodeTreeFingerprint] = None
-	mat_action_name: str = 'None'
-	node_tree_action_name: str = 'None'
+	mat_action_name: Optional[Union[str, AnimState]] = AnimState.NONE
+	node_tree_action_name: Optional[Union[str, AnimState]] = AnimState.NONE
 	animation: Optional[Dict[str, List[FCurveData]]] = None
 	render_settings: Optional[Dict[str, PropertyEntry]] = None
 	line_art_settings: Optional[Dict[str, PropertyEntry]] = None

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -18,12 +18,15 @@
 
 
 import os
-from typing import Dict, List, Optional, Tuple
 
 import bpy
+from collections import deque
+import time
+
+from typing import Dict, List, Optional, Set, Tuple, Union, Any, Deque
+from numpy.typing import NDArray
 
 import numpy as np
-from numpy.typing import NDArray
 
 from . import generate
 from . import sequences
@@ -40,6 +43,21 @@ from ..conf import MCprepError, env
 # and 4 is the RGBA channels
 RGBA_PIXELS_4096_MAX = 16384
 
+# --- CONFIG: PROPERTIES TO IGNORE ---
+IGNORE_PROPS = (
+	'bl_description', 'bl_width_default', 'bl_width_min', 'bl_width_max', 'bl_height_default', 'bl_height_min',
+	'bl_height_max', 'bl_icon', 'bl_static_type', 'bl_label', 'name', 'label',
+	'location', 'width', 'height', 'dimensions', 'hide', 'select',
+	'show_options', 'show_texture', 'show_preview', 'use_custom_color',
+	'color', 'parent', 'internal_links', 'texture_mapping', 'color_mapping', 'node_tree'
+)
+
+IGNORE_MAT_SETTINGS = {
+	'name', 'use_fake_user', 'is_runtime_data', 'tag', 'asset_data',
+	'preview_render_type', 'use_preview_world', 'use_nodes', 'node_tree',
+	'diffuse_color', 'specular_color', 'roughness', 'specular_intensity',
+	'metallic', 'line_color', 'animation_data'
+}
 
 # -----------------------------------------------------------------------------
 # UI and utility functions
@@ -117,6 +135,363 @@ class ListMaterials(bpy.types.PropertyGroup):
 	path: bpy.props.StringProperty(subtype='FILE_PATH')
 	index: bpy.props.IntProperty(min=0, default=0)  # for icon drawing
 
+# -----------------------------------------------------------------------------
+# Material structural comparison helpers
+# -----------------------------------------------------------------------------
+
+# --- SERIALIZATION HELPERS ---
+
+def serialize_fcurve(fcurve: bpy.types.FCurve) -> Dict[str, Any]:
+	"""
+	Converts an F-Curve data-block into a dictionary of primitive values for structural comparison.
+	"""
+	fcurve.keyframe_points.sort()
+
+	return {
+		"array_index": fcurve.array_index,
+		"extrapolation": fcurve.extrapolation,
+		"auto_smoothing": fcurve.auto_smoothing,
+		"mute": fcurve.mute,
+		"keyframes": [
+			serialize_keyframe(kp)
+			for kp in fcurve.keyframe_points
+		],
+	}
+
+def serialize_keyframe(kp: bpy.types.Keyframe) -> Dict[str, Any]:
+	"""
+	Serializes individual keyframe points, rounding float values to ensure consistent hashing.
+	"""
+	return {
+		"co": tuple(round(v, 6) for v in kp.co),
+		"handle_left": tuple(round(v, 6) for v in kp.handle_left),
+		"handle_right": tuple(round(v, 6) for v in kp.handle_right),
+		"handle_left_type": kp.handle_left_type,
+		"handle_right_type": kp.handle_right_type,
+		"interpolation": kp.interpolation,
+		"easing": kp.easing,
+		"back": round(kp.back, 6),
+		"amplitude": round(kp.amplitude, 6),
+		"period": round(kp.period, 6),
+	}
+
+def serialize_action(action: Optional[bpy.types.Action]) -> Optional[Dict[str, Any]]:
+	"""Serializes an entire Action (collection of F-Curves)."""
+	if not action:
+		return None
+
+	fcurves = sorted(action.fcurves, key=lambda f: (f.data_path, f.array_index))
+
+	return {
+		# "name": action.name, # make togglable optional by user
+		"fcurves": [serialize_fcurve(f) for f in fcurves]
+	}
+
+# --- ANIMATION & DRIVER LOGIC ---
+def get_animation_fingerprint(id_data: bpy.types.ID, data_path: Optional[str] = None, array_index: Optional[int] = None) -> Optional[Dict[str, Any]]:
+	"""
+	Retrieves the animation data for a specific property or data-block as a serializable fingerprint.
+	"""
+	if not id_data.animation_data or not id_data.animation_data.action:
+		return None
+
+	action = id_data.animation_data.action
+
+	if data_path:
+		fcurve = next((f for f in action.fcurves if f.data_path == data_path and
+					  (array_index is None or f.array_index == array_index)), None)
+		return serialize_fcurve(fcurve) if fcurve else None
+
+	fcurves = sorted(action.fcurves, key=lambda f: (f.data_path, f.array_index))
+	return {"fcurves": [serialize_fcurve(f) for f in fcurves]}
+
+def get_driver_fingerprint(id_data: bpy.types.ID, data_path: str, array_index: Optional[int] = None) -> Optional[Dict[str, Any]]:
+	"""
+	Captures driver expressions, variables, and modifier stacks into a serializable structure.
+	"""
+	if not id_data.animation_data:
+		return None
+
+	fcurve = next((d for d in id_data.animation_data.drivers if d.data_path == data_path and (array_index is None or d.array_index == array_index)), None)
+	if not fcurve:
+		return None
+
+	drv = fcurve.driver
+
+	# 1. Basic Driver Settings
+	driver_data = {"type": drv.type,}
+	if drv.type == 'SCRIPTED':
+		driver_data["expression"] = drv.expression
+
+	# 2. Variable Logic (Only properties that affect driver result)
+
+	driver_data["variables"] = []
+	for var in drv.variables:
+		var_data = {"name": var.name, "type": var.type, "targets": []}
+
+		for tar in var.targets:
+			tar_info = {}
+			if var.type == 'CONTEXT_PROP':
+				tar_info["context_property"] = tar.context_property
+				tar_info["data_path"] = tar.data_path
+				var_data["targets"].append(tar_info)
+				continue
+
+			tar_info = {"id": getattr(tar.id, "name_full", tar.id.name)}
+
+			if tar.bone_target:
+				tar_info["bone_target"] = tar.bone_target
+
+			if var.type == 'SINGLE_PROP':
+				tar_info["id_type"] = tar.id_type
+				tar_info["data_path"] = tar.data_path
+
+			elif var.type == 'TRANSFORMS':
+				tar_info["transform_type"] = tar.transform_type
+				if tar.transform_type.startswith("ROT"):
+					tar_info["rotation_mode"] = tar.rotation_mode
+				tar_info["transform_space"] = tar.transform_space
+
+			elif var.type == 'LOC_DIFF':
+				tar_info["transform_space"] = tar.transform_space
+
+			var_data["targets"].append(tar_info)
+		driver_data["variables"].append(var_data)
+
+	# 3. F-Curve
+	driver_data["fcurve"] = serialize_fcurve(fcurve)
+
+	# 4. F-Curve Modifiers (Skip if muted or influence is 0)
+	driver_data["modifiers"] = []
+	for mod in fcurve.modifiers:
+		if mod.mute or getattr(mod, "influence", 1.0) <= 0.0:
+			continue
+
+		m_data = {"type": mod.type}
+		for prop in mod.bl_rna.properties:
+			if not prop.is_readonly and prop.identifier not in {'name', 'type', 'is_active'}:
+				m_data[prop.identifier] = to_primitive(getattr(mod, prop.identifier))
+		driver_data["modifiers"].append(m_data)
+
+	return driver_data
+
+# --- NODE TREE ANALYSIS ---
+
+def get_material_fingerprint(material: bpy.types.Material, exclude_settings: bool) -> Dict[str, Any]:
+	"""
+	Generates a unique signature of a material's node tree and render settings to identify duplicates.
+	"""
+	if not material.node_tree:
+		fp = {
+			"type": "FIXED_MAT",
+			"diffuse": to_primitive(material.diffuse_color),
+			"roughness": material.roughness,
+			"metallic": material.metallic
+		}
+	else:
+		fp = {
+			"type": "NODE_TREE",
+			"data": get_node_group_fingerprint(material.node_tree)
+		}
+
+	# Gather Animation
+	anim = get_animation_fingerprint(material)
+	if anim:
+		fp["animation"] = anim
+
+	# Gather Material / Render Settings
+	if not exclude_settings:
+		render_settings = {}
+		for prop in material.bl_rna.properties:
+			if prop.is_readonly or prop.identifier in IGNORE_MAT_SETTINGS:
+				continue
+
+			val_data = {"val": to_primitive(getattr(material, prop.identifier))}
+
+			# Check for driver
+			driver = get_driver_fingerprint(material, prop.identifier)
+			if driver is not None:
+				val_data["driver"] = driver
+
+			render_settings[prop.identifier] = val_data
+
+		fp["render_settings"] = render_settings
+
+		# Gather Line Art Settings
+		line_art_settings = {}
+		if hasattr(material, "lineart"):
+			la = material.lineart
+			for prop in la.bl_rna.properties:
+				if prop.is_readonly or prop.identifier in IGNORE_MAT_SETTINGS:
+					continue
+
+				value = getattr(la, prop.identifier)
+				if hasattr(value, "__iter__") and not isinstance(value, (str, bytes)):
+					value = [to_primitive(v) for v in value]
+				else:
+					value = to_primitive(value)
+
+				val_data = {"val": value}
+
+				# Check for driver
+				driver = get_driver_fingerprint(material, f"line_art.{prop.identifier}")
+				if driver is not None:
+					val_data["driver"] = driver
+
+				line_art_settings[prop.identifier] = val_data
+
+	return fp
+
+def get_node_group_fingerprint(node_tree: bpy.types.NodeTree) -> Optional[Dict[str, Any]]:
+	"""
+	Recursively maps the connected node network, properties, and internal group contents.
+	"""
+	if not node_tree: return None
+	active_nodes = get_connected_nodes(node_tree)
+	nodes_data = []
+
+	for node in sorted(list(active_nodes), key=lambda n: (n.bl_idname, n.name)):
+		if node.bl_idname in {'NodeFrame', 'NodeReroute'}: continue
+
+		node_data = {"type": node.bl_idname, "muted": node.mute, "properties": {}, "inputs": []}
+
+		# Properties + Drivers + Anim
+		for prop in node.bl_rna.properties:
+			if prop.identifier in IGNORE_PROPS or prop.is_readonly: continue
+			data_path = f'nodes["{node.name}"].{prop.identifier}'
+
+			prop_entry = {"val": to_primitive(getattr(node, prop.identifier))}
+
+			# Check Driver & Anim
+			driver = get_driver_fingerprint(node_tree, data_path)
+			anim = get_animation_fingerprint(node_tree, data_path)
+			if driver: prop_entry["driver"] = driver
+			if anim: prop_entry["animation"] = anim
+
+			node_data["properties"][prop.identifier] = prop_entry
+
+		# Inputs
+		for socket_idx, socket in enumerate(node.inputs):
+			if socket.is_linked or not hasattr(socket, "default_value"):
+				continue
+
+			default_val = socket.default_value
+			data_path = f'nodes["{node.name}"].inputs[{socket_idx}].default_value'
+
+			# Scalar
+			if isinstance(default_val, (int, float)):
+				input_data = {"idx": socket_idx, "val": to_primitive(default_val)}
+
+				# Check Driver & Anim
+				driver = get_driver_fingerprint(node_tree, data_path)
+				anim = get_animation_fingerprint(node_tree, data_path)
+				if driver: input_data["driver"] = driver
+				if anim: input_data["animation"] = anim
+
+				node_data["inputs"].append(input_data)
+
+			# Array (RGBA / Vector)
+			else:
+				for array_idx, value in enumerate(default_val):
+
+					input_data = {
+						"idx": socket_idx,
+						"array_index": array_idx,
+						"val": value if isinstance(value, str) else round(value, 6)}
+
+					# Check Driver & Anim
+					driver = get_driver_fingerprint(node_tree, data_path, array_idx)
+					anim = get_animation_fingerprint(node_tree, data_path, array_idx)
+					if driver: input_data["driver"] = driver
+					if anim: input_data["animation"] = anim
+
+					node_data["inputs"].append(input_data)
+
+
+		if node.bl_idname in {'ShaderNodeGroup', 'GeometryNodeGroup'} and node.node_tree: # 'GeometryNodeGroup' included for future merge geoNode operator
+			node_data["group_content"] = get_node_group_fingerprint(node.node_tree)
+		nodes_data.append(node_data)
+
+	links_data = []
+	for node in active_nodes:
+		if node.bl_idname in {'NodeFrame', 'NodeReroute'}: continue
+		for socket in node.inputs:
+			if socket.is_linked:
+				src = trace_socket(socket)
+				if src.node in active_nodes:
+					links_data.append({"from_socket": src.name, "from_node": src.node.bl_idname, "to_socket": socket.name, "to_node": node.bl_idname})
+
+	return {"nodes": nodes_data, "links": sorted(links_data, key=lambda x: str(x))}
+
+def count_total_nodes(material: bpy.types.Material) -> int:
+	"""
+	Performs a recursive count of all functional nodes within a material and its nested node groups.
+	"""
+	if not material.node_tree:
+		return 0
+
+	def _recursive_count(node_tree):
+		count = 0
+		for node in node_tree.nodes:
+			if node.bl_idname in {'NodeFrame', 'NodeReroute'}:
+				continue
+			count += 1
+			# If it's a group, count its internal nodes too
+			if node.bl_idname in {'ShaderNodeGroup', 'GeometryNodeGroup'} and node.node_tree:
+				count += _recursive_count(node.node_tree)
+		return count
+
+	return _recursive_count(material.node_tree)
+
+def to_primitive(val: Any) -> Union[int, float, str, bool, list, None]:
+	"""
+	Converts Blender-specific data types into standard Python primitives for serialization.
+	"""
+	if isinstance(val, (int, float)):
+		return round(val, 6)
+	elif isinstance(val, (str, bool, type(None))):
+		return val
+	elif hasattr(val, "to_list"):
+		return [round(x, 6) for x in val.to_list()]
+	elif hasattr(val, "__iter__"):
+		return [to_primitive(x) for x in val]
+	return str(val)
+
+def trace_socket(socket: bpy.types.NodeSocket) -> bpy.types.NodeSocket:
+	"""
+	Follows a node socket link back to its source, traversing reroute nodes.
+	"""
+	if not socket or not socket.is_linked:
+		return socket
+	current_link = socket.links[0]
+	source_node = current_link.from_node
+	while source_node and source_node.bl_idname == 'NodeReroute':
+		if source_node.inputs[0].is_linked:
+			current_link = source_node.inputs[0].links[0]
+			source_node = current_link.from_node
+		else:
+			return source_node.inputs[0]
+	return current_link.from_socket
+
+def get_connected_nodes(node_tree: bpy.types.NodeTree) -> Set[bpy.types.Node]:
+	"""
+	Identifies all nodes that are functionally connected to a material or group output.
+	"""
+	if not node_tree:
+		return set()
+	outputNodes = [n for n in node_tree.nodes if n.bl_idname in {'ShaderNodeOutputMaterial', 'NodeGroupOutput'}]
+	connected = set()
+	queue = deque(outputNodes)
+	while queue:
+		node = queue.popleft()
+		if node in connected: continue
+		connected.add(node)
+		for input_socket in node.inputs:
+			for link in input_socket.links:
+				from_node = link.from_node
+				if from_node not in connected:
+					queue.append(from_node)
+	return connected
 
 # -----------------------------------------------------------------------------
 # Material data management operators
@@ -151,130 +526,111 @@ class MCPREP_OT_reload_materials(bpy.types.Operator):
 class MCPREP_OT_combine_materials(bpy.types.Operator):
 	bl_idname = "mcprep.combine_materials"
 	bl_label = "Combine materials"
-	bl_description = (
-		"Consolidate the same materials together e.g. mat.001 and mat.002")
-	bl_options = {'REGISTER', 'UNDO'}
+	bl_description = "Consolidate duplicate materials based on nodes or name"
+	bl_options = {'REGISTER', 'UNDO'} #add group_undo?
 
-	# arg to auto-force remove old? versus just keep as 0-users
+	group_by_name: bpy.props.BoolProperty(
+		name="Group Method: Material Name",
+		description="Finds materials with the same name (ignoring extensions like .001)",
+		default=False)
+
 	selection_only: bpy.props.BoolProperty(
 		name="Selection only",
 		description="Build materials to consolidate based on selected objects only",
-		default=True)
-	skipUsage: bpy.props.BoolProperty(default=False, options={'HIDDEN'})
+		default=False)
+
+	exclude_mat_settings: bpy.props.BoolProperty(
+		name="Exclude Material Settings",
+		description="Do not compare materials settings, only nodes",
+		default=False)
+
+	def invoke(self, context, event):
+		return context.window_manager.invoke_props_dialog(self)
 
 	track_function = "combine_materials"
 	@tracking.report_error
 	def execute(self, context):
-		removeold = True
-
-		if self.selection_only is True and len(context.selected_objects) == 0:
-			self.report(
-				{'ERROR'},
-				"Either turn selection only off or select objects with materials")
+		if self.selection_only and not context.selected_objects:
+			self.report({'ERROR'}, "Select objects with materials first")
 			return {'CANCELLED'}
 
-		# 2-level structure to hold base name and all
-		# materials blocks with the same base
-		name_cat = {}
+		# 1. Gather materials
+		if self.selection_only:
+			materials_to_check = set()
+			for obj in context.selected_objects:
+				if hasattr(obj.data, "materials"):
+					for mat in obj.data.materials:
+						if mat and not mat.library:
+							materials_to_check.add(mat)
+			materials_to_check = list(materials_to_check)
+		else:
+			materials_to_check = [m for m in bpy.data.materials if not m.library]
 
-		def getMaterials(self, context):
-			if self.selection_only is False:
-				return bpy.data.materials
-			else:
-				mats = []
-				for ob in bpy.data.objects:
-					for sl in ob.material_slots:
-						if sl is None or sl.material is None:
-							continue
-						if sl.material in mats:
-							continue
-						mats.append(sl.material)
-				return mats
-
-		data = getMaterials(self, context)
-		precount = len(["x" for x in data if x.users > 0])
-
-		if not data:
-			if self.selection_only:
-				self.report({"ERROR"}, "No materials found on selected objects")
-			else:
-				self.report({"ERROR"}, "No materials in open file")
-			return {'CANCELLED'}
-
-		# get and categorize all materials names
-		for mat in data:
-			base = util.nameGeneralize(mat.name)
-			if base not in name_cat:
-				name_cat[base] = [mat.name]
-			elif mat.name not in name_cat[base]:
-				name_cat[base].append(mat.name)
-			else:
-				env.log("Skipping, already added material", True)
-
-		# Pre 2.78 solution, deep loop.
-		if bpy.app.version < (2, 78):
-			for ob in bpy.data.objects:
-				for sl in ob.material_slots:
-					if sl is None or sl.material is None:
-						continue
-					if sl.material not in data:
-						continue  # Selection only.
-					name_ref = name_cat[util.nameGeneralize(sl.material.name)][0]
-					sl.material = bpy.data.materials[name_ref]
-			# doesn't remove old textures, but gets it to zero users
-
-			postcount = len([True for x in bpy.data.materials if x.users > 0])
-			self.report(
-				{"INFO"},
-				f"Consolidated {precount - postcount} materials, down to {postcount} overall")
+		if not materials_to_check:
+			self.report({'INFO'}, "No materials found to process")
 			return {'FINISHED'}
 
-		# perform the consolidation with one basename set at a time
-		for base in name_cat:  # The keys of the dictionary.
-			if len(base) < 2:
-				continue
+		precount = len(bpy.data.materials)
 
-			name_cat[base].sort()  # in-place sorting
-			baseMat = bpy.data.materials[name_cat[base][0]]
+		# 2. Grouping by Fingerprint
+		# Structure: { group_key: [ {fingerprint: dict, materials: [mat1, mat2]} ] }
+		fingerprint_groups = {}
 
-			env.log(f"{name_cat[base]} ##  {baseMat}", vv_only=True)
+		for mat in materials_to_check:
+			group_key = mat.name.split('.')[0] if self.group_by_name else "GLOBAL"
+			fp = get_material_fingerprint(mat, self.exclude_mat_settings)
 
-			for matname in name_cat[base][1:]:
-				# skip if fake user set
-				if bpy.data.materials[matname].use_fake_user is True:
+			if group_key not in fingerprint_groups:
+				fingerprint_groups[group_key] = []
+
+			# Check if fingerprint exists in the current group
+			match_found = False
+			for entry in fingerprint_groups[group_key]:
+				if entry['fingerprint'] == fp:
+					entry['materials'].append(mat)
+					match_found = True
+					break
+
+			if not match_found:
+				fingerprint_groups[group_key].append({'fingerprint': fp, 'materials': [mat]})
+
+		# 3. Determine Masters and Build Merge Map
+		merge_map = {}
+		for group_key, entries in fingerprint_groups.items():
+			for entry in entries:
+				mats = entry['materials']
+				if len(mats) <= 1:
 					continue
-				# otherwise, remap
-				bpy.data.materials[matname].user_remap(baseMat)
-				old = bpy.data.materials[matname]
-				env.log(f"removing old? {matname}", vv_only=True)
-				if removeold is True and old.users == 0:
-					env.log(f"removing old:{matname}", vv_only=True)
-					try:
-						data.remove(old)
-					except ReferenceError as err:
-						print(f'Error trying to remove material {matname}')
-						print(str(err))
-					except ValueError as err:
-						print(f'Error trying to remove material {matname}')
-						print(str(err))
 
-			# Final step.. rename to not have .001 if it does,
-			# unless the target base-named material still exists and has users.
-			gen_base = util.nameGeneralize(baseMat.name)
-			gen_material = bpy.data.materials.get(gen_base)
-			if baseMat.name != gen_base:
-				if gen_material and gen_material.users != 0:
-					pass
-				else:
-					baseMat.name = gen_base
-			else:
-				baseMat.name = gen_base
-			env.log(f"Final: {baseMat}", vv_only=True)
+				# Sort materials by total node count (add option for user to decide, least or greatest node count. What about number of users?), then by name length as a tie-breaker
+				mats.sort(key=lambda m: (count_total_nodes(m), len(m.name)))
 
-		postcount = len(["x" for x in getMaterials(self, context) if x.users > 0])
-		self.report({"INFO"}, f"Consolidated {precount} materials down to {postcount}")
+				master_mat = mats[0] # The one with the least nodes
+				for i in range(1, len(mats)):
+					merge_map[mats[i]] = master_mat
 
+		# 4. Remap & Cleanup
+		if not merge_map:
+			self.report({'INFO'}, "No duplicates found")
+			return {'FINISHED'}
+
+		for old_mat, master_mat in merge_map.items():
+			env.log(f"Replaced '{old_mat.name}' with '{master_mat.name}'")
+			old_mat.user_remap(master_mat)
+
+		to_delete = [m for m in merge_map.keys() if m.users == 0 and not m.use_fake_user]
+		if to_delete:
+			bpy.data.batch_remove(ids=to_delete)
+
+		postcount = len(bpy.data.materials)
+		consolidated_count = precount - postcount
+
+		if consolidated_count > 0:
+			self.report({"INFO"}, f"Consolidated {consolidated_count} material{'s' if consolidated_count > 1 else ''} (Total: {precount} -> {postcount})")
+		else:
+			self.report({"INFO"}, "No duplicates found")
 		return {'FINISHED'}
+
 
 
 class MCPREP_OT_combine_images(bpy.types.Operator):

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -885,12 +885,12 @@ class MCPREP_OT_combine_images(bpy.types.Operator):
 		description="Only check images used by materials on selected objects",
 		default=True)
 
-	compare_name: bpy.props.BoolProperty(
+	group_by_name: bpy.props.BoolProperty(
 		name="Compare Image Name",
 		description="Compare duplicates using base names (e.g., 'Texture.001' matches 'Texture')",
 		default=True)
 
-	compare_pixels: bpy.props.BoolProperty(
+	strict_comparison: bpy.props.BoolProperty(
 		name="Compare Pixels (slower)",
 		description="Compare full image content instead of samples. More accurate, but slower for large images",
 		default=False)
@@ -948,7 +948,7 @@ class MCPREP_OT_combine_images(bpy.types.Operator):
 			if w == 0 or h == 0 or not img.has_data:
 				continue
 
-			base_name = util.nameGeneralize(img.name) if self.compare_name else "GLOBAL"
+			base_name = util.nameGeneralize(img.name) if self.group_by_name else "GLOBAL"
 			groups.append((base_name, w, h, img))
 
 		# Comparison and Remapping
@@ -970,7 +970,7 @@ class MCPREP_OT_combine_images(bpy.types.Operator):
 			# comparison, which checks the actual pixels, this
 			# sums up the pixels and uses that to represent the
 			# image contents
-			if not self.compare_pixels:
+			if not self.strict_comparison:
 				num_pixels = w * h * 4
 				stride = max(1, num_pixels // RGBA_PIXELS_4096_MAX)
 				cur_img_data = img_array[::stride] if stride > 1 else img_array
@@ -988,7 +988,7 @@ class MCPREP_OT_combine_images(bpy.types.Operator):
 			for uni_image, uni_data, uni_sum in unique_images[cur_img_key]:
 				# Fast prefilter, used as an alternative
 				# to strict comparison
-				if not self.compare_pixels and not pix_sum == uni_sum:
+				if not self.strict_comparison and not pix_sum == uni_sum:
 					continue
 				elif not np.array_equal(uni_data, img_array):
 					continue
@@ -1027,6 +1027,7 @@ class MCPREP_OT_combine_images(bpy.types.Operator):
 		else:
 			self.report({"INFO"}, "No duplicates found")
 		return {'FINISHED'}
+
 
 
 class MCPREP_OT_replace_missing_textures(bpy.types.Operator):

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -175,18 +175,6 @@ def serialize_keyframe(kp: bpy.types.Keyframe) -> Dict[str, Any]:
 		"period": round(kp.period, 6),
 	}
 
-def serialize_action(action: Optional[bpy.types.Action]) -> Optional[Dict[str, Any]]:
-	"""Serializes an entire Action (collection of F-Curves)."""
-	if not action:
-		return None
-
-	fcurves = sorted(action.fcurves, key=lambda f: (f.data_path, f.array_index))
-
-	return {
-		# "name": action.name, # make togglable optional by user
-		"fcurves": [serialize_fcurve(f) for f in fcurves]
-	}
-
 # --- ANIMATION & DRIVER LOGIC ---
 def get_animation_fingerprint(id_data: bpy.types.ID, data_path: Optional[str] = None, array_index: Optional[int] = None) -> Optional[Dict[str, Any]]:
 	"""
@@ -277,7 +265,7 @@ def get_driver_fingerprint(id_data: bpy.types.ID, data_path: str, array_index: O
 
 # --- NODE TREE ANALYSIS ---
 
-def get_material_fingerprint(material: bpy.types.Material, exclude_settings: bool) -> Dict[str, Any]:
+def get_material_fingerprint(material: bpy.types.Material, exclude_settings: bool, use_action_names: bool) -> Dict[str, Any]:
 	"""
 	Generates a unique signature of a material's node tree and render settings to identify duplicates.
 	"""
@@ -295,6 +283,16 @@ def get_material_fingerprint(material: bpy.types.Material, exclude_settings: boo
 		}
 
 	# Gather Animation
+	if use_action_names:
+		# Material level action
+		fp["mat_action_name"] = material.animation_data.action.name if (material.animation_data and material.animation_data.action) else 'None'
+
+		# Node Tree level action
+		if material.node_tree and material.node_tree.animation_data and material.node_tree.animation_data.action:
+			fp["node_tree_action_name"] = material.node_tree.animation_data.action.name
+		else:
+			fp["node_tree_action_name"] = 'None'
+
 	anim = get_animation_fingerprint(material)
 	if anim:
 		fp["animation"] = anim
@@ -339,6 +337,7 @@ def get_material_fingerprint(material: bpy.types.Material, exclude_settings: boo
 					val_data["driver"] = driver
 
 				line_art_settings[prop.identifier] = val_data
+		fp["line_art_settings"] = line_art_settings
 
 	return fp
 
@@ -544,6 +543,11 @@ class MCPREP_OT_combine_materials(bpy.types.Operator):
 		description="Do not compare materials settings, only nodes",
 		default=False)
 
+	use_action_names: bpy.props.BoolProperty(
+		name="Differentiate by Action Name",
+		description="If true, materials with identical animation but different Action names will be kept separate",
+		default=False)
+
 	def invoke(self, context, event):
 		return context.window_manager.invoke_props_dialog(self)
 
@@ -578,7 +582,7 @@ class MCPREP_OT_combine_materials(bpy.types.Operator):
 
 		for mat in materials_to_check:
 			group_key = util.nameGeneralize(mat.name) if self.group_by_name else "GLOBAL"
-			fp = get_material_fingerprint(mat, self.exclude_mat_settings)
+			fp = get_material_fingerprint(mat, self.exclude_mat_settings, self.use_action_names)
 
 			if group_key not in fingerprint_groups:
 				fingerprint_groups[group_key] = []

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -674,8 +674,9 @@ def get_connected_nodes(node_tree: bpy.types.NodeTree) -> Set[bpy.types.Node]:
 		connected.add(node)
 		for socket in node.inputs:
 			for link in socket.links:
-				if link.from_node not in connected:
-					queue.append(link.from_node)
+				if link.from_node in connected:
+					continue
+				queue.append(link.from_node)
 	return connected
 
 # -----------------------------------------------------------------------------
@@ -734,16 +735,12 @@ class MCPREP_OT_combine_materials(bpy.types.Operator):
 		description="Treat materials with different Action names as unique, even if their animation data matches",
 		default=False)
 
-	matching_precision: bpy.props.EnumProperty(
-		items=[
-			('OFF', "Off (Exact)", "No rounding. Values must match exactly"),
-			('STRICT', "Strict (4 decimals)", "High precision matching. Values must be nearly identical (e.g. 0.1234)"),
-			('LOOSE', "Loose (2 decimals)", "Forgiving matching. Values like 0.12 and 0.124 will match"),
-			('ROUGH', "Rough (1 decimal)", "Very loose matching. Values like 0.1 and 0.14 will match"),
-		],
-		name="Value Matching",
-		description="Controls how precisely float values are compared (node inputs, colors, vectors, animation keyframes)",
-		default='STRICT'
+	value_rounding: bpy.props.IntProperty(
+		name="Decimal Rounding",
+		description="Number of decimal places to round float values (node inputs, colors, vectors, animation keyframes) for comparison. -1 for exact matching",
+		default=4,
+		min=-1,
+		max=10
 	)
 
 	master_selection: bpy.props.EnumProperty(
@@ -777,9 +774,8 @@ class MCPREP_OT_combine_materials(bpy.types.Operator):
 			self.report({'ERROR'}, "Select objects with materials first")
 			return {'CANCELLED'}
 
-		# Map Enum to numeric precision. 'inf' means Exact Matching (no rounding).
-		precision_map = {'OFF': float('inf'), 'STRICT': 4, 'LOOSE': 2, 'ROUGH': 1}
-		precision_val = precision_map.get(self.matching_precision, 4)
+		# < 0 means Exact Matching (no rounding).
+		precision_val = float('inf') if self.value_rounding < 0 else self.value_rounding
 
 		# 1. Gather materials
 		if self.selection_only:

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -26,6 +26,8 @@ import time
 from typing import Dict, List, Optional, Set, Tuple, Union
 from numpy.typing import NDArray
 
+from dataclasses import dataclass
+
 import numpy as np
 
 from . import generate

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -261,7 +261,7 @@ def serialize_keyframe(precision: int, kp: bpy.types.Keyframe) -> KeyframeData:
 	)
 
 # --- ANIMATION & DRIVER LOGIC ---
-def get_animation_fingerprint(precision: int, id_data: bpy.types.ID, data_path: Optional[str] = None, array_index: Optional[int] = None) -> Optional[List[FCurveData]]:
+def get_animation_fingerprint(precision: int, id_data: bpy.types.ID, data_path: Optional[str] = None, array_index: Optional[int] = -1) -> Optional[List[FCurveData]]:
 	"""
 	Retrieves the animation data for a specific property or data-block as a serializable fingerprint.
 	"""
@@ -269,33 +269,31 @@ def get_animation_fingerprint(precision: int, id_data: bpy.types.ID, data_path: 
 		return None
 
 	action = id_data.animation_data.action
-
+	fcurve = None
+	
 	if data_path:
-		fcurve = next((f for f in action.fcurves if f.data_path == data_path and
-					  (array_index is None or f.array_index == array_index)), None)
-		return [serialize_fcurve(precision, fcurve)] if fcurve else None
-
-	fcurves = sorted(action.fcurves, key=lambda f: (f.data_path, f.array_index))
-	return [serialize_fcurve(precision, f) for f in fcurves]
-
-def get_driver_fingerprint(precision: int, id_data: bpy.types.ID, data_path: str, array_index: Optional[int] = None) -> Optional[DriverFingerprint]:
-	"""
-	Captures driver expressions, variables, and modifier stacks into a serializable structure.
-	"""
-	if not id_data.animation_data:
-		return None
-
-	fcurve: Optional[bpy.types.FCurve] = None
-	for d in id_data.animation_data.drivers:
-		if d.data_path == data_path and (array_index is None or d.array_index == array_index):
-			fcurve = d
-			break
+		found = action.fcurves.find(data_path, index=array_index)
+		fcurve = [found] if found else None 
+	else:
+		fcurve = sorted(action.fcurves, key=lambda f: (f.data_path, f.array_index))
 
 	if not fcurve:
 		return None
+	return [serialize_fcurve(precision, f) for f in fcurve]
+
+def get_driver_fingerprint(precision: int, id_data: bpy.types.ID, data_path: str, array_index: Optional[int] = -1) -> Optional[DriverFingerprint]:
+	"""
+	Captures driver expressions, variables, and modifier stacks into a serializable structure.
+	"""
+	if not id_data.animation_data or not id_data.animation_data.drivers:
+		return None
+		
+	fcurve = id_data.animation_data.drivers.find(data_path, index=array_index)
+	
+	if fcurve is None:
+		return None
 
 	drv = fcurve.driver
-
 
 	variables: List[DriverVariableData] = []
 	for var in drv.variables:

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -252,15 +252,21 @@ class MaterialFingerprint:
 
 # --- SERIALIZATION HELPERS ---
 
-def serialize_fcurve(precision: int, fcurve: bpy.types.FCurve) -> FCurveData:
+def serialize_fcurve(precision: int, fcurve: bpy.types.FCurve) -> Optional[FCurveData]:
 	"""
 	Converts a Blender F-Curve into a dataclass.
 	Returns None if the curve has 1 or fewer keyframes, as this doesn't 
 	constitute a functional animation for comparison purposes.
 	"""
+	# If there's only one keyframe, it's a static value, not an animation.
+	# We ignore it to keep the fingerprint focused on actual movement.
+	if len(fcurve.keyframe_points) <= 1:
+		return
+
 	fcurve.keyframe_points.sort()
 
 	return FCurveData(
+		data_path=fcurve.data_path,
 		array_index=fcurve.array_index,
 		extrapolation=fcurve.extrapolation,
 		auto_smoothing=fcurve.auto_smoothing,
@@ -293,81 +299,104 @@ def get_animation_fingerprint(precision: int, id_data: bpy.types.ID, data_path: 
 		return None
 
 	action = id_data.animation_data.action
-	fcurve = None
+	fcurves_to_serialize = []
 	
+	# Gather relevant curves:
 	if data_path:
 		found = action.fcurves.find(data_path, index=array_index)
-		fcurve = [found] if found else None 
+		if found:
+			fcurves_to_serialize = [found]
 	else:
-		fcurve = sorted(action.fcurves, key=lambda f: (f.data_path, f.array_index))
+		fcurves_to_serialize = sorted(
+			[f for f in action.fcurves if f.is_valid], 
+			key=lambda f: (f.data_path, f.array_index)
+		)
 
-	if not fcurve:
-		return None
-	return [serialize_fcurve(precision, f) for f in fcurve]
+	# Serialize and Filter
+	results: List[FCurveData] = []
+	
+	for fcurve in fcurves_to_serialize:
+		serialized = serialize_fcurve(precision, fcurve)
+		if serialized is not None:
+			results.append(serialized)
+
+	# Return None if no valid (multi-keyframe) curves were found
+	return results if results else None
 
 def get_driver_fingerprint(precision: int, id_data: bpy.types.ID, data_path: str, array_index: int = 0) -> Optional[DriverFingerprint]:
 	"""Captures drivers math (expression), inputs (variables), and modifiers."""
 
 	if not id_data.animation_data or not id_data.animation_data.drivers:
 		return None
-		
+
+	# Locate the specific driver F-Curve for the given property path
 	fcurve = id_data.animation_data.drivers.find(data_path, index=array_index)
-	
-	if fcurve is None:
+	if not fcurve:
 		return None
 
 	drv = fcurve.driver
-
 	variables: List[DriverVariableData] = []
+
+	# Process Variables
 	for var in drv.variables:
 		targets: List[DriverVariableTarget] = []
-		
+		var_type = var.type
+
 		for tar in var.targets:
-			# 1. Basic Driver Settings
-			tar_info: Dict[str, str] = {"id_name": getattr(tar.id, "name_full", tar.id.name) if tar.id else ""}
+			# Every target needs an ID
+			tar_obj = DriverVariableTarget(
+				id_name=getattr(tar.id, "name_full", tar.id.name) if tar.id else ""
+			)
 
-			# 2. Variable Logic (Only properties that affect driver result)
-			if tar.bone_target:
-				tar_info["bone_target"] = tar.bone_target
-
-			if var.type == 'CONTEXT_PROP':
-				tar_info["context_property"] = tar.context_property
-				tar_info["data_path"] = tar.data_path
-
-			elif var.type == 'SINGLE_PROP':
-				tar_info["id_type"] = tar.id_type
-				tar_info["data_path"] = tar.data_path
-
-			elif var.type == 'TRANSFORMS':
-				tar_info["transform_type"] = tar.transform_type
-				tar_info["transform_space"] = tar.transform_space
+			# 4. Contextual Logic: Only capture attributes relevant to the variable type.
+			# This prevents "noise" / irrelevant unused attributes in the driver results
+			
+			# - Property based variables (getting a value from a UI field)
+			if var_type in ('SINGLE_PROP', 'CONTEXT_PROP'):
+				tar_obj.data_path = tar.data_path
+				if var_type == 'SINGLE_PROP':
+					tar_obj.id_type = tar.id_type
+				else:
+					tar_obj.context_property = tar.context_property
+			
+			# - Transform based variables (getting Loc/Rot/Scale from 3D space)
+			elif var_type == 'TRANSFORMS':
+				tar_obj.transform_type = tar.transform_type
+				tar_obj.transform_space = tar.transform_space
 				if tar.transform_type.startswith("ROT"):
-					tar_info["rotation_mode"] = tar.rotation_mode
+					tar_obj.rotation_mode = tar.rotation_mode
+			
+			# - Distance-based variables
+			elif var_type == 'LOC_DIFF':
+				tar_obj.transform_space = tar.transform_space
+			
+			# Bones require a specific sub-target name within an Armature
+			if tar.id and tar.id.type == 'ARMATURE' and tar.bone_target:
+				tar_obj.bone_target = tar.bone_target
 
-			elif var.type == 'LOC_DIFF':
-				tar_info["transform_space"] = tar.transform_space
-
-			targets.append(DriverVariableTarget(**tar_info))
-		variables.append(DriverVariableData(name=var.name, var_type=var.type, targets=targets))
-
-	# 3. F-Curve
-	driver_fcurve = serialize_fcurve(precision, fcurve)
-	
-	# 4. F-Curve Modifiers (Skip if muted or influence is 0)
-	modifiers: List[DriverModifierData] = []
-	for mod in fcurve.modifiers:
-		if mod.mute or getattr(mod, "influence", 1.0) <= 0.0:
-			continue
-
-		m_data: Dict[str, Primitive] = {}
-		for prop in mod.bl_rna.properties:
-			if not prop.is_readonly and prop.identifier not in {'name', 'type', 'is_active'}:
-				m_data[prop.identifier] = to_primitive(getattr(mod, prop.identifier), precision)
+			targets.append(tar_obj)
 		
-		modifiers.append(DriverModifierData(mod_type=mod.type, settings=m_data))
+		variables.append(DriverVariableData(name=var.name, var_type=var_type, targets=targets))
+
+	# Capture Driver F-Curve Influence and Modifiers
+	driver_fcurve = serialize_fcurve(precision, fcurve)
+	modifiers: List[DriverModifierData] = [
+		DriverModifierData(
+			mod_type=mod.type,
+			settings={
+				# Automatically scrape all settings for this modifier type
+				p.identifier: serialize_value(getattr(mod, p.identifier), precision)
+				for p in mod.bl_rna.properties
+				if not p.is_readonly and p.identifier not in ('name', 'type', 'is_active')
+			})
+		# Ignore modifiers that are turned off or have no strength
+		for mod in fcurve.modifiers
+		if not mod.mute and getattr(mod, "influence", 1.0) > 0.0
+	]
 
 	return DriverFingerprint(
 		drv_type=drv.type,
+		# Only 'SCRIPTED' drivers use the expression string (e.g., "var * 2")
 		expression=drv.expression if drv.type == 'SCRIPTED' else None,
 		variables=variables,
 		fcurve=driver_fcurve,
@@ -542,22 +571,32 @@ def count_total_nodes(material: bpy.types.Material) -> int:
 	"""
 	Counts all functional nodes. If a NodeGroup is found, 
 	it enters that sub-tree and adds those nodes to the total count.
-
-	return _recursive_count(material.node_tree)
-
-def to_primitive(val, decimals: int = 4) -> Primitive:
+def serialize_value(val, decimals: int = 4) -> Primitive:
 	"""
-	Converts Blender-specific data types into standard Python primitives for serialization.
+	Standardizes Blender's internal math types into Python-native primitives.
+	Args:
+		val: The value to convert (Vector, Color, Euler, float, etc.)
+		decimals: Precision for rounding. Needed for "Matching Precision" option ('fuzzy matching')
+				  where two materials are identical except for a tiny 
+				  floating-point difference (e.g., 0.5001 vs 0.5).
 	"""
-	if isinstance(val, (int, float)):
-		return round(val, decimals)
-	elif isinstance(val, (str, bool, type(None))):
+	if val is None:
+		return None
+		
+	# Standard types are returned as-is
+	if isinstance(val, (str, bool, int)):
 		return val
-	elif hasattr(val, "to_list"):
-		return [round(x, decimals) for x in val.to_list()]
-	elif hasattr(val, "__iter__"):
-		return [to_primitive(x, decimals) for x in val]
-	return str(val)
+	
+	# Floats are rounded for the 'Matching Precision' feature
+	if isinstance(val, float):
+		return round(val, decimals)
+
+	# If the value is iterable (like a Vector, Color, or Euler), 
+	# we convert it to a tuple of primitives recursively.
+	if isinstance(val, Iterable):
+		return tuple(serialize_value(x, decimals) for x in val)
+		
+	return val
 
 def trace_socket(socket: bpy.types.NodeSocket) -> bpy.types.NodeSocket:
 	"""Follows a node socket link back to its source, traversing reroute nodes."""

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -420,7 +420,7 @@ def extract_property(target_val: object, id_block: bpy.types.ID, data_path: str,
 		animation=get_animation_fingerprint(precision, id_block, data_path)
 	)
 
-def get_material_fingerprint(material: bpy.types.Material, exclude_settings: bool, use_action_names: bool, precision: int) -> MaterialFingerprint:
+def get_material_fingerprint(material: bpy.types.Material, compare_settings: bool, use_action_names: bool, precision: int) -> MaterialFingerprint:
 	"""Generates a unique signature of a material's node tree and render settings to identify duplicates."""
 	fp = MaterialFingerprint()
 
@@ -456,7 +456,7 @@ def get_material_fingerprint(material: bpy.types.Material, exclude_settings: boo
 		fp.animation = None
 
 	# 4. Gather Settings and Line Art
-	if not exclude_settings:
+	if compare_settings:
 		# Material Render Settings
 		fp.render_settings = {
 			prop.identifier: extract_property(getattr(material, prop.identifier), material, prop.identifier, precision)
@@ -670,31 +670,56 @@ class MCPREP_OT_combine_materials(bpy.types.Operator):
 	bl_description = "Consolidate duplicate materials based on nodes or name"
 	bl_options = {'REGISTER', 'UNDO'}
 
-	group_by_name: bpy.props.BoolProperty(
-		name="Group Method: Material Name",
-		description="Finds materials with the same name (ignoring extensions like .001)",
-		default=False)
-
 	selection_only: bpy.props.BoolProperty(
 		name="Selection only",
-		description="Build materials to consolidate based on selected objects only",
+		description="Only check materials used by selected objects",
+		default=True)
+
+	compare_name: bpy.props.BoolProperty(
+		name="Compare Material Name",
+		description="Only compare materials with matching base names (ignores .001, .002, etc.)",
 		default=False)
 
-	exclude_mat_settings: bpy.props.BoolProperty(
-		name="Exclude Material Settings",
-		description="Do not compare materials settings, only nodes",
+	compare_settings: bpy.props.BoolProperty(
+		name="Compare Material Settings",
+		description="Compare materials settings alongside nodes",
+		default=True)
+
+	compare_action_name: bpy.props.BoolProperty(
+		name="Compare Action Name",
+		description="Treat materials with different Action names as unique, even if their animation data matches",
 		default=False)
 
-	use_action_names: bpy.props.BoolProperty(
-		name="Differentiate by Action Name",
-		description="If true, materials with identical animation but different Action names will be kept separate",
-		default=False)
+	matching_precision: bpy.props.EnumProperty(
+		items=[
+			('OFF', "Off (Exact)", "No rounding. Values must match exactly"),
+			('STRICT', "Strict (4 decimals)", "High precision matching. Values must be nearly identical (e.g. 0.1234)"),
+			('LOOSE', "Loose (2 decimals)", "Forgiving matching. Values like 0.12 and 0.124 will match"),
+			('ROUGH', "Rough (1 decimal)", "Very loose matching. Values like 0.1 and 0.14 will match"),
+		],
+		name="Value Matching",
+		description="Controls how precisely float values are compared (node inputs, colors, vectors, animation keyframes)",
+		default='STRICT'
+	)
 
-	precision: bpy.props.IntProperty(
-		name="Matching Precision",
-		description="Number of decimal places to round values to when comparing. Higher = stricter",
-		min=0, max=6,
-		default=4)
+	master_selection: bpy.props.EnumProperty(
+		items=[
+		('LOW_NODES', "Fewest Nodes",
+		"Keep the simplest material (fewest nodes)."),
+
+		('HIGH_NODES', "Most Nodes",
+		"Keep the most complex material (most nodes)."),
+
+		('HIGH_USERS', "Most Users",
+		"Keep the material used by the most objects."),
+
+		('LOW_USERS', "Fewest Users",
+		"Keep the material used by the fewest objects."),
+		],
+		name="Material to Keep",
+		description="Choose which material remains when duplicates are merged. All others are remapped to the selected material",
+		default='LOW_NODES'
+	)
 
 	skipUsage: bpy.props.BoolProperty(default=False, options={'HIDDEN'})
 
@@ -734,8 +759,8 @@ class MCPREP_OT_combine_materials(bpy.types.Operator):
 		fingerprint_groups = {}
 
 		for mat in materials_to_check:
-			group_key = util.nameGeneralize(mat.name) if self.group_by_name else "GLOBAL"
-			fp = get_material_fingerprint(mat, self.exclude_mat_settings, self.use_action_names, self.precision)
+			group_key = util.nameGeneralize(mat.name) if self.compare_name else "GLOBAL"
+			fp = get_material_fingerprint(mat, self.compare_settings, self.compare_action_name, precision_val)
 
 			if group_key not in fingerprint_groups:
 				fingerprint_groups[group_key] = []
@@ -801,18 +826,18 @@ class MCPREP_OT_combine_images(bpy.types.Operator):
 	bl_description = "Find and merge duplicate images, remapping users to a single image"
 	bl_options = {'REGISTER', 'UNDO'}
 
-	group_by_name: bpy.props.BoolProperty(
-		name="Group by Name",
-		description="Compare duplicates using base names (e.g., 'Texture.001' matches 'Texture')",
-		default=True)
-
 	selection_only: bpy.props.BoolProperty(
 		name="Selection only",
 		description="Only check images used by materials on selected objects",
-		default=False)
+		default=True)
 
-	strict_comparison: bpy.props.BoolProperty(
-		name="Strict Comparison",
+	compare_name: bpy.props.BoolProperty(
+		name="Compare Image Name",
+		description="Compare duplicates using base names (e.g., 'Texture.001' matches 'Texture')",
+		default=True)
+
+	compare_pixels: bpy.props.BoolProperty(
+		name="Compare Pixels (slower)",
 		description="Compare full image content instead of samples. More accurate, but slower for large images",
 		default=False)
 
@@ -869,7 +894,7 @@ class MCPREP_OT_combine_images(bpy.types.Operator):
 			if w == 0 or h == 0 or not img.has_data:
 				continue
 
-			base_name = util.nameGeneralize(img.name) if self.group_by_name else "GLOBAL"
+			base_name = util.nameGeneralize(img.name) if self.compare_name else "GLOBAL"
 			groups.append((base_name, w, h, img))
 
 		# Comparison and Remapping
@@ -891,7 +916,7 @@ class MCPREP_OT_combine_images(bpy.types.Operator):
 			# comparison, which checks the actual pixels, this
 			# sums up the pixels and uses that to represent the
 			# image contents
-			if not self.strict_comparison:
+			if not self.compare_pixels:
 				num_pixels = w * h * 4
 				stride = max(1, num_pixels // RGBA_PIXELS_4096_MAX)
 				cur_img_data = img_array[::stride] if stride > 1 else img_array
@@ -909,7 +934,7 @@ class MCPREP_OT_combine_images(bpy.types.Operator):
 			for uni_image, uni_data, uni_sum in unique_images[cur_img_key]:
 				# Fast prefilter, used as an alternative
 				# to strict comparison
-				if not self.strict_comparison and not pix_sum == uni_sum:
+				if not self.compare_pixels and not pix_sum == uni_sum:
 					continue
 				elif not np.array_equal(uni_data, img_array):
 					continue

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -527,7 +527,7 @@ class MCPREP_OT_combine_materials(bpy.types.Operator):
 	bl_idname = "mcprep.combine_materials"
 	bl_label = "Combine materials"
 	bl_description = "Consolidate duplicate materials based on nodes or name"
-	bl_options = {'REGISTER', 'UNDO'} #add group_undo?
+	bl_options = {'REGISTER', 'UNDO'}
 
 	group_by_name: bpy.props.BoolProperty(
 		name="Group Method: Material Name",

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -52,12 +52,12 @@ IGNORE_PROPS = (
 	'color', 'parent', 'internal_links', 'texture_mapping', 'color_mapping', 'node_tree'
 )
 
-IGNORE_MAT_SETTINGS = {
+IGNORE_MAT_SETTINGS = (
 	'name', 'use_fake_user', 'is_runtime_data', 'tag', 'asset_data',
 	'preview_render_type', 'use_preview_world', 'use_nodes', 'node_tree',
 	'diffuse_color', 'specular_color', 'roughness', 'specular_intensity',
 	'metallic', 'line_color', 'animation_data'
-}
+)
 
 # -----------------------------------------------------------------------------
 # UI and utility functions
@@ -408,7 +408,7 @@ def get_node_group_fingerprint(node_tree: bpy.types.NodeTree) -> Optional[Dict[s
 					node_data["inputs"].append(input_data)
 
 
-		if node.bl_idname in {'ShaderNodeGroup', 'GeometryNodeGroup'} and node.node_tree: # 'GeometryNodeGroup' included for future merge geoNode operator
+		if node.bl_idname in ('ShaderNodeGroup', 'GeometryNodeGroup') and node.node_tree: # 'GeometryNodeGroup' included for future merge geoNode operator
 			node_data["group_content"] = get_node_group_fingerprint(node.node_tree)
 		nodes_data.append(node_data)
 
@@ -437,7 +437,7 @@ def count_total_nodes(material: bpy.types.Material) -> int:
 				continue
 			count += 1
 			# If it's a group, count its internal nodes too
-			if node.bl_idname in {'ShaderNodeGroup', 'GeometryNodeGroup'} and node.node_tree:
+			if node.bl_idname in ('ShaderNodeGroup', 'GeometryNodeGroup') and node.node_tree:
 				count += _recursive_count(node.node_tree)
 		return count
 
@@ -479,7 +479,7 @@ def get_connected_nodes(node_tree: bpy.types.NodeTree) -> Set[bpy.types.Node]:
 	"""
 	if not node_tree:
 		return set()
-	outputNodes = [n for n in node_tree.nodes if n.bl_idname in {'ShaderNodeOutputMaterial', 'NodeGroupOutput'}]
+	outputNodes = [n for n in node_tree.nodes if n.bl_idname in ('ShaderNodeOutputMaterial', 'NodeGroupOutput')]
 	connected = set()
 	queue = deque(outputNodes)
 	while queue:

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -254,7 +254,9 @@ class MaterialFingerprint:
 
 def serialize_fcurve(precision: int, fcurve: bpy.types.FCurve) -> FCurveData:
 	"""
-	Converts an F-Curve data-block into a dictionary of primitive values for structural comparison.
+	Converts a Blender F-Curve into a dataclass.
+	Returns None if the curve has 1 or fewer keyframes, as this doesn't 
+	constitute a functional animation for comparison purposes.
 	"""
 	fcurve.keyframe_points.sort()
 
@@ -268,7 +270,8 @@ def serialize_fcurve(precision: int, fcurve: bpy.types.FCurve) -> FCurveData:
 
 def serialize_keyframe(precision: int, kp: bpy.types.Keyframe) -> KeyframeData:
 	"""
-	Serializes individual keyframe points, rounding float values to ensure consistent hashing.
+	Extracts essential keyframe data: coordinates, handle positions, 
+	interpolation types, and dynamic easing properties (Back/Bounce/Elastic).
 	"""
 	return KeyframeData(
 		co=(round(kp.co[0], precision), round(kp.co[1], precision)),
@@ -284,7 +287,7 @@ def serialize_keyframe(precision: int, kp: bpy.types.Keyframe) -> KeyframeData:
 def get_animation_fingerprint(precision: int, id_data: bpy.types.ID, data_path: Optional[str] = None, array_index: Optional[int] = -1) -> Optional[List[FCurveData]]:
 	"""
 	Retrieves the animation data for a specific property or data-block as a serializable fingerprint.
-	"""
+	"""	
 	if not id_data.animation_data or not id_data.animation_data.action:
 		return None
 
@@ -301,10 +304,9 @@ def get_animation_fingerprint(precision: int, id_data: bpy.types.ID, data_path: 
 		return None
 	return [serialize_fcurve(precision, f) for f in fcurve]
 
-def get_driver_fingerprint(precision: int, id_data: bpy.types.ID, data_path: str, array_index: Optional[int] = -1) -> Optional[DriverFingerprint]:
-	"""
-	Captures driver expressions, variables, and modifier stacks into a serializable structure.
-	"""
+def get_driver_fingerprint(precision: int, id_data: bpy.types.ID, data_path: str, array_index: int = 0) -> Optional[DriverFingerprint]:
+	"""Captures drivers math (expression), inputs (variables), and modifiers."""
+
 	if not id_data.animation_data or not id_data.animation_data.drivers:
 		return None
 		
@@ -373,21 +375,14 @@ def get_driver_fingerprint(precision: int, id_data: bpy.types.ID, data_path: str
 
 # --- NODE TREE ANALYSIS ---
 
-def get_material_fingerprint(material: bpy.types.Material, exclude_settings: bool, use_action_names: bool,	precision: int) -> MaterialFingerprint:
 	"""
-	Generates a unique signature of a material's node tree and render settings to identify duplicates.
-	"""
-	mat_type = "FIXED_MAT"
-	diffuse = None
-	roughness = None
-	metallic = None
-	node_tree_data = None
-	mat_action_name = 'None'
-	node_tree_action_name = 'None'
-	anim = None
-	render_settings = None
-	line_art_settings = None
+	Bundles a property's current value with its associated animation 
+	and driver data.
 
+	target_val: The actual value (already retrieved).
+	id_block: The owner of the animation (Material/NodeTree).
+	data_path: The RNA path for driver/animation lookup.
+	"""
 	if not material.node_tree:
 		mat_type = "FIXED_MAT"
 		diffuse = to_primitive(material.diffuse_color, precision)
@@ -463,10 +458,7 @@ def get_material_fingerprint(material: bpy.types.Material, exclude_settings: boo
 	)
 
 def get_node_group_fingerprint(node_tree: bpy.types.NodeTree, precision: int) -> Optional[NodeTreeFingerprint]:
-	"""
-	Recursively maps the connected node network, properties, and internal group contents.
-	"""
-	if not node_tree: return None
+	"""Recursively maps the connected node network, properties, and internal group contents."""   
 	active_nodes = get_connected_nodes(node_tree)
 	nodes_data = []
 
@@ -547,21 +539,8 @@ def get_node_group_fingerprint(node_tree: bpy.types.NodeTree, precision: int) ->
 
 def count_total_nodes(material: bpy.types.Material) -> int:
 	"""
-	Performs a recursive count of all functional nodes within a material and its nested node groups.
-	"""
-	if not material.node_tree:
-		return 0
-
-	def _recursive_count(node_tree):
-		count = 0
-		for node in node_tree.nodes:
-			if node.bl_idname in {'NodeFrame', 'NodeReroute'}:
-				continue
-			count += 1
-			# If it's a group, count its internal nodes too
-			if node.bl_idname in ('ShaderNodeGroup', 'GeometryNodeGroup') and node.node_tree:
-				count += _recursive_count(node.node_tree)
-		return count
+	Counts all functional nodes. If a NodeGroup is found, 
+	it enters that sub-tree and adds those nodes to the total count.
 
 	return _recursive_count(material.node_tree)
 
@@ -580,7 +559,7 @@ def to_primitive(val, decimals: int = 4) -> Primitive:
 	return str(val)
 
 def trace_socket(socket: bpy.types.NodeSocket) -> bpy.types.NodeSocket:
-	"""
+	"""Follows a node socket link back to its source, traversing reroute nodes."""
 	Follows a node socket link back to its source, traversing reroute nodes.
 	"""
 	if not socket or not socket.is_linked:
@@ -597,7 +576,9 @@ def trace_socket(socket: bpy.types.NodeSocket) -> bpy.types.NodeSocket:
 
 def get_connected_nodes(node_tree: bpy.types.NodeTree) -> Set[bpy.types.Node]:
 	"""
-	Identifies all nodes that are functionally connected to a material or group output.
+	Traces the node tree backwards from the Material or Group outputs.
+	This ensures we only fingerprint nodes that actually contribute 
+	to the final render, ignoring "floating" or disconnected nodes.
 	"""
 	if not node_tree:
 		return set()

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -23,7 +23,7 @@ import bpy
 from collections import deque
 import time
 
-from typing import Dict, List, Optional, Set, Tuple, Union
+from typing import Dict, List, Optional, Set, Tuple, Union, Iterable
 from numpy.typing import NDArray
 
 from dataclasses import dataclass
@@ -65,7 +65,6 @@ IGNORE_MAT_SETTINGS = (
 # -----------------------------------------------------------------------------
 # UI and utility functions
 # -----------------------------------------------------------------------------
-
 
 def reload_materials(context):
 	"""Reload the material UI list"""
@@ -143,6 +142,7 @@ class ListMaterials(bpy.types.PropertyGroup):
 # Dataclasses for material comparison 
 # -----------------------------------------------------------------------------
 
+Primitive = Union[int, float, str, bool, Tuple['Primitive', ...], None]
 
 class AnimState(Enum):
 	"""Represents the presence or absence of animation data."""
@@ -284,7 +284,8 @@ def serialize_keyframe(precision: int, kp: bpy.types.Keyframe) -> KeyframeData:
 	)
 
 # --- ANIMATION & DRIVER LOGIC ---
-def get_animation_fingerprint(precision: int, id_data: bpy.types.ID, data_path: Optional[str] = None, array_index: Optional[int] = -1) -> Optional[List[FCurveData]]:
+
+def get_animation_fingerprint(precision: int, id_data: bpy.types.ID, data_path: Optional[str] = None, array_index: int = -1) -> Optional[List[FCurveData]]:
 	"""
 	Retrieves the animation data for a specific property or data-block as a serializable fingerprint.
 	"""	

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -285,7 +285,12 @@ def get_driver_fingerprint(precision: int, id_data: bpy.types.ID, data_path: str
 	if not id_data.animation_data:
 		return None
 
-	fcurve = next((d for d in id_data.animation_data.drivers if d.data_path == data_path and (array_index is None or d.array_index == array_index)), None)
+	fcurve: Optional[bpy.types.FCurve] = None
+	for d in id_data.animation_data.drivers:
+		if d.data_path == data_path and (array_index is None or d.array_index == array_index):
+			fcurve = d
+			break
+
 	if not fcurve:
 		return None
 

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -258,7 +258,7 @@ class MaterialFingerprint:
 
 # --- SERIALIZATION HELPERS ---
 
-def serialize_fcurve(precision: int, fcurve: bpy.types.FCurve) -> Optional[FCurveData]:
+def serialize_fcurve(precision: float, fcurve: bpy.types.FCurve) -> Optional[FCurveData]:
 	"""
 	Converts a Blender F-Curve into a dataclass.
 	Returns None if the curve has 1 or fewer keyframes, as this doesn't
@@ -280,7 +280,7 @@ def serialize_fcurve(precision: int, fcurve: bpy.types.FCurve) -> Optional[FCurv
 		keyframes=[serialize_keyframe(precision, kp) for kp in fcurve.keyframe_points]
 	)
 
-def serialize_keyframe(precision: int, kp: bpy.types.Keyframe) -> KeyframeData:
+def serialize_keyframe(precision: float, kp: bpy.types.Keyframe) -> KeyframeData:
 	"""
 	Extracts essential keyframe data: coordinates, handle positions,
 	interpolation types, and dynamic easing properties (Back/Bounce/Elastic).
@@ -294,10 +294,7 @@ def serialize_keyframe(precision: int, kp: bpy.types.Keyframe) -> KeyframeData:
 
 # --- ANIMATION & DRIVER LOGIC ---
 
-def get_animation_fingerprint(precision: int, id_data: bpy.types.ID, data_path: Optional[str] = None, array_index: int = -1) -> Optional[List[FCurveData]]:
-	"""
-	Retrieves the animation data for a specific property or data-block as a serializable fingerprint.
-	"""
+def get_animation_fingerprint(precision: float, id_data: bpy.types.ID, data_path: Optional[str] = None, array_index: int = -1) -> Optional[List[FCurveData]]:
 	if not id_data.animation_data or not id_data.animation_data.action:
 		return None
 
@@ -326,7 +323,7 @@ def get_animation_fingerprint(precision: int, id_data: bpy.types.ID, data_path: 
 	# Return None if no valid (multi-keyframe) curves were found
 	return results if results else None
 
-def get_driver_fingerprint(precision: int, id_data: bpy.types.ID, data_path: str, array_index: int = 0) -> Optional[DriverFingerprint]:
+def get_driver_fingerprint(precision: float, id_data: bpy.types.ID, data_path: str, array_index: int = 0) -> Optional[DriverFingerprint]:
 	"""Captures drivers math (expression), inputs (variables), and modifiers."""
 
 	if not id_data.animation_data or not id_data.animation_data.drivers:
@@ -408,7 +405,7 @@ def get_driver_fingerprint(precision: int, id_data: bpy.types.ID, data_path: str
 
 # --- NODE TREE ANALYSIS ---
 
-def extract_property(target_val: object, id_block: bpy.types.ID, data_path: str, precision: int) -> PropertyEntry:
+def extract_property(target_val: object, id_block: bpy.types.ID, data_path: str, precision: float) -> PropertyEntry:
 	"""
 	Bundles a property's current value with its associated animation
 	and driver data.
@@ -423,7 +420,7 @@ def extract_property(target_val: object, id_block: bpy.types.ID, data_path: str,
 		animation=get_animation_fingerprint(precision, id_block, data_path)
 	)
 
-def get_material_fingerprint(material: bpy.types.Material, compare_settings: bool, use_action_names: bool, precision: int) -> MaterialFingerprint:
+def get_material_fingerprint(material: bpy.types.Material, compare_settings: bool, use_action_names: bool, precision: float) -> MaterialFingerprint:
 	"""Generates a unique signature of a material's node tree and render settings to identify duplicates."""
 	fp = MaterialFingerprint()
 
@@ -478,7 +475,7 @@ def get_material_fingerprint(material: bpy.types.Material, compare_settings: boo
 
 	return fp
 
-def get_node_group_fingerprint(node_tree: bpy.types.NodeTree, precision: int) -> Optional[NodeTreeFingerprint]:
+def get_node_group_fingerprint(node_tree: bpy.types.NodeTree, precision: float) -> Optional[NodeTreeFingerprint]:
 	"""Recursively maps the connected node network, properties, and internal group contents."""
 	if not node_tree:
 		return
@@ -601,7 +598,7 @@ def round_value(val: object, decimals: Union[int, float, None]  = None) -> Primi
 	if isinstance(val, float):
 		if decimals == float('inf'):
 			return val  # No rounding, return original value as-is
-		
+
 		# Makes sure decimals is an int
 		decimal = round(decimals) if isinstance(decimals, (int, float)) else None
 		return round(val, decimal)
@@ -1029,7 +1026,6 @@ class MCPREP_OT_combine_images(bpy.types.Operator):
 		else:
 			self.report({"INFO"}, "No duplicates found")
 		return {'FINISHED'}
-
 
 
 class MCPREP_OT_replace_missing_textures(bpy.types.Operator):

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -560,11 +560,11 @@ class MCPREP_OT_combine_materials(bpy.types.Operator):
 			for obj in context.selected_objects:
 				if hasattr(obj.data, "materials"):
 					for mat in obj.data.materials:
-						if mat and not mat.library:
+						if mat and not mat.library and not mat.is_library_indirect:
 							materials_to_check.add(mat)
 			materials_to_check = list(materials_to_check)
 		else:
-			materials_to_check = [m for m in bpy.data.materials if not m.library]
+			materials_to_check = [m for m in bpy.data.materials if not m.library and not m.is_library_indirect]
 
 		if not materials_to_check:
 			self.report({'INFO'}, "No materials found to process")
@@ -577,7 +577,7 @@ class MCPREP_OT_combine_materials(bpy.types.Operator):
 		fingerprint_groups = {}
 
 		for mat in materials_to_check:
-			group_key = mat.name.split('.')[0] if self.group_by_name else "GLOBAL"
+			group_key = util.nameGeneralize(mat.name) if self.group_by_name else "GLOBAL"
 			fp = get_material_fingerprint(mat, self.exclude_mat_settings)
 
 			if group_key not in fingerprint_groups:
@@ -614,7 +614,13 @@ class MCPREP_OT_combine_materials(bpy.types.Operator):
 			self.report({'INFO'}, "No duplicates found")
 			return {'FINISHED'}
 
+		renamed_masters = set()
 		for old_mat, master_mat in merge_map.items():
+			if master_mat not in renamed_masters:
+				new_name = util.nameGeneralize(master_mat.name)
+				if new_name != master_mat.name and new_name not in bpy.data.materials:
+					master_mat.name = new_name
+				renamed_masters.add(master_mat)
 			env.log(f"Replaced '{old_mat.name}' with '{master_mat.name}'")
 			old_mat.user_remap(master_mat)
 

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -139,7 +139,7 @@ class ListMaterials(bpy.types.PropertyGroup):
 
 
 # -----------------------------------------------------------------------------
-# Dataclasses for material comparison 
+# Dataclasses for material comparison
 # -----------------------------------------------------------------------------
 
 PrimitiveBasic = Union[int, float, str, bool, None, Vector, Color, Euler, Quaternion, Matrix]
@@ -214,7 +214,7 @@ class PropertyEntry:
 	driver: Optional[DriverFingerprint] = None
 	animation: Optional[List[FCurveData]] = None
 
-@dataclass
+@dataclass(order=True)
 class NodeLinkData:
 	"""Stores connection details between two node sockets."""
 	from_socket: str
@@ -261,7 +261,7 @@ class MaterialFingerprint:
 def serialize_fcurve(precision: int, fcurve: bpy.types.FCurve) -> Optional[FCurveData]:
 	"""
 	Converts a Blender F-Curve into a dataclass.
-	Returns None if the curve has 1 or fewer keyframes, as this doesn't 
+	Returns None if the curve has 1 or fewer keyframes, as this doesn't
 	constitute a functional animation for comparison purposes.
 	"""
 	# If there's only one keyframe, it's a static value, not an animation.
@@ -297,13 +297,13 @@ def serialize_keyframe(precision: int, kp: bpy.types.Keyframe) -> KeyframeData:
 def get_animation_fingerprint(precision: int, id_data: bpy.types.ID, data_path: Optional[str] = None, array_index: int = -1) -> Optional[List[FCurveData]]:
 	"""
 	Retrieves the animation data for a specific property or data-block as a serializable fingerprint.
-	"""	
+	"""
 	if not id_data.animation_data or not id_data.animation_data.action:
 		return None
 
 	action = id_data.animation_data.action
 	fcurves_to_serialize = []
-	
+
 	# Gather relevant curves:
 	if data_path:
 		found = action.fcurves.find(data_path, index=array_index)
@@ -311,13 +311,13 @@ def get_animation_fingerprint(precision: int, id_data: bpy.types.ID, data_path: 
 			fcurves_to_serialize = [found]
 	else:
 		fcurves_to_serialize = sorted(
-			[f for f in action.fcurves if f.is_valid], 
+			[f for f in action.fcurves if f.is_valid],
 			key=lambda f: (f.data_path, f.array_index)
 		)
 
 	# Serialize and Filter
 	results: List[FCurveData] = []
-	
+
 	for fcurve in fcurves_to_serialize:
 		serialized = serialize_fcurve(precision, fcurve)
 		if serialized is not None:
@@ -326,7 +326,7 @@ def get_animation_fingerprint(precision: int, id_data: bpy.types.ID, data_path: 
 	# Return None if no valid (multi-keyframe) curves were found
 	return results if results else None
 
-def get_driver_fingerprint(precision: int, id_data: bpy.types.ID, data_path: str, array_index: int = -1) -> Optional[DriverFingerprint]:
+def get_driver_fingerprint(precision: int, id_data: bpy.types.ID, data_path: str, array_index: int = 0) -> Optional[DriverFingerprint]:
 	"""Captures drivers math (expression), inputs (variables), and modifiers."""
 
 	if not id_data.animation_data or not id_data.animation_data.drivers:
@@ -353,7 +353,7 @@ def get_driver_fingerprint(precision: int, id_data: bpy.types.ID, data_path: str
 
 			# - Contextual Logic: Only capture attributes relevant to the variable type.
 			# This prevents "noise" / irrelevant unused attributes in the driver results
-			
+
 			# - Property based variables (getting a value from a UI field)
 			if var_type in ('SINGLE_PROP', 'CONTEXT_PROP'):
 				tar_obj.data_path = tar.data_path
@@ -361,24 +361,24 @@ def get_driver_fingerprint(precision: int, id_data: bpy.types.ID, data_path: str
 					tar_obj.id_type = tar.id_type
 				else:
 					tar_obj.context_property = tar.context_property
-			
+
 			# - Transform based variables (getting Loc/Rot/Scale from 3D space)
 			elif var_type == 'TRANSFORMS':
 				tar_obj.transform_type = tar.transform_type
 				tar_obj.transform_space = tar.transform_space
 				if tar.transform_type.startswith("ROT"):
 					tar_obj.rotation_mode = tar.rotation_mode
-			
+
 			# - Distance-based variables
 			elif var_type == 'LOC_DIFF':
 				tar_obj.transform_space = tar.transform_space
-			
+
 			# Bones require a specific sub-target name within an Armature
 			if tar.id and tar.id.type == 'ARMATURE' and tar.bone_target:
 				tar_obj.bone_target = tar.bone_target
 
 			targets.append(tar_obj)
-		
+
 		variables.append(DriverVariableData(name=var.name, var_type=var_type, targets=targets))
 
 	# Capture Driver F-Curve Influence and Modifiers
@@ -410,7 +410,7 @@ def get_driver_fingerprint(precision: int, id_data: bpy.types.ID, data_path: str
 
 def extract_property(target_val: object, id_block: bpy.types.ID, data_path: str, precision: int) -> PropertyEntry:
 	"""
-	Bundles a property's current value with its associated animation 
+	Bundles a property's current value with its associated animation
 	and driver data.
 
 	target_val: The actual value (already retrieved).
@@ -479,7 +479,7 @@ def get_material_fingerprint(material: bpy.types.Material, compare_settings: boo
 	return fp
 
 def get_node_group_fingerprint(node_tree: bpy.types.NodeTree, precision: int) -> Optional[NodeTreeFingerprint]:
-	"""Recursively maps the connected node network, properties, and internal group contents."""   
+	"""Recursively maps the connected node network, properties, and internal group contents."""
 	if not node_tree:
 		return
 
@@ -488,7 +488,7 @@ def get_node_group_fingerprint(node_tree: bpy.types.NodeTree, precision: int) ->
 	active_nodes = get_connected_nodes(node_tree)
 	nodes_data: List[NodeFingerprint] = []
 
-	# Sort: We sort by type and name so that the order of nodes in 
+	# Sort: We sort by type and name so that the order of nodes in
 	# the list is always identical (deterministic) for the same setup.
 	for node in sorted(active_nodes, key=lambda n: (n.bl_idname, n.name)):
 		if node.bl_idname in ('NodeFrame', 'NodeReroute'):
@@ -548,7 +548,7 @@ def get_node_group_fingerprint(node_tree: bpy.types.NodeTree, precision: int) ->
 
 def node_tree_counter(node_tree: bpy.types.NodeTree) -> int:
 	"""
-	Counts all functional nodes. If a NodeGroup is found, 
+	Counts all functional nodes. If a NodeGroup is found,
 	it enters that sub-tree and adds those nodes to the total count.
 	"""
 	count = 0
@@ -629,7 +629,7 @@ def trace_socket(dest_socket: bpy.types.NodeSocket) -> bpy.types.NodeSocket:
 	"""Follows a node socket link back to its source, traversing reroute nodes."""
 	if not dest_socket or not dest_socket.is_linked:
 		return dest_socket
-	
+
 	# Start at the first link connected to the destination socket
 	current_link = dest_socket.links[0]
 	source_node = current_link.from_node
@@ -639,7 +639,7 @@ def trace_socket(dest_socket: bpy.types.NodeSocket) -> bpy.types.NodeSocket:
 		reroute_input = source_node.inputs[0]
 		if not reroute_input.is_linked:
 			return reroute_input
-		
+
 		current_link = reroute_input.links[0]
 		source_node = current_link.from_node
 
@@ -649,12 +649,12 @@ def trace_socket(dest_socket: bpy.types.NodeSocket) -> bpy.types.NodeSocket:
 def get_connected_nodes(node_tree: bpy.types.NodeTree) -> Set[bpy.types.Node]:
 	"""
 	Traces the node tree backwards from the Material or Group outputs.
-	This ensures we only fingerprint nodes that actually contribute 
+	This ensures we only fingerprint nodes that actually contribute
 	to the final render, ignoring "floating" or disconnected nodes.
 	"""
 	if not node_tree:
 		return set()
-	
+
 	# Identify the starting output node of the data flow - typically the Material Output node, but also Group Outputs for nested groups
 	outputs = [n for n in node_tree.nodes if n.bl_idname in ('ShaderNodeOutputMaterial', 'NodeGroupOutput')]
 	connected = set()
@@ -781,7 +781,7 @@ class MCPREP_OT_combine_materials(bpy.types.Operator):
 			for obj in context.selected_objects:
 				if not hasattr(obj.data, "materials"):
 					continue
-				
+
 				for mat in obj.data.materials:
 					if not mat or mat.library or mat.is_library_indirect:
 						continue

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -760,7 +760,6 @@ class MCPREP_OT_combine_materials(bpy.types.Operator):
 					continue
 
 				# Sort materials by total node count (add option for user to decide, least or greatest node count. What about number of users?), then by name length as a tie-breaker
-				mats.sort(key=lambda m: (count_total_nodes(m), len(m.name)))
 				mats.sort(key=lambda m: (count_nodes_in_material(m), len(m.name)))
 
 				master_mat = mats[0] # The one with the least nodes

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -741,7 +741,7 @@ class MCPREP_OT_combine_materials(bpy.types.Operator):
 	compare_name: bpy.props.BoolProperty(
 		name="Compare Material Name",
 		description="Only compare materials with matching base names (ignores .001, .002, etc.)",
-		default=False)
+		default=True)
 
 	compare_settings: bpy.props.BoolProperty(
 		name="Compare Material Settings",
@@ -780,6 +780,11 @@ class MCPREP_OT_combine_materials(bpy.types.Operator):
 		default='LOW_NODES'
 	)
 
+	combine_images: bpy.props.BoolProperty(
+		name="Compare image blocks",
+		description="Combine Images first",
+		default=True)
+
 	skipUsage: bpy.props.BoolProperty(default=False, options={'HIDDEN'})
 
 	def invoke(self, context, event):
@@ -791,6 +796,14 @@ class MCPREP_OT_combine_materials(bpy.types.Operator):
 		if self.selection_only and not context.selected_objects:
 			self.report({'ERROR'}, "Select objects with materials first")
 			return {'CANCELLED'}
+
+		if self.combine_images:
+			bpy.ops.mcprep.combine_images(
+				'EXEC_DEFAULT',
+				selection_only=self.selection_only,
+				group_by_name=self.compare_name,
+				strict_comparison=True
+			)
 
 		# < 0 means Exact Matching (no rounding).
 		precision_val = float('inf') if self.value_rounding < 0 else self.value_rounding

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -771,6 +771,10 @@ class MCPREP_OT_combine_materials(bpy.types.Operator):
 			self.report({'ERROR'}, "Select objects with materials first")
 			return {'CANCELLED'}
 
+		# Map Enum to numeric precision. 'inf' means Exact Matching (no rounding).
+		precision_map = {'OFF': float('inf'), 'STRICT': 4, 'LOOSE': 2, 'ROUGH': 1}
+		precision_val = precision_map.get(self.matching_precision, 4)
+
 		# 1. Gather materials
 		if self.selection_only:
 			materials_to_check = set()
@@ -816,16 +820,28 @@ class MCPREP_OT_combine_materials(bpy.types.Operator):
 
 		# 3. Determine Masters and Build Merge Map
 		merge_map = {}
+
+		# Define sort keys for Master Selection.
+		# We sort so that index 0 becomes the Master.
+		# Secondary sort key (len(m.name)) for tie-breaker.
+		sort_logic = {
+			'LOW_NODES': lambda m: (count_nodes_in_material(m), len(m.name)),
+			'HIGH_NODES': lambda m: (-count_nodes_in_material(m), len(m.name)), # Negative for Descending
+			'HIGH_USERS': lambda m: (-m.users, len(m.name)),                    # Negative for Descending
+			'LOW_USERS': lambda m: (m.users, len(m.name))
+		}
+		active_sort = sort_logic.get(self.master_selection, sort_logic['LOW_NODES'])
+
 		for group_key, entries in fingerprint_groups.items():
 			for entry in entries:
 				mats = entry['materials']
 				if len(mats) <= 1:
 					continue
 
-				# Sort materials by total node count (add option for user to decide, least or greatest node count. What about number of users?), then by name length as a tie-breaker
-				mats.sort(key=lambda m: (count_nodes_in_material(m), len(m.name)))
+				# Sort based on user selection.
+				mats.sort(key=active_sort)
 
-				master_mat = mats[0] # The one with the least nodes
+				master_mat = mats[0] # The "Winner" of the sort logic
 				for i in range(1, len(mats)):
 					merge_map[mats[i]] = master_mat
 

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -23,8 +23,8 @@ import bpy
 from collections import deque
 import time
 
-from typing import Dict, List, Optional, Set, Tuple, Union, Iterable
-from numpy.typing import NDArray
+from typing import Dict, List, Optional, Set, Tuple, Union, Iterable, Mapping, Any
+from mathutils import Vector, Color, Euler, Quaternion, Matrix
 
 from dataclasses import dataclass
 
@@ -142,7 +142,8 @@ class ListMaterials(bpy.types.PropertyGroup):
 # Dataclasses for material comparison 
 # -----------------------------------------------------------------------------
 
-Primitive = Union[int, float, str, bool, Tuple['Primitive', ...], None]
+PrimitiveBasic = Union[int, float, str, bool, None, Vector, Color, Euler, Quaternion, Matrix]
+Primitive = Union[PrimitiveBasic, Tuple['Primitive', ...]]
 
 class AnimState(Enum):
 	"""Represents the presence or absence of animation data."""
@@ -152,10 +153,10 @@ class AnimState(Enum):
 @dataclass
 class KeyframeData:
 	"""Stores keyframe coordinate, handle, and dynamic data."""
-	co: Tuple[float, float]
-	handles: Tuple[float, float, float, float] # left_x, left_y, right_x, right_y
-	types: Tuple[str, str, str, str]		   # handle_l, handle_r, interp, easing
-	dynamics: Tuple[float, float, float]	   # back, amplitude, period
+	co: Iterable[float]
+	handles: Iterable[float] 			# left_x, left_y, right_x, right_y
+	types: Tuple[str, str, str, str]	# handle_l, handle_r, interp, easing
+	dynamics: Iterable[float]	   		# back, amplitude, period
 
 @dataclass
 class FCurveData:
@@ -517,22 +518,28 @@ def get_node_group_fingerprint(node_tree: bpy.types.NodeTree, precision: int) ->
 			group_content=nested_group
 		))
 
-	# Links: Define the "wiring" of the network. 
+	# Links: Define the "wiring" of the network.
 	# We trace from the Destination (input) back to the Source (output).
-	links_data = [
-		NodeLinkData(
-			from_socket=(source_socket := trace_socket(dest_socket)).name,
-			from_node=source_socket.node.bl_idname,
-			to_socket=dest_socket.name,
-			to_node=node.bl_idname)
+	links_data = []
+	for node in active_nodes:
+		if node.bl_idname in ('NodeFrame', 'NodeReroute'):
+			continue
 
-		for node in active_nodes if node.bl_idname not in ('NodeFrame', 'NodeReroute')
-		for dest_socket in node.inputs if dest_socket.is_linked and (source_socket := trace_socket(dest_socket)).node in active_nodes
-	]
+		for dest_socket in node.inputs:
+			if not dest_socket.is_linked:
+				continue
 
-	# Sorting links by a string representation ensures the link order 
-	# doesn't change if the user re-wired nodes in a different sequence.
-	return NodeTreeFingerprint(nodes=nodes_data, links=sorted(links_data, key=lambda x: str(x)))
+			source_socket = trace_socket(dest_socket)
+			if source_socket.node in active_nodes:
+				links_data.append(NodeLinkData(
+					from_socket=source_socket.name,
+					from_node=source_socket.node.bl_idname,
+					to_socket=dest_socket.name,
+					to_node=node.bl_idname
+				))
+
+	# Sorting links via dataclass native sorting (order=True) ensures determinism.
+	return NodeTreeFingerprint(nodes=nodes_data, links=sorted(links_data))
 
 def node_tree_counter(node_tree: bpy.types.NodeTree) -> int:
 	"""
@@ -928,7 +935,7 @@ class MCPREP_OT_combine_images(bpy.types.Operator):
 		# Value: List of (image_obj, comparison_array, sum)
 		# store both the image (for remapping later on), the pixel array,
 		# and pixel array sum for super fast prefilter
-		unique_images: Dict[Tuple[str, int, int], List[Tuple[bpy.types.Image, NDArray[np.float32], Optional[np.float64]]]] = {}
+		unique_images: Dict[Tuple[str, int, int], List[Tuple[bpy.types.Image, np.ndarray, Optional[np.float64]]]] = {}
 		images_to_remove = []
 
 		for base_name, w, h, img in groups:

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -405,6 +405,7 @@ def get_driver_fingerprint(precision: int, id_data: bpy.types.ID, data_path: str
 
 # --- NODE TREE ANALYSIS ---
 
+def extract_property(target_val: object, id_block: bpy.types.ID, data_path: str, precision: int) -> PropertyEntry:
 	"""
 	Bundles a property's current value with its associated animation 
 	and driver data.
@@ -413,159 +414,128 @@ def get_driver_fingerprint(precision: int, id_data: bpy.types.ID, data_path: str
 	id_block: The owner of the animation (Material/NodeTree).
 	data_path: The RNA path for driver/animation lookup.
 	"""
+	return PropertyEntry(
+		val=serialize_value(target_val, precision),
+		driver=get_driver_fingerprint(precision, id_block, data_path),
+		animation=get_animation_fingerprint(precision, id_block, data_path)
+	)
+
+def get_material_fingerprint(material: bpy.types.Material, exclude_settings: bool, use_action_names: bool, precision: int) -> MaterialFingerprint:
+	"""Generates a unique signature of a material's node tree and render settings to identify duplicates."""
+	fp = MaterialFingerprint()
+
+	# 1. Handle Surface Type
 	if not material.node_tree:
-		mat_type = "FIXED_MAT"
-		diffuse = to_primitive(material.diffuse_color, precision)
-		roughness = to_primitive(material.roughness, precision)
-		metallic = to_primitive(material.metallic, precision)
+		fp.mat_type = "FIXED_MAT"
+		fp.diffuse = serialize_value(material.diffuse_color, precision)
+		fp.roughness = serialize_value(material.roughness, precision)
+		fp.metallic = serialize_value(material.metallic, precision)
 	else:
-		mat_type = "NODE_TREE"
-		node_tree_data = get_node_group_fingerprint(material.node_tree, precision)
+		fp.mat_type = "NODE_TREE"
+		fp.node_tree_data = get_node_group_fingerprint(material.node_tree, precision)
 
-	# Gather Animation
+	# 2. Gather Action Names (Optional metadata)
 	if use_action_names:
-		# Material level action
-		mat_action_name = material.animation_data.action.name if (material.animation_data and material.animation_data.action) else 'None'
+		if material.animation_data and material.animation_data.action:
+			fp.mat_action_name = material.animation_data.action.name
+		
+		nt = material.node_tree
+		if nt and nt.animation_data and nt.animation_data.action:
+			fp.node_tree_action_name = nt.animation_data.action.name
 
-		# Node Tree level action
-		if material.node_tree and material.node_tree.animation_data and material.node_tree.animation_data.action:
-			node_tree_action_name = material.node_tree.animation_data.action.name
-		else:
-			node_tree_action_name = 'None'
+	# 3. Full Animation Data (F-Curves)
+	anim_list = get_animation_fingerprint(precision, material)
+	if anim_list:
+		fp.animation = {}
+		for f in anim_list:
+			# Group by data_path to match Dict[str, List[FCurveData]]
+			if f.data_path not in fp.animation:
+				fp.animation[f.data_path] = []
+			fp.animation[f.data_path].append(f)
+	else:
+		fp.animation = None
 
-	anim = get_animation_fingerprint(precision, material)
-
-	# Gather Material / Render Settings
+	# 4. Gather Settings and Line Art
 	if not exclude_settings:
-		render_settings = {}
-		for prop in material.bl_rna.properties:
-			if prop.is_readonly or prop.identifier in IGNORE_MAT_SETTINGS:
-				continue
+		# Material Render Settings
+		fp.render_settings = {
+			prop.identifier: extract_property(getattr(material, prop.identifier), material, prop.identifier, precision)
+			for prop in material.bl_rna.properties
+			if not prop.is_readonly and prop.identifier not in IGNORE_MAT_SETTINGS
+		}
 
-			val_data = PropertyEntry(val=to_primitive(getattr(material, prop.identifier), precision))
-
-			# Check for driver
-			driver = get_driver_fingerprint(precision, material, prop.identifier)
-			if driver is not None:
-				val_data.driver = driver
-
-			render_settings[prop.identifier] = val_data
-
-		# Gather Line Art Settings
-		line_art_settings = {}
+		# Line Art Settings (Nested object property)
 		if hasattr(material, "lineart"):
 			la = material.lineart
-			for prop in la.bl_rna.properties:
-				if prop.is_readonly or prop.identifier in IGNORE_MAT_SETTINGS:
-					continue
+			fp.line_art_settings = {
+				prop.identifier: extract_property(getattr(la, prop.identifier), material, f"lineart.{prop.identifier}", precision)
+				for prop in la.bl_rna.properties
+				if not prop.is_readonly and prop.identifier not in IGNORE_MAT_SETTINGS
+			}
 
-				value = getattr(la, prop.identifier)
-				if hasattr(value, "__iter__") and not isinstance(value, (str, bytes)):
-					value = [to_primitive(v, precision) for v in value]
-				else:
-					value = to_primitive(value, precision)
-
-				val_data = PropertyEntry(val=value)
-
-				# Check for driver
-				driver = get_driver_fingerprint(precision, material, f"line_art.{prop.identifier}")
-				if driver is not None:
-					val_data.driver = driver
-
-				line_art_settings[prop.identifier] = val_data
-
-	return MaterialFingerprint(
-		mat_type=mat_type,
-		diffuse=diffuse,
-		roughness=roughness,
-		metallic=metallic,
-		node_tree_data=node_tree_data,
-		mat_action_name=mat_action_name,
-		node_tree_action_name=node_tree_action_name,
-		animation=anim,
-		render_settings=render_settings,
-		line_art_settings=line_art_settings
-	)
+	return fp
 
 def get_node_group_fingerprint(node_tree: bpy.types.NodeTree, precision: int) -> Optional[NodeTreeFingerprint]:
 	"""Recursively maps the connected node network, properties, and internal group contents."""   
+	if not node_tree:
+		return
+
+	# Filter: Only process nodes that actually lead to an output.
+	# This prevents 'stray' nodes from making two materials look different.
 	active_nodes = get_connected_nodes(node_tree)
-	nodes_data = []
+	nodes_data: List[NodeFingerprint] = []
 
-	for node in sorted(list(active_nodes), key=lambda n: (n.bl_idname, n.name)):
-		if node.bl_idname in {'NodeFrame', 'NodeReroute'}: continue
+	# Sort: We sort by type and name so that the order of nodes in 
+	# the list is always identical (deterministic) for the same setup.
+	for node in sorted(active_nodes, key=lambda n: (n.bl_idname, n.name)):
+		if node.bl_idname in ('NodeFrame', 'NodeReroute'):
+			continue
 
-		node_data = {"type": node.bl_idname, "muted": node.mute, "properties": {}, "inputs": []}
+		# Capture Attributes: Every input property, slider, checkbox, enum, etc. on the node.
+		properties = {
+			p.identifier: extract_property(getattr(node, p.identifier), node_tree, f'nodes["{node.name}"].{p.identifier}', precision)
+			for p in node.bl_rna.properties
+			if p.identifier not in IGNORE_PROPS and not p.is_readonly
+		}
 
-		# Properties + Drivers + Anim
-		for prop in node.bl_rna.properties:
-			if prop.identifier in IGNORE_PROPS or prop.is_readonly: continue
-			data_path = f'nodes["{node.name}"].{prop.identifier}'
+		# Capture Inputs: Only record inputs that are NOT linked (static values).
+		# Linked inputs are handled later in the 'links_data' section.
+		inputs = [
+			extract_property(socket.default_value, node_tree, f'nodes["{node.name}"].inputs[{i}].default_value', precision)
+			for i, socket in enumerate(node.inputs)
+			if not socket.is_linked and hasattr(socket, "default_value")
+		]
 
-			prop_entry = {"val": to_primitive(getattr(node, prop.identifier), precision)}
+		# RECURSION: If this node is a group, we call this function again
+		# to fingerprint the 'inside' of the group. This can go many levels deep.
+		nested_group = None
+		if node.bl_idname == 'ShaderNodeGroup' and node.node_tree:
+			nested_group = get_node_group_fingerprint(node.node_tree, precision)
 
-			# Check Driver & Anim
-			driver = get_driver_fingerprint(precision, node_tree, data_path)
-			anim = get_animation_fingerprint(precision, node_tree, data_path)
-			if driver: prop_entry["driver"] = driver
-			if anim: prop_entry["animation"] = anim
+		nodes_data.append(NodeFingerprint(
+			node_type=node.bl_idname,
+			muted=node.mute,
+			properties=properties,
+			inputs=inputs,
+			group_content=nested_group
+		))
 
-			node_data["properties"][prop.identifier] = prop_entry
+	# Links: Define the "wiring" of the network. 
+	# We trace from the Destination (input) back to the Source (output).
+	links_data = [
+		NodeLinkData(
+			from_socket=(source_socket := trace_socket(dest_socket)).name,
+			from_node=source_socket.node.bl_idname,
+			to_socket=dest_socket.name,
+			to_node=node.bl_idname)
 
-		# Inputs
-		for socket_idx, socket in enumerate(node.inputs):
-			if socket.is_linked or not hasattr(socket, "default_value"):
-				continue
+		for node in active_nodes if node.bl_idname not in ('NodeFrame', 'NodeReroute')
+		for dest_socket in node.inputs if dest_socket.is_linked and (source_socket := trace_socket(dest_socket)).node in active_nodes
+	]
 
-			default_val = socket.default_value
-			data_path = f'nodes["{node.name}"].inputs[{socket_idx}].default_value'
-
-			# Scalar
-			if isinstance(default_val, (int, float)):
-				input_data = {"idx": socket_idx, "val": to_primitive(default_val, precision)}
-
-				# Check Driver & Anim
-				driver = get_driver_fingerprint(precision, node_tree, data_path)
-				anim = get_animation_fingerprint(precision, node_tree, data_path)
-				if driver: input_data["driver"] = driver
-				if anim: input_data["animation"] = anim
-
-				node_data["inputs"].append(input_data)
-
-			# Array (RGBA / Vector)
-			else:
-				for array_idx, value in enumerate(default_val):
-
-					input_data = {
-						"idx": socket_idx,
-						"array_index": array_idx,
-						"val": value if isinstance(value, str) else round(value, 6)}
-
-					# Check Driver & Anim
-					driver = get_driver_fingerprint(precision, node_tree, data_path, array_idx)
-					anim = get_animation_fingerprint(precision, node_tree, data_path, array_idx)
-					if driver: input_data["driver"] = driver
-					if anim: input_data["animation"] = anim
-
-					node_data["inputs"].append(input_data)
-
-
-		if node.bl_idname in ('ShaderNodeGroup', 'GeometryNodeGroup') and node.node_tree: # 'GeometryNodeGroup' included for future merge geoNode operator
-			node_data["group_content"] = get_node_group_fingerprint(node.node_tree, precision)
-		nodes_data.append(node_data)
-
-	links_data = []
-	for node in active_nodes:
-		if node.bl_idname in {'NodeFrame', 'NodeReroute'}: continue
-		for socket in node.inputs:
-			if socket.is_linked:
-				src = trace_socket(socket)
-				if src.node in active_nodes:
-					links_data.append({"from_socket": src.name, "from_node": src.node.bl_idname, "to_socket": socket.name, "to_node": node.bl_idname})
-
-	return NodeTreeFingerprint(
-		nodes=nodes_data,
-		links=sorted(links_data, key=lambda x: str(x)))
+	# Sorting links by a string representation ensures the link order 
+	# doesn't change if the user re-wired nodes in a different sequence.
+	return NodeTreeFingerprint(nodes=nodes_data, links=sorted(links_data, key=lambda x: str(x)))
 
 def count_total_nodes(material: bpy.types.Material) -> int:
 	"""

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -23,7 +23,7 @@ import bpy
 from collections import deque
 import time
 
-from typing import Dict, List, Optional, Set, Tuple, Union, Any, Deque
+from typing import Dict, List, Optional, Set, Tuple, Union
 from numpy.typing import NDArray
 
 import numpy as np
@@ -135,48 +135,133 @@ class ListMaterials(bpy.types.PropertyGroup):
 	path: bpy.props.StringProperty(subtype='FILE_PATH')
 	index: bpy.props.IntProperty(min=0, default=0)  # for icon drawing
 
+
+# -----------------------------------------------------------------------------
+# Dataclasses for material comparison 
+# -----------------------------------------------------------------------------
+
+Primitive = Union[int, float, str, bool, list, None]
+
+@dataclass
+class KeyframeData:
+	co: Tuple[float, float]
+	handles: Tuple[float, float, float, float] # left_x, left_y, right_x, right_y
+	types: Tuple[str, str, str, str]		   # handle_l, handle_r, interp, easing
+	dynamics: Tuple[float, float, float]	   # back, amplitude, period
+
+@dataclass
+class FCurveData:
+	array_index: int
+	extrapolation: str
+	auto_smoothing: bool
+	mute: bool
+	keyframes: List[KeyframeData]
+
+@dataclass
+class DriverVariableTarget:
+	id_name: str
+	data_path: str = ""
+	bone_target: str = ""
+	id_type: str = ""
+	transform_type: str = ""
+	transform_space: str = ""
+	rotation_mode: str = ""
+	context_property: str = ""
+
+@dataclass
+class DriverVariableData:
+	name: str
+	var_type: str
+	targets: List[DriverVariableTarget]
+
+@dataclass
+class DriverModifierData:
+	mod_type: str
+	settings: Dict[str, Primitive]
+
+@dataclass
+class DriverFingerprint:
+	drv_type: str
+	expression: Optional[str]
+	variables: List[DriverVariableData]
+	fcurve: FCurveData
+	modifiers: List[DriverModifierData]
+
+@dataclass
+class PropertyEntry:
+	val: Primitive
+	driver: Optional[DriverFingerprint] = None
+	animation: Optional[List[FCurveData]] = None
+
+class NodeLinkData:
+	from_socket: str
+	from_node: str
+	to_socket: str
+	to_node: str
+
+@dataclass
+class NodeFingerprint:
+	node_type: str
+	muted: bool
+	properties: Dict[str, PropertyEntry]
+	inputs: List[PropertyEntry]
+	group_content: Optional['NodeTreeFingerprint'] = None
+
+@dataclass
+class NodeTreeFingerprint:
+	nodes: List[NodeFingerprint]
+	links: List[NodeLinkData]
+
+@dataclass
+class MaterialFingerprint:
+	mat_type: str = ""
+	diffuse: Optional[List[float]] = None
+	roughness: Optional[float] = None
+	metallic: Optional[float] = None
+	node_tree_data: Optional[NodeTreeFingerprint] = None
+	mat_action_name: str = 'None'
+	node_tree_action_name: str = 'None'
+	animation: Optional[Dict[str, List[FCurveData]]] = None
+	render_settings: Optional[Dict[str, PropertyEntry]] = None
+	line_art_settings: Optional[Dict[str, PropertyEntry]] = None
+
+
 # -----------------------------------------------------------------------------
 # Material structural comparison helpers
 # -----------------------------------------------------------------------------
 
 # --- SERIALIZATION HELPERS ---
 
-def serialize_fcurve(fcurve: bpy.types.FCurve) -> Dict[str, Any]:
+def serialize_fcurve(fcurve: bpy.types.FCurve) -> FCurveData:
 	"""
 	Converts an F-Curve data-block into a dictionary of primitive values for structural comparison.
 	"""
 	fcurve.keyframe_points.sort()
 
-	return {
-		"array_index": fcurve.array_index,
-		"extrapolation": fcurve.extrapolation,
-		"auto_smoothing": fcurve.auto_smoothing,
-		"mute": fcurve.mute,
-		"keyframes": [
-			serialize_keyframe(kp)
-			for kp in fcurve.keyframe_points
-		],
-	}
+	return FCurveData(
+        array_index=fcurve.array_index,
+        extrapolation=fcurve.extrapolation,
+        auto_smoothing=fcurve.auto_smoothing,
+        mute=fcurve.mute,
+        keyframes=[serialize_keyframe(kp) for kp in fcurve.keyframe_points]
+    )
 
-def serialize_keyframe(kp: bpy.types.Keyframe) -> Dict[str, Any]:
+def serialize_keyframe(kp: bpy.types.Keyframe) -> KeyframeData:
 	"""
 	Serializes individual keyframe points, rounding float values to ensure consistent hashing.
 	"""
-	return {
-		"co": tuple(round(v, 6) for v in kp.co),
-		"handle_left": tuple(round(v, 6) for v in kp.handle_left),
-		"handle_right": tuple(round(v, 6) for v in kp.handle_right),
-		"handle_left_type": kp.handle_left_type,
-		"handle_right_type": kp.handle_right_type,
-		"interpolation": kp.interpolation,
-		"easing": kp.easing,
-		"back": round(kp.back, 6),
-		"amplitude": round(kp.amplitude, 6),
-		"period": round(kp.period, 6),
-	}
+	return KeyframeData(
+        co=(round(kp.co[0]), round(kp.co[1])),
+        handles=(
+            round(kp.handle_left[0]), round(kp.handle_left[1]),
+            round(kp.handle_right[0]), round(kp.handle_right[1])
+        ),
+        types=(kp.handle_left_type, kp.handle_right_type, kp.interpolation, kp.easing),
+        dynamics=(round(kp.back), round(kp.amplitude), round(kp.period))
+    )
 
 # --- ANIMATION & DRIVER LOGIC ---
-def get_animation_fingerprint(id_data: bpy.types.ID, data_path: Optional[str] = None, array_index: Optional[int] = None) -> Optional[Dict[str, Any]]:
+def get_animation_fingerprint(id_data: bpy.types.ID, data_path: Optional[str] = None, array_index: Optional[int] = None) -> Optional[List[FCurveData]]:
 	"""
 	Retrieves the animation data for a specific property or data-block as a serializable fingerprint.
 	"""
@@ -188,12 +273,12 @@ def get_animation_fingerprint(id_data: bpy.types.ID, data_path: Optional[str] = 
 	if data_path:
 		fcurve = next((f for f in action.fcurves if f.data_path == data_path and
 					  (array_index is None or f.array_index == array_index)), None)
-		return serialize_fcurve(fcurve) if fcurve else None
+		return [serialize_fcurve(fcurve)] if fcurve else None
 
 	fcurves = sorted(action.fcurves, key=lambda f: (f.data_path, f.array_index))
-	return {"fcurves": [serialize_fcurve(f) for f in fcurves]}
+	return [serialize_fcurve(f) for f in fcurves]
 
-def get_driver_fingerprint(id_data: bpy.types.ID, data_path: str, array_index: Optional[int] = None) -> Optional[Dict[str, Any]]:
+def get_driver_fingerprint(id_data: bpy.types.ID, data_path: str, array_index: Optional[int] = None) -> Optional[DriverFingerprint]:
 	"""
 	Captures driver expressions, variables, and modifier stacks into a serializable structure.
 	"""
@@ -206,96 +291,101 @@ def get_driver_fingerprint(id_data: bpy.types.ID, data_path: str, array_index: O
 
 	drv = fcurve.driver
 
-	# 1. Basic Driver Settings
-	driver_data = {"type": drv.type,}
-	if drv.type == 'SCRIPTED':
-		driver_data["expression"] = drv.expression
 
-	# 2. Variable Logic (Only properties that affect driver result)
-
-	driver_data["variables"] = []
+	variables: List[DriverVariableData] = []
 	for var in drv.variables:
-		var_data = {"name": var.name, "type": var.type, "targets": []}
-
+		targets: List[DriverVariableTarget] = []
+		
 		for tar in var.targets:
-			tar_info = {}
-			if var.type == 'CONTEXT_PROP':
-				tar_info["context_property"] = tar.context_property
-				tar_info["data_path"] = tar.data_path
-				var_data["targets"].append(tar_info)
-				continue
+			# 1. Basic Driver Settings
+			tar_info: Dict[str, str] = {"id_name": getattr(tar.id, "name_full", tar.id.name) if tar.id else ""}
 
-			tar_info = {"id": getattr(tar.id, "name_full", tar.id.name)}
-
+			# 2. Variable Logic (Only properties that affect driver result)
 			if tar.bone_target:
 				tar_info["bone_target"] = tar.bone_target
 
-			if var.type == 'SINGLE_PROP':
+			if var.type == 'CONTEXT_PROP':
+				tar_info["context_property"] = tar.context_property
+				tar_info["data_path"] = tar.data_path
+
+			elif var.type == 'SINGLE_PROP':
 				tar_info["id_type"] = tar.id_type
 				tar_info["data_path"] = tar.data_path
 
 			elif var.type == 'TRANSFORMS':
 				tar_info["transform_type"] = tar.transform_type
+				tar_info["transform_space"] = tar.transform_space
 				if tar.transform_type.startswith("ROT"):
 					tar_info["rotation_mode"] = tar.rotation_mode
-				tar_info["transform_space"] = tar.transform_space
 
 			elif var.type == 'LOC_DIFF':
 				tar_info["transform_space"] = tar.transform_space
 
-			var_data["targets"].append(tar_info)
-		driver_data["variables"].append(var_data)
+			targets.append(DriverVariableTarget(**tar_info))
+		variables.append(DriverVariableData(name=var.name, var_type=var.type, targets=targets))
 
 	# 3. F-Curve
-	driver_data["fcurve"] = serialize_fcurve(fcurve)
-
+	driver_fcurve = serialize_fcurve(precision, fcurve)
+	
 	# 4. F-Curve Modifiers (Skip if muted or influence is 0)
-	driver_data["modifiers"] = []
+	modifiers: List[DriverModifierData] = []
 	for mod in fcurve.modifiers:
 		if mod.mute or getattr(mod, "influence", 1.0) <= 0.0:
 			continue
 
-		m_data = {"type": mod.type}
+		m_data: Dict[str, Primitive] = {}
 		for prop in mod.bl_rna.properties:
 			if not prop.is_readonly and prop.identifier not in {'name', 'type', 'is_active'}:
 				m_data[prop.identifier] = to_primitive(getattr(mod, prop.identifier))
-		driver_data["modifiers"].append(m_data)
+		
+		modifiers.append(DriverModifierData(mod_type=mod.type, settings=m_data))
 
-	return driver_data
+	return DriverFingerprint(
+		drv_type=drv.type,
+		expression=drv.expression if drv.type == 'SCRIPTED' else None,
+		variables=variables,
+		fcurve=driver_fcurve,
+		modifiers=modifiers
+	)
 
 # --- NODE TREE ANALYSIS ---
 
-def get_material_fingerprint(material: bpy.types.Material, exclude_settings: bool, use_action_names: bool) -> Dict[str, Any]:
+def get_material_fingerprint(material: bpy.types.Material, exclude_settings: bool, use_action_names: bool) -> MaterialFingerprint:
 	"""
 	Generates a unique signature of a material's node tree and render settings to identify duplicates.
 	"""
+	mat_type = "FIXED_MAT"
+	diffuse = None
+	roughness = None
+	metallic = None
+	node_tree_data = None
+	mat_action_name = 'None'
+	node_tree_action_name = 'None'
+	anim = None
+	render_settings = None
+	line_art_settings = None
+
 	if not material.node_tree:
-		fp = {
-			"type": "FIXED_MAT",
-			"diffuse": to_primitive(material.diffuse_color),
-			"roughness": material.roughness,
-			"metallic": material.metallic
-		}
+		mat_type = "FIXED_MAT"
+		diffuse = to_primitive(material.diffuse_color)
+		roughness = to_primitive(material.roughness)
+		metallic = to_primitive(material.metallic)
 	else:
-		fp = {
-			"type": "NODE_TREE",
-			"data": get_node_group_fingerprint(material.node_tree)
-		}
+		mat_type = "NODE_TREE"
+		node_tree_data = get_node_group_fingerprint(material.node_tree)
 
 	# Gather Animation
 	if use_action_names:
 		# Material level action
-		fp["mat_action_name"] = material.animation_data.action.name if (material.animation_data and material.animation_data.action) else 'None'
+		mat_action_name = material.animation_data.action.name if (material.animation_data and material.animation_data.action) else 'None'
 
 		# Node Tree level action
 		if material.node_tree and material.node_tree.animation_data and material.node_tree.animation_data.action:
-			fp["node_tree_action_name"] = material.node_tree.animation_data.action.name
+			node_tree_action_name = material.node_tree.animation_data.action.name
 		else:
-			fp["node_tree_action_name"] = 'None'
+			node_tree_action_name = 'None'
 
-	anim = get_animation_fingerprint(material)
-	if anim:
-		fp["animation"] = anim
+	anim = get_animation_fingerprint(precision, material)
 
 	# Gather Material / Render Settings
 	if not exclude_settings:
@@ -304,16 +394,14 @@ def get_material_fingerprint(material: bpy.types.Material, exclude_settings: boo
 			if prop.is_readonly or prop.identifier in IGNORE_MAT_SETTINGS:
 				continue
 
-			val_data = {"val": to_primitive(getattr(material, prop.identifier))}
+			val_data = PropertyEntry(val=to_primitive(getattr(material, prop.identifier)))
 
 			# Check for driver
-			driver = get_driver_fingerprint(material, prop.identifier)
+			driver = get_driver_fingerprint(precision, material, prop.identifier)
 			if driver is not None:
-				val_data["driver"] = driver
+				val_data.driver = driver
 
 			render_settings[prop.identifier] = val_data
-
-		fp["render_settings"] = render_settings
 
 		# Gather Line Art Settings
 		line_art_settings = {}
@@ -329,19 +417,29 @@ def get_material_fingerprint(material: bpy.types.Material, exclude_settings: boo
 				else:
 					value = to_primitive(value)
 
-				val_data = {"val": value}
+				val_data = PropertyEntry(val=value)
 
 				# Check for driver
-				driver = get_driver_fingerprint(material, f"line_art.{prop.identifier}")
+				driver = get_driver_fingerprint(precision, material, f"line_art.{prop.identifier}")
 				if driver is not None:
-					val_data["driver"] = driver
+					val_data.driver = driver
 
 				line_art_settings[prop.identifier] = val_data
-		fp["line_art_settings"] = line_art_settings
 
-	return fp
+	return MaterialFingerprint(
+		mat_type=mat_type,
+		diffuse=diffuse,
+		roughness=roughness,
+		metallic=metallic,
+		node_tree_data=node_tree_data,
+		mat_action_name=mat_action_name,
+		node_tree_action_name=node_tree_action_name,
+		animation=anim,
+		render_settings=render_settings,
+		line_art_settings=line_art_settings
+	)
 
-def get_node_group_fingerprint(node_tree: bpy.types.NodeTree) -> Optional[Dict[str, Any]]:
+def get_node_group_fingerprint(node_tree: bpy.types.NodeTree) -> Optional[NodeTreeFingerprint]
 	"""
 	Recursively maps the connected node network, properties, and internal group contents.
 	"""
@@ -420,7 +518,9 @@ def get_node_group_fingerprint(node_tree: bpy.types.NodeTree) -> Optional[Dict[s
 				if src.node in active_nodes:
 					links_data.append({"from_socket": src.name, "from_node": src.node.bl_idname, "to_socket": socket.name, "to_node": node.bl_idname})
 
-	return {"nodes": nodes_data, "links": sorted(links_data, key=lambda x: str(x))}
+	return NodeTreeFingerprint(
+		nodes=nodes_data,
+		links=sorted(links_data, key=lambda x: str(x)))
 
 def count_total_nodes(material: bpy.types.Material) -> int:
 	"""
@@ -442,7 +542,7 @@ def count_total_nodes(material: bpy.types.Material) -> int:
 
 	return _recursive_count(material.node_tree)
 
-def to_primitive(val: Any) -> Union[int, float, str, bool, list, None]:
+def to_primitive(val: Any) -> Primitive:
 	"""
 	Converts Blender-specific data types into standard Python primitives for serialization.
 	"""

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -295,8 +295,9 @@ def serialize_keyframe(precision: float, kp: bpy.types.Keyframe) -> KeyframeData
 # --- ANIMATION & DRIVER LOGIC ---
 
 def get_animation_fingerprint(precision: float, id_data: bpy.types.ID, data_path: Optional[str] = None, array_index: int = -1) -> Optional[List[FCurveData]]:
+	"""Retrieves the animation data for a specific property or data-block as a serializable fingerprint."""
 	if not id_data.animation_data or not id_data.animation_data.action:
-		return None
+		return
 
 	action = id_data.animation_data.action
 	fcurves_to_serialize = []
@@ -327,12 +328,12 @@ def get_driver_fingerprint(precision: float, id_data: bpy.types.ID, data_path: s
 	"""Captures drivers math (expression), inputs (variables), and modifiers."""
 
 	if not id_data.animation_data or not id_data.animation_data.drivers:
-		return None
+		return
 
 	# Locate the specific driver F-Curve for the given property path
 	fcurve = id_data.animation_data.drivers.find(data_path, index=array_index)
 	if not fcurve:
-		return None
+		return
 
 	drv = fcurve.driver
 	variables: List[DriverVariableData] = []
@@ -459,16 +460,26 @@ def get_material_fingerprint(material: bpy.types.Material, compare_settings: boo
 	if compare_settings:
 		# Material Render Settings
 		fp.render_settings = {
-			prop.identifier: extract_property(getattr(material, prop.identifier), material, prop.identifier, precision)
-			for prop in material.bl_rna.properties
-			if not prop.is_readonly and prop.identifier not in IGNORE_MAT_SETTINGS
-		}
+        prop.identifier: extract_property(
+            getattr(material, prop.identifier),
+            material,
+            prop.identifier,
+            precision
+        )
+        for prop in material.bl_rna.properties
+        if not prop.is_readonly and prop.identifier not in IGNORE_MAT_SETTINGS
+    }
 
 		# Line Art Settings (Nested object property)
 		if hasattr(material, "lineart"):
 			la = material.lineart
 			fp.line_art_settings = {
-				prop.identifier: extract_property(getattr(la, prop.identifier), material, f"lineart.{prop.identifier}", precision)
+				prop.identifier: extract_property(
+					getattr(la, prop.identifier),
+					material,
+					f"lineart.{prop.identifier}",
+					precision
+				)
 				for prop in la.bl_rna.properties
 				if not prop.is_readonly and prop.identifier not in IGNORE_MAT_SETTINGS
 			}
@@ -493,7 +504,12 @@ def get_node_group_fingerprint(node_tree: bpy.types.NodeTree, precision: float) 
 
 		# Capture Attributes: Every input property, slider, checkbox, enum, etc. on the node.
 		properties = {
-			p.identifier: extract_property(getattr(node, p.identifier), node_tree, f'nodes["{node.name}"].{p.identifier}', precision)
+			p.identifier: extract_property(
+				getattr(node, p.identifier),
+				node_tree,
+				f'nodes["{node.name}"].{p.identifier}',
+				precision
+			)
 			for p in node.bl_rna.properties
 			if p.identifier not in IGNORE_PROPS and not p.is_readonly
 		}
@@ -501,7 +517,12 @@ def get_node_group_fingerprint(node_tree: bpy.types.NodeTree, precision: float) 
 		# Capture Inputs: Only record inputs that are NOT linked (static values).
 		# Linked inputs are handled later in the 'links_data' section.
 		inputs = [
-			extract_property(socket.default_value, node_tree, f'nodes["{node.name}"].inputs[{i}].default_value', precision)
+			extract_property(
+				socket.default_value,
+				node_tree,
+				f'nodes["{node.name}"].inputs[{i}].default_value',
+				precision
+			)
 			for i, socket in enumerate(node.inputs)
 			if not socket.is_linked and hasattr(socket, "default_value")
 		]
@@ -859,7 +880,7 @@ class MCPREP_OT_combine_materials(bpy.types.Operator):
 			env.log(f"Replaced '{old_mat.name}' with '{master_mat.name}'")
 			old_mat.user_remap(master_mat)
 
-		to_delete = [m for m in merge_map.keys() if m.users == 0 and not m.use_fake_user]
+		to_delete = [m for m in merge_map.keys() if not (m.users or m.use_fake_user)]
 		if to_delete:
 			bpy.data.batch_remove(ids=to_delete)
 
@@ -867,9 +888,14 @@ class MCPREP_OT_combine_materials(bpy.types.Operator):
 		consolidated_count = precount - postcount
 
 		if consolidated_count > 0:
-			self.report({"INFO"}, f"Consolidated {consolidated_count} material{'s' if consolidated_count > 1 else ''} (Total: {precount} -> {postcount})")
+			# Slices 's' if count is 1 (1^1=0) to handle pluralization via bitwise XOR
+			self.report({"INFO"}, 
+				f"Consolidated {consolidated_count} material{'s'[:consolidated_count^1]} "
+				f"(Total: {precount} -> {postcount})"
+			)
 		else:
 			self.report({"INFO"}, "No duplicates found")
+			
 		return {'FINISHED'}
 
 

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -143,7 +143,7 @@ class ListMaterials(bpy.types.PropertyGroup):
 # -----------------------------------------------------------------------------
 
 PrimitiveBasic = Union[int, float, str, bool, None, Vector, Color, Euler, Quaternion, Matrix]
-Primitive = Union[PrimitiveBasic, Tuple['Primitive', ...]]
+Primitive = Union[PrimitiveBasic, Tuple['Primitive', ...], Dict[str, 'Primitive'], Iterable['Primitive']]
 
 class AnimState(Enum):
 	"""Represents the presence or absence of animation data."""
@@ -569,7 +569,7 @@ def count_nodes_in_material(material: bpy.types.Material) -> int:
 		return 0
 	return node_tree_counter(material.node_tree)
 
-def round_value(val: object, decimals: int = 4) -> Primitive:
+def round_value(val: object, decimals: Union[int, float, None]  = None) -> Primitive:
 	"""
 	Recursively rounds floating-point values within nested data structures and Blender types.
 
@@ -579,11 +579,14 @@ def round_value(val: object, decimals: int = 4) -> Primitive:
 
 	Args:
 		val (object): The input value or container to process.
-		decimals (int, optional): The number of decimal places to round to.
-			If float('inf'), exact values are returned (no rounding). | Default 4.
+		decimals (int | float | None): The number of decimal places to round to.
+			If None, rounds to the nearest integer (returns int).
+			If float('inf'), returns values as-is (no rounding).
+			If floats are passed, they are rounded to the nearest whole integer.
+			| Default: None
 
 	Returns:
-		Primitive: The processed structure with rounded floats. Falls back to a tuple if the
+		Primitive: The processed structure with rounded floats or integers. Falls back to a tuple if the
 			original type cannot be re-instantiated.
 	"""
 
@@ -598,7 +601,10 @@ def round_value(val: object, decimals: int = 4) -> Primitive:
 	if isinstance(val, float):
 		if decimals == float('inf'):
 			return val  # No rounding, return original value as-is
-		return round(val, decimals)
+		
+		# Makes sure decimals is an int
+		decimal = round(decimals) if isinstance(decimals, (int, float)) else None
+		return round(val, decimal)
 
 	# Handle Mappings (Dictionaries)
 	if isinstance(val, Mapping):

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -151,6 +151,7 @@ class AnimState(Enum):
 
 @dataclass
 class KeyframeData:
+	"""Stores keyframe coordinate, handle, and dynamic data."""
 	co: Tuple[float, float]
 	handles: Tuple[float, float, float, float] # left_x, left_y, right_x, right_y
 	types: Tuple[str, str, str, str]		   # handle_l, handle_r, interp, easing
@@ -158,49 +159,58 @@ class KeyframeData:
 
 @dataclass
 class FCurveData:
+	"""Stores F-Curve settings and list of keyframes."""
+	data_path: str
 	array_index: int
 	extrapolation: str
-	auto_smoothing: bool
+	auto_smoothing: str
 	mute: bool
 	keyframes: List[KeyframeData]
 
 @dataclass
 class DriverVariableTarget:
+	"""Stores driver variable target data."""
 	id_name: str
-	data_path: str = ""
-	bone_target: str = ""
-	id_type: str = ""
-	transform_type: str = ""
-	transform_space: str = ""
-	rotation_mode: str = ""
-	context_property: str = ""
+	data_path: Optional[str] = None
+	bone_target: Optional[str] = None
+	id_type: Optional[str] = None
+	transform_type: Optional[str] = None
+	transform_space: Optional[str] = None
+	rotation_mode: Optional[str] = None
+	context_property: Optional[str] = None
 
 @dataclass
 class DriverVariableData:
+	"""Stores driver variable name, type, and targets."""
 	name: str
 	var_type: str
 	targets: List[DriverVariableTarget]
 
 @dataclass
 class DriverModifierData:
+	"""Stores driver modifier type and settings."""
 	mod_type: str
 	settings: Dict[str, Primitive]
 
 @dataclass
 class DriverFingerprint:
+	"""Stores full driver data including variables, F-curves, and modifiers."""
 	drv_type: str
 	expression: Optional[str]
 	variables: List[DriverVariableData]
-	fcurve: FCurveData
+	fcurve: Optional[FCurveData]
 	modifiers: List[DriverModifierData]
 
 @dataclass
 class PropertyEntry:
+	"""Stores a property value along with potential driver or animation data."""
 	val: Primitive
 	driver: Optional[DriverFingerprint] = None
 	animation: Optional[List[FCurveData]] = None
 
+@dataclass
 class NodeLinkData:
+	"""Stores connection details between two node sockets."""
 	from_socket: str
 	from_node: str
 	to_socket: str
@@ -208,6 +218,7 @@ class NodeLinkData:
 
 @dataclass
 class NodeFingerprint:
+	"""Stores node type, mute status, and input/property data."""
 	node_type: str
 	muted: bool
 	properties: Dict[str, PropertyEntry]
@@ -216,15 +227,17 @@ class NodeFingerprint:
 
 @dataclass
 class NodeTreeFingerprint:
+	"""Stores the list of nodes and links within a node tree."""
 	nodes: List[NodeFingerprint]
 	links: List[NodeLinkData]
 
 @dataclass
 class MaterialFingerprint:
-	mat_type: str = ""
-	diffuse: Optional[List[float]] = None
-	roughness: Optional[float] = None
-	metallic: Optional[float] = None
+	"""Stores a unique signature of a material for structural comparison."""
+	mat_type: str = "FIXED_MAT"
+	diffuse: Optional[Primitive] = None
+	roughness: Optional[Primitive] = None
+	metallic: Optional[Primitive] = None
 	node_tree_data: Optional[NodeTreeFingerprint] = None
 	mat_action_name: Optional[Union[str, AnimState]] = AnimState.NONE
 	node_tree_action_name: Optional[Union[str, AnimState]] = AnimState.NONE

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -276,17 +276,14 @@ def serialize_fcurve(precision: int, fcurve: bpy.types.FCurve) -> Optional[FCurv
 
 def serialize_keyframe(precision: int, kp: bpy.types.Keyframe) -> KeyframeData:
 	"""
-	Extracts essential keyframe data: coordinates, handle positions, 
+	Extracts essential keyframe data: coordinates, handle positions,
 	interpolation types, and dynamic easing properties (Back/Bounce/Elastic).
 	"""
 	return KeyframeData(
-		co=(round(kp.co[0], precision), round(kp.co[1], precision)),
-		handles=(
-			round(kp.handle_left[0], precision), round(kp.handle_left[1], precision),
-			round(kp.handle_right[0], precision), round(kp.handle_right[1], precision)
-		),
+		co=round_value(kp.co, precision),
+		handles=(*round_value(kp.handle_left, precision), *round_value(kp.handle_right, precision)),
 		types=(kp.handle_left_type, kp.handle_right_type, kp.interpolation, kp.easing),
-		dynamics=(round(kp.back, precision), round(kp.amplitude, precision), round(kp.period, precision))
+		dynamics=round_value((kp.back, kp.amplitude, kp.period), precision)
 	)
 
 # --- ANIMATION & DRIVER LOGIC ---
@@ -385,7 +382,7 @@ def get_driver_fingerprint(precision: int, id_data: bpy.types.ID, data_path: str
 			mod_type=mod.type,
 			settings={
 				# Automatically scrape all settings for this modifier type
-				p.identifier: serialize_value(getattr(mod, p.identifier), precision)
+				p.identifier: round_value(getattr(mod, p.identifier), precision)
 				for p in mod.bl_rna.properties
 				if not p.is_readonly and p.identifier not in ('name', 'type', 'is_active')
 			})
@@ -415,7 +412,7 @@ def extract_property(target_val: object, id_block: bpy.types.ID, data_path: str,
 	data_path: The RNA path for driver/animation lookup.
 	"""
 	return PropertyEntry(
-		val=serialize_value(target_val, precision),
+		val=round_value(target_val, precision),
 		driver=get_driver_fingerprint(precision, id_block, data_path),
 		animation=get_animation_fingerprint(precision, id_block, data_path)
 	)
@@ -427,9 +424,9 @@ def get_material_fingerprint(material: bpy.types.Material, compare_settings: boo
 	# 1. Handle Surface Type
 	if not material.node_tree:
 		fp.mat_type = "FIXED_MAT"
-		fp.diffuse = serialize_value(material.diffuse_color, precision)
-		fp.roughness = serialize_value(material.roughness, precision)
-		fp.metallic = serialize_value(material.metallic, precision)
+		fp.diffuse = round_value(material.diffuse_color, precision)
+		fp.roughness = round_value(material.roughness, precision)
+		fp.metallic = round_value(material.metallic, precision)
 	else:
 		fp.mat_type = "NODE_TREE"
 		fp.node_tree_data = get_node_group_fingerprint(material.node_tree, precision)
@@ -560,31 +557,60 @@ def count_nodes_in_material(material: bpy.types.Material) -> int:
 		return 0
 	return node_tree_counter(material.node_tree)
 
-def serialize_value(val, decimals: int = 4) -> Primitive:
+def round_value(val: object, decimals: int = 4) -> Primitive:
 	"""
-	Standardizes Blender's internal math types into Python-native primitives.
+	Recursively rounds floating-point values within nested data structures and Blender types.
+
+	Preserves the original data types where possible. If a container is immutable
+	or cannot be re-instantiated (e.g., `bpy_prop_array`), it returns
+	a standard tuple of the rounded values.
+
 	Args:
-		val: The value to convert (Vector, Color, Euler, float, etc.)
-		decimals: Precision for rounding. Needed for "Matching Precision" option ('fuzzy matching')
-				  where two materials are identical except for a tiny 
-				  floating-point difference (e.g., 0.5001 vs 0.5).
+		val (object): The input value or container to process.
+		decimals (int, optional): The number of decimal places to round to.
+			If float('inf'), exact values are returned (no rounding). | Default 4.
+
+	Returns:
+		Primitive: The processed structure with rounded floats. Falls back to a tuple if the
+			original type cannot be re-instantiated.
 	"""
+
 	if val is None:
-		return None
-		
-	# Standard types are returned as-is
+		return val
+
+	# Standard non-roundable primitive types
 	if isinstance(val, (str, bool, int)):
 		return val
-	
-	# Floats are rounded for the 'Matching Precision' feature
+
+	# Direct float rounding
 	if isinstance(val, float):
+		if decimals == float('inf'):
+			return val  # No rounding, return original value as-is
 		return round(val, decimals)
 
-	# If the value is iterable (like a Vector, Color, or Euler), 
-	# we convert it to a tuple of primitives recursively.
-	if isinstance(val, Iterable):
-		return tuple(serialize_value(x, decimals) for x in val)
-		
+	# Handle Mappings (Dictionaries)
+	if isinstance(val, Mapping):
+		return {k: round_value(v, decimals) for k, v in val.items()}
+
+	# Handle Mathutils and Iterables
+	if isinstance(val, (Iterable, Vector, Color, Euler, Quaternion, Matrix)):
+		# Recursively process elements
+		rounded_data = [round_value(x, decimals) for x in val]
+
+		# Try to reconstruct the original container type (Vector, Color, etc.)
+		val_type = type(val)
+		try:
+			# Special case: Euler rotation order preserved
+			if isinstance(val, Euler):
+				return val_type(rounded_data, val.order)
+
+			return val_type(rounded_data)
+
+		except (TypeError, ValueError):
+			# Fallback for read-only/uninstantiable types (e.g., bpy_prop_array)
+			return tuple(rounded_data)
+
+	# Return as-is if type is unknown/currently not supported/not roundable
 	return val
 
 def trace_socket(dest_socket: bpy.types.NodeSocket) -> bpy.types.NodeSocket:

--- a/test_files/materials_test.py
+++ b/test_files/materials_test.py
@@ -974,21 +974,51 @@ class MaterialsTest(unittest.TestCase):
         self.assertEqual(len(bpy.data.materials), init_count)
         # TODO: add test for ensuring selection_only=True also works
 
-    def test_combine_images(self):
-        img1 = bpy.data.images.new("CombineImages", width=1, height=1)
-        init_count = len(bpy.data.images)
-        img2 = bpy.data.images.new("CombineImages", width=1, height=1)
-        self.assertNotEqual(img1.id_data, img2.id_data)
-        bpy.ops.mcprep.combine_images()
-        self.assertEqual(init_count, len(bpy.data.images))
+	def test_combine_images(self):
+		bpy.ops.mesh.primitive_plane_add()
+		obj = bpy.context.active_object
 
-    def test_combine_images_strict_comparision(self):
-        img1 = bpy.data.images.new("CombineImages", width=1, height=1)
-        init_count = len(bpy.data.images)
-        img2 = bpy.data.images.new("CombineImages", width=1, height=1)
-        self.assertNotEqual(img1.id_data, img2.id_data)
-        bpy.ops.mcprep.combine_images(strict_comparison=True)
-        self.assertEqual(init_count, len(bpy.data.images))
+		img1 = bpy.data.images.new("CombineImages", width=8, height=8)
+		img2 = bpy.data.images.new("CombineImages", width=8, height=8)
+
+		pixels = [1.0] * (8 * 8 * 4)
+		img1.pixels = pixels
+		img2.pixels = pixels
+
+		init_count = len(bpy.data.images)
+
+		for i, img in enumerate([img1, img2]):
+			mat = bpy.data.materials.new(name=f"TestMat_{i}")
+			mat.use_nodes = True
+			node = mat.node_tree.nodes.new(type="ShaderNodeTexImage")
+			node.image = img
+			obj.data.materials.append(mat)
+
+		bpy.ops.mcprep.combine_images(selection_only=True)
+		self.assertEqual(len(bpy.data.images), init_count - 1)
+
+	def test_combine_images_strict_comparision(self):
+		bpy.ops.mesh.primitive_plane_add()
+		obj = bpy.context.active_object
+
+		img1 = bpy.data.images.new("CombineImages", width=8, height=8)
+		img2 = bpy.data.images.new("CombineImages", width=8, height=8)
+
+		pixels = [0.5] * (8 * 8 * 4)
+		img1.pixels = pixels
+		img2.pixels = pixels
+
+		init_count = len(bpy.data.images)
+
+		for i, img in enumerate([img1, img2]):
+			mat = bpy.data.materials.new(name=f"StrictMat_{i}")
+			mat.use_nodes = True
+			node = mat.node_tree.nodes.new(type="ShaderNodeTexImage")
+			node.image = img
+			obj.data.materials.append(mat)
+
+		bpy.ops.mcprep.combine_images(selection_only=True, strict_comparison=True)
+		self.assertEqual(len(bpy.data.images), init_count - 1)
 
     def test_uv_scale(self):
         bpy.ops.mesh.primitive_plane_add()

--- a/test_files/materials_test.py
+++ b/test_files/materials_test.py
@@ -974,51 +974,51 @@ class MaterialsTest(unittest.TestCase):
         self.assertEqual(len(bpy.data.materials), init_count)
         # TODO: add test for ensuring selection_only=True also works
 
-	def test_combine_images(self):
-		bpy.ops.mesh.primitive_plane_add()
-		obj = bpy.context.active_object
+    def test_combine_images(self):
+        bpy.ops.mesh.primitive_plane_add()
+        obj = bpy.context.active_object
 
-		img1 = bpy.data.images.new("CombineImages", width=8, height=8)
-		img2 = bpy.data.images.new("CombineImages", width=8, height=8)
+        img1 = bpy.data.images.new("CombineImages", width=8, height=8)
+        img2 = bpy.data.images.new("CombineImages", width=8, height=8)
 
-		pixels = [1.0] * (8 * 8 * 4)
-		img1.pixels = pixels
-		img2.pixels = pixels
+        pixels = [1.0] * (8 * 8 * 4)
+        img1.pixels = pixels
+        img2.pixels = pixels
 
-		init_count = len(bpy.data.images)
+        init_count = len(bpy.data.images)
 
-		for i, img in enumerate([img1, img2]):
-			mat = bpy.data.materials.new(name=f"TestMat_{i}")
-			mat.use_nodes = True
-			node = mat.node_tree.nodes.new(type="ShaderNodeTexImage")
-			node.image = img
-			obj.data.materials.append(mat)
+        for i, img in enumerate([img1, img2]):
+            mat = bpy.data.materials.new(name=f"TestMat_{i}")
+            mat.use_nodes = True
+            node = mat.node_tree.nodes.new(type="ShaderNodeTexImage")
+            node.image = img
+            obj.data.materials.append(mat)
 
-		bpy.ops.mcprep.combine_images(selection_only=True)
-		self.assertEqual(len(bpy.data.images), init_count - 1)
+        bpy.ops.mcprep.combine_images(selection_only=True)
+        self.assertEqual(len(bpy.data.images), init_count - 1)
 
-	def test_combine_images_strict_comparision(self):
-		bpy.ops.mesh.primitive_plane_add()
-		obj = bpy.context.active_object
+    def test_combine_images_strict_comparision(self):
+        bpy.ops.mesh.primitive_plane_add()
+        obj = bpy.context.active_object
 
-		img1 = bpy.data.images.new("CombineImages", width=8, height=8)
-		img2 = bpy.data.images.new("CombineImages", width=8, height=8)
+        img1 = bpy.data.images.new("CombineImages", width=8, height=8)
+        img2 = bpy.data.images.new("CombineImages", width=8, height=8)
 
-		pixels = [0.5] * (8 * 8 * 4)
-		img1.pixels = pixels
-		img2.pixels = pixels
+        pixels = [0.5] * (8 * 8 * 4)
+        img1.pixels = pixels
+        img2.pixels = pixels
 
-		init_count = len(bpy.data.images)
+        init_count = len(bpy.data.images)
 
-		for i, img in enumerate([img1, img2]):
-			mat = bpy.data.materials.new(name=f"StrictMat_{i}")
-			mat.use_nodes = True
-			node = mat.node_tree.nodes.new(type="ShaderNodeTexImage")
-			node.image = img
-			obj.data.materials.append(mat)
+        for i, img in enumerate([img1, img2]):
+            mat = bpy.data.materials.new(name=f"StrictMat_{i}")
+            mat.use_nodes = True
+            node = mat.node_tree.nodes.new(type="ShaderNodeTexImage")
+            node.image = img
+            obj.data.materials.append(mat)
 
-		bpy.ops.mcprep.combine_images(selection_only=True, strict_comparison=True)
-		self.assertEqual(len(bpy.data.images), init_count - 1)
+        bpy.ops.mcprep.combine_images(selection_only=True, strict_comparison=True)
+        self.assertEqual(len(bpy.data.images), init_count - 1)
 
     def test_uv_scale(self):
         bpy.ops.mesh.primitive_plane_add()


### PR DESCRIPTION
The current `Combine Materials` operator is limited and can accidentally merge materials that are actually different. I upgraded the operator to use a "fingerprinting" system that analyzes the full node tree, drivers, and animation data to verify that materials are only merged if they are functionally identical.

For the node_tree fingerprinting, it uses `bl_rna` properties to make it multi-version Blender compatible.
Also, it only considers nodes that actually contribute to the `Material Output` node; dead nodes are not included in the fingerprint.

**Note**: I've set this to a Draft as it's still a WIP. I have left comments in the code for a few things I'm still working on:
- [x] Toggle to allow users to choose if Action names should be used to differentiate fingerprints.
- [x] Users can choose the precision for how closely property values must match (adjusting the `round()` precision in the `to_primitive`& `serialize_keyframe` functions).
- [x] Automatically strip the `.001` suffixes from the chosen master material
- [x] Allow users to define the "Master" material (the material that will be kept) based on: Highest/Lowest node count | User count (popularity)*