### PR TITLE
Implement internal support for layered resource packs

### DIFF
--- a/MCprep_addon/materials/generate.py
+++ b/MCprep_addon/materials/generate.py
@@ -27,7 +27,7 @@ from bpy.types import Context, Material, Image, Texture, Nodes, NodeLinks, Node
 
 from .. import util
 from ..conf import MCprepError, env, Form
-from .resource_pack import find_from_texturepack
+from .resource_pack import MCResourcePack, find_texture_from_layers, get_default_pack
 
 AnimatedTex = Dict[str, int]
 
@@ -284,24 +284,26 @@ def matprep_cycles(mat: Material, options: PrepOptions) -> Optional[bool]:
 	return res
 
 
-def set_texture_pack(
-	material: Material, folder: Path, use_extra_passes: bool) -> bool:
-	"""Replace existing material's image with texture pack's.
+def set_texture_pack_stack(
+		material: Material, resource_packs: List[MCResourcePack], use_extra_passes: bool) -> bool:
+	"""Replace existing material's image with one from the texture pack(s).
+
+	This goes through a stack of texture packs, from top to bottom.
 
 	Run through and check for each if counterpart material exists, then
 	run the swap (and auto load e.g. normals and specs if avail.)
 	"""
 	mc_name, _ = get_mc_canonical_name(material.name)
-	image = find_from_texturepack(mc_name, folder)
+	image = find_texture_from_layers(mc_name, resource_packs)
 	if isinstance(image, MCprepError):
 		if image.msg:
 			env.log(image.msg)
-		return 0
+		return False
 
 	image_data = util.loadTexture(str(image))
 	_ = set_cycles_texture(
 		image_data, material, extra_passes=use_extra_passes)
-	return 1
+	return True
 
 
 def assert_textures_on_materials(
@@ -585,7 +587,14 @@ def replace_missing_texture(image: Image) -> bool:
 	name = os.path.splitext(name)[0]  # cut off png / jpg / etc
 	canon, _ = get_mc_canonical_name(name)
 	# TODO: detect for pass structure like normal and still look for right pass
-	image_path = find_from_texturepack(canon)
+
+	internal_pack = get_default_pack()
+	if isinstance(internal_pack, MCprepError):
+		if internal_pack.msg is not None:
+			env.log(internal_pack.msg)
+		return False
+
+	image_path = find_texture_from_layers(canon, [internal_pack])
 	if isinstance(image_path, MCprepError):
 		if image_path.msg:
 			env.log(image_path.msg)

--- a/MCprep_addon/materials/generate.py
+++ b/MCprep_addon/materials/generate.py
@@ -27,6 +27,7 @@ from bpy.types import Context, Material, Image, Texture, Nodes, NodeLinks, Node
 
 from .. import util
 from ..conf import MCprepError, env, Form
+from .resource_pack import find_from_texturepack
 
 AnimatedTex = Dict[str, int]
 
@@ -139,93 +140,6 @@ def get_mc_canonical_name(name: str) -> Tuple[str, Optional[Form]]:
 		canon = general_name
 
 	return canon, form
-
-
-def find_from_texturepack(blockname: str, resource_folder: Optional[Path]=None) -> Union[Path, MCprepError]:
-	"""Given a blockname (and resource folder), find image filepath.
-
-	Finds textures following any pack which should have this structure, and
-	the input folder or default resource folder could target at any of the
-	following sublevels above the <subfolder> level.
-	//pack_name/assets/minecraft/textures/<subfolder>/<blockname.png>
-
-	Returns:
-		- Path if successful
-		- MCprepError if error occurs (may return with a message)
-	"""
-	if resource_folder is None:
-		# default to internal pack
-		resource_folder = Path(cast(
-			str,
-			bpy.path.abspath(bpy.context.scene.mcprep_texturepack_path)
-		))
-
-	if not resource_folder.exists() or not resource_folder.is_dir():
-		env.log("Error, resource folder does not exist")
-		line, file = env.current_line_and_file()
-		return MCprepError(FileNotFoundError(), line, file, f"Resource pack folder at {resource_folder} does not exist!")
-
-	# Check multiple paths, picking the first match (order is important),
-	# goal of picking out the /textures folder.
-	check_dirs = [
-		Path(resource_folder, "textures"),
-		Path(resource_folder, "minecraft", "textures"),
-		Path(resource_folder, "assets", "minecraft", "textures")]
-	for path in check_dirs:
-		if path.exists():
-			resource_folder = path
-			break
-
-	search_paths = [
-		resource_folder,
-		# Both singular and plural shown below as it has varied historically.
-		Path(resource_folder, "blocks"),
-		Path(resource_folder, "block"),
-		Path(resource_folder, "items"),
-		Path(resource_folder, "item"),
-		Path(resource_folder, "entity"),
-		Path(resource_folder, "models"),
-		Path(resource_folder, "model"),
-	]
-	res = None
-
-	# first see if subpath included is found, prioritize use of that
-	extensions = [".png", ".jpg", ".jpeg"]
-	if "/" in blockname:
-		newpath = blockname.replace("/", os.path.sep)
-		for ext in extensions:
-			if Path(resource_folder, newpath + ext).exists():
-				res = Path(resource_folder, newpath + ext)
-				return res
-		newpath = os.path.basename(blockname)  # case where goes into other subpaths
-		for ext in extensions:
-			if Path(resource_folder, newpath + ext).exists():
-				res = Path(resource_folder, newpath + ext)
-				return res
-
-	# fallback (more common case), wide-search for
-	for path in search_paths:
-		if not path.is_dir():
-			continue
-		for ext in extensions:
-			check_path = Path(path, blockname + ext)
-			if check_path.exists() and check_path.is_file():
-				res = Path(path, blockname + ext)
-				return res
-
-	# Mineways fallback
-	for suffix in ["-Alpha", "-RGB", "-RGBA"]:
-		if blockname.endswith(suffix):
-			res = Path(
-				resource_folder, "mineways_assets", f"mineways{suffix}.png")
-			if res.exists() and res.is_file():
-				return res
-
-	if res is None:
-		line, file = env.current_line_and_file()
-		return MCprepError(FileNotFoundError(), line, file)
-	return res
-
 
 def detect_form(materials: List[Material]) -> Optional[Form]:
 	"""Function which, given the input materials, guesses the exporter form.

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -26,6 +26,7 @@ import numpy as np
 from numpy.typing import NDArray
 
 from . import generate
+from . import resource_pack
 from . import sequences
 from .. import tracking
 from .. import util
@@ -503,7 +504,14 @@ class MCPREP_OT_replace_missing_textures(bpy.types.Operator):
 		"""If image datablock not found in passes, try to directly load and assign"""
 		env.log(f"Loading from texpack for {mat.name}", vv_only=True)
 		canon, _ = generate.get_mc_canonical_name(mat.name)
-		image_path = generate.find_from_texturepack(canon)
+
+		internal_pack = resource_pack.get_default_pack()
+		if isinstance(internal_pack, MCprepError):
+			if internal_pack.msg:
+				env.log(internal_pack.msg)
+			return False
+
+		image_path = resource_pack.find_texture_from_layers(canon, [internal_pack])
 		if isinstance(image_path, MCprepError):
 			if image_path.msg:
 				env.log(image_path.msg)

--- a/MCprep_addon/materials/prep.py
+++ b/MCprep_addon/materials/prep.py
@@ -27,10 +27,11 @@ from bpy.types import Context
 from . import generate
 from . import sequences
 from . import uv_tools
+from . import resource_pack
 from .. import tracking
 from .. import util
 from .. import world_tools
-from ..conf import env
+from ..conf import MCprepError, env
 
 # -----------------------------------------------------------------------------
 # Material class functions
@@ -469,12 +470,12 @@ class MCPREP_OT_swap_texture_pack(
 
 		# check folder exist, but keep relative if relevant
 		folder = self.filepath
-		if os.path.isfile(bpy.path.abspath(folder)):
-			folder = os.path.dirname(folder)
-		env.log(f"Folder: {folder}")
+		file_path = Path(bpy.path.abspath(folder))
+		parsed_resource_pack = resource_pack.get_resource_pack_info(file_path)
 
-		if not os.path.isdir(bpy.path.abspath(folder)):
-			self.report({'ERROR'}, "Selected folder does not exist")
+		if isinstance(parsed_resource_pack, MCprepError):
+			self.report({'ERROR'}, parsed_resource_pack.msg)
+			env.log(f"{parsed_resource_pack.file}:{parsed_resource_pack.line}", vv_only=True)
 			return {'CANCELLED'}
 
 		# get list of selected objects
@@ -507,7 +508,7 @@ class MCPREP_OT_swap_texture_pack(
 		res = 0
 		for mat in mat_list:
 			self.preprocess_material(mat)
-			res += generate.set_texture_pack(mat, Path(folder), self.useExtraMaps)
+			res += generate.set_texture_pack_stack(mat, [parsed_resource_pack], self.useExtraMaps)
 			if self.animateTextures:
 				sequences.animate_single_material(
 					mat,

--- a/MCprep_addon/materials/resource_pack.py
+++ b/MCprep_addon/materials/resource_pack.py
@@ -25,7 +25,7 @@ from typing import List, cast, Optional, Tuple, Union, final
 
 import bpy
 
-from MCprep_addon.conf import MCprepError, env
+from ..conf import MCprepError, env
 
 PACK_MCMETA = "pack.mcmeta"
 

--- a/MCprep_addon/materials/resource_pack.py
+++ b/MCprep_addon/materials/resource_pack.py
@@ -35,6 +35,7 @@ class MCMetaErrorType(Enum):
     FIELD_INVALID = auto()
     PARSED_FIELD_INVALID_TYPE = auto()
 
+
 @final
 class MCMetaIncorrectFormatException(Exception):
     def __init__(
@@ -50,10 +51,12 @@ class MCMetaIncorrectFormatException(Exception):
         self.err_type = err_type
         self.additional_context = additional_context
 
+
 @final
 class MCResourcePackTextureNotFound(Exception):
     def __init__(self, msg: str = "") -> None:
         super().__init__(msg)
+
 
 @dataclass
 class PackVersionData:
@@ -68,13 +71,25 @@ class MCResourcePack:
     pack_format: Optional[PackVersionData]
 
 
-def get_resource_pack_info(path: Path, dont_parse_pack_mcmeta: bool = False) -> Union[MCResourcePack, MCprepError]:
+def get_resource_pack_info(
+    path: Path, dont_parse_pack_mcmeta: bool = False
+) -> Union[MCResourcePack, MCprepError]:
     if not path.exists():
         line, file = env.current_line_and_file()
-        return MCprepError(FileNotFoundError(), line, file, f"Resource pack cannot be found at {str(path)}")
+        return MCprepError(
+            FileNotFoundError(),
+            line,
+            file,
+            f"Resource pack cannot be found at {str(path)}",
+        )
     elif not path.is_dir():
         line, file = env.current_line_and_file()
-        return MCprepError(NotADirectoryError(), line, file, f"Resource pack not a directory: {str(path)}")
+        return MCprepError(
+            NotADirectoryError(),
+            line,
+            file,
+            f"Resource pack not a directory: {str(path)}",
+        )
 
     name = path.name
 
@@ -266,12 +281,14 @@ def get_resource_pack_info(path: Path, dont_parse_pack_mcmeta: bool = False) -> 
 
     return MCResourcePack(name, path, PackVersionData(min_format, max_format))
 
+
 def get_default_pack() -> Union[MCResourcePack, MCprepError]:
     """Return the default texture pack bundled with MCprep."""
     internal_pack = Path(
         cast(str, bpy.path.abspath(bpy.context.scene.mcprep_texturepack_path))
     )
     return get_resource_pack_info(internal_pack)
+
 
 def find_from_texturepack(
     blockname: str, resource_folder: Path
@@ -360,9 +377,11 @@ def find_from_texturepack(
     return res
 
 
-def find_texture_from_layers(block_name: str, resource_pack_layers: List[MCResourcePack]) -> Union[Path, MCprepError]:
+def find_texture_from_layers(
+    block_name: str, resource_pack_layers: List[MCResourcePack]
+) -> Union[Path, MCprepError]:
     """Given a list of resource packs, in order from top to bottom, search for a texture.
-    
+
     Returns:
         - Path to the texture if it exists in any of the resource packs
         - MCprepError with err_type set to MCResourcePackTextureNotFound

--- a/MCprep_addon/materials/resource_pack.py
+++ b/MCprep_addon/materials/resource_pack.py
@@ -21,7 +21,7 @@ from enum import auto, Enum
 import json
 import os
 from pathlib import Path
-from typing import cast, Optional, Tuple, Union
+from typing import List, cast, Optional, Tuple, Union, final
 
 import bpy
 
@@ -35,7 +35,7 @@ class MCMetaErrorType(Enum):
     FIELD_INVALID = auto()
     PARSED_FIELD_INVALID_TYPE = auto()
 
-
+@final
 class MCMetaIncorrectFormatException(Exception):
     def __init__(
         self,
@@ -50,6 +50,10 @@ class MCMetaIncorrectFormatException(Exception):
         self.err_type = err_type
         self.additional_context = additional_context
 
+@final
+class MCResourcePackTextureNotFound(Exception):
+    def __init__(self, msg: str = "") -> None:
+        super().__init__(msg)
 
 @dataclass
 class PackVersionData:
@@ -61,11 +65,29 @@ class PackVersionData:
 class MCResourcePack:
     name: str
     path: Path
-    pack_format: PackVersionData
+    pack_format: Optional[PackVersionData]
 
 
-def get_resource_pack_info(path: Path) -> Union[MCResourcePack, MCprepError]:
+def get_resource_pack_info(path: Path, dont_parse_pack_mcmeta: bool = False) -> Union[MCResourcePack, MCprepError]:
+    if not path.exists():
+        line, file = env.current_line_and_file()
+        return MCprepError(FileNotFoundError(), line, file, f"Resource pack cannot be found at {str(path)}")
+    elif not path.is_dir():
+        line, file = env.current_line_and_file()
+        return MCprepError(NotADirectoryError(), line, file, f"Resource pack not a directory: {str(path)}")
+
     name = path.name
+
+    # Intended for the default resource
+    # pack because it doesn't come with
+    # a pack.mcmeta file for some reason.
+    #
+    # TODO: Figure out a way to extract the
+    # pack format of the default resource pack
+    # without pack.mcmeta.
+    if dont_parse_pack_mcmeta:
+        return MCResourcePack(name, path, None)
+
     pack_meta_json = Path(path, PACK_MCMETA)
 
     if not pack_meta_json.exists():
@@ -244,9 +266,15 @@ def get_resource_pack_info(path: Path) -> Union[MCResourcePack, MCprepError]:
 
     return MCResourcePack(name, path, PackVersionData(min_format, max_format))
 
+def get_default_pack() -> Union[MCResourcePack, MCprepError]:
+    """Return the default texture pack bundled with MCprep."""
+    internal_pack = Path(
+        cast(str, bpy.path.abspath(bpy.context.scene.mcprep_texturepack_path))
+    )
+    return get_resource_pack_info(internal_pack)
 
 def find_from_texturepack(
-    blockname: str, resource_folder: Optional[Path] = None
+    blockname: str, resource_folder: Path
 ) -> Union[Path, MCprepError]:
     """Given a blockname (and resource folder), find image filepath.
 
@@ -259,11 +287,6 @@ def find_from_texturepack(
             - Path if successful
             - MCprepError if error occurs (may return with a message)
     """
-    if resource_folder is None:
-        # default to internal pack
-        resource_folder = Path(
-            cast(str, bpy.path.abspath(bpy.context.scene.mcprep_texturepack_path))
-        )
 
     if not resource_folder.exists() or not resource_folder.is_dir():
         env.log("Error, resource folder does not exist")
@@ -333,5 +356,26 @@ def find_from_texturepack(
 
     if res is None:
         line, file = env.current_line_and_file()
-        return MCprepError(FileNotFoundError(), line, file)
+        return MCprepError(MCResourcePackTextureNotFound(), line, file)
     return res
+
+
+def find_texture_from_layers(block_name: str, resource_pack_layers: List[MCResourcePack]) -> Union[Path, MCprepError]:
+    """Given a list of resource packs, in order from top to bottom, search for a texture.
+    
+    Returns:
+        - Path to the texture if it exists in any of the resource packs
+        - MCprepError with err_type set to MCResourcePackTextureNotFound
+        - If an alternate error occurs, then MCprepError with err_type set
+          any other exception class
+    """
+    for pack in resource_pack_layers:
+        res = find_from_texturepack(block_name, pack.path)
+        if isinstance(res, MCprepError):
+            if isinstance(res.err_type, MCResourcePackTextureNotFound):
+                continue
+            return res
+        return res
+
+    line, file = env.current_line_and_file()
+    return MCprepError(MCResourcePackTextureNotFound(), line, file)

--- a/MCprep_addon/materials/resource_pack.py
+++ b/MCprep_addon/materials/resource_pack.py
@@ -1,0 +1,242 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 2
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+from dataclasses import dataclass
+from enum import auto, Enum
+import json
+from pathlib import Path
+from typing import Tuple, Union
+
+from MCprep_addon.conf import MCprepError, env
+
+PACK_MCMETA = "pack.mcmeta"
+
+
+class MCMetaErrorType(Enum):
+    MISSING_FIELD = auto()
+    FIELD_INVALID = auto()
+    PARSED_FIELD_INVALID_TYPE = auto()
+
+
+class MCMetaIncorrectFormatException(Exception):
+    def __init__(
+        self,
+        msg: str = "",
+        resource_pack_name: str = "",
+        err_type: MCMetaErrorType = MCMetaErrorType.MISSING_FIELD,
+        additional_context: str = "",
+    ) -> None:
+        super().__init__(msg)
+
+        self.resource_pack_name = resource_pack_name
+        self.err_type = err_type
+        self.additional_context = additional_context
+
+
+@dataclass
+class PackVersionData:
+    min_format: Tuple[int, int]
+    max_format: Tuple[int, int]
+
+
+@dataclass
+class MCResourcePack:
+    name: str
+    path: Path
+    pack_format: PackVersionData
+
+
+def get_resource_pack_info(path: Path) -> Union[MCResourcePack, MCprepError]:
+    name = path.name
+    pack_meta_json = Path(path, PACK_MCMETA)
+
+    if not pack_meta_json.exists():
+        line, file = env.current_line_and_file()
+        return MCprepError(
+            FileNotFoundError(),
+            line,
+            file,
+            f"pack.mcmeta could not be found for {name}!",
+        )
+    elif not pack_meta_json.is_file():
+        line, file = env.current_line_and_file()
+        return MCprepError(
+            FileNotFoundError(), line, file, f"pack.mcmeta for {name} is not a file!"
+        )
+
+    with open(pack_meta_json, "r") as f:
+        data = json.load(f)
+
+    if "pack" not in data:
+        line, file = env.current_line_and_file()
+        return MCprepError(
+            MCMetaIncorrectFormatException(resource_pack_name=name),
+            line,
+            file,
+            f"pack.mcmeta is missing 'pack' field!",
+        )
+
+    pack_data = data["pack"]
+
+    min_format = (0, 0)
+    max_format = (0, 0)
+
+    # Treat the old format as setting min
+    # and max to the same version
+    if "pack_format" in pack_data:
+        min_format = (pack_data["pack_format"], 0)
+        max_format = (pack_data["pack_format"], 0)
+    else:
+        if "min_format" not in pack_data:
+            line, file = env.current_line_and_file()
+            return MCprepError(
+                MCMetaIncorrectFormatException(resource_pack_name=name),
+                line,
+                file,
+                f"pack.min_format is missing in mcmeta",
+            )
+
+        min_raw = pack_data["min_format"]
+
+        if isinstance(min_raw, int):
+            min_format = (min_raw, 0)
+        elif isinstance(min_raw, list):
+            if len(min_raw) == 1:
+                min_format = (min_raw[0], 0)
+            elif len(min_raw) == 2:
+                min_format == tuple(min_raw)  # simpler to convert directly
+        else:
+            line, file = env.current_line_and_file()
+            return MCprepError(
+                MCMetaIncorrectFormatException(
+                    resource_pack_name=name, err_type=MCMetaErrorType.FIELD_INVALID
+                ),
+                line,
+                file,
+                f"'pack.min_format' in mcmeta is not the correct format!",
+            )
+
+        if "max_format" not in pack_data:
+            line, file = env.current_line_and_file()
+            return MCprepError(
+                MCMetaIncorrectFormatException(resource_pack_name=name),
+                line,
+                file,
+                f"pack.max_format is missing in mcmeta!",
+            )
+
+        max_raw = pack_data["max_format"]
+
+        # Single integers for max_format are interpreted
+        # as minor versions, according to the Minecraft Wiki
+        # at least
+        if isinstance(max_raw, int):
+            max_format = (min_format[0], max_raw)
+        elif isinstance(max_raw, list):
+            if len(max_raw) == 1:
+                max_format = (min_format[0], max_raw[0])
+            elif len(max_raw) == 2:
+                max_format == tuple(max_raw)  # simpler to convert directly
+        else:
+            line, file = env.current_line_and_file()
+            return MCprepError(
+                MCMetaIncorrectFormatException(
+                    resource_pack_name=name, err_type=MCMetaErrorType.FIELD_INVALID
+                ),
+                line,
+                file,
+                f"'pack.max_format' in mcmeta is not the correct format!",
+            )
+
+    # Verify data is correct
+    #
+    # Admittedly, we have a large block of
+    # checks here, but it's to make sure that
+    # the datatypes are correct at runtime
+    # so that we don't have any issues.
+    #
+    # TODO: Simplify these checks
+    line, file = env.current_line_and_file()
+    if not isinstance(min_format, tuple):
+        return MCprepError(
+            MCMetaIncorrectFormatException(
+                resource_pack_name=name,
+                err_type=MCMetaErrorType.PARSED_FIELD_INVALID_TYPE,
+                additional_context=f"Parsed value: {min_format}",
+            ),
+            line,
+            file,
+            "min_format is an invalid type after procesing!",
+        )
+    elif not isinstance(max_format, tuple):
+        return MCprepError(
+            MCMetaIncorrectFormatException(
+                resource_pack_name=name,
+                err_type=MCMetaErrorType.PARSED_FIELD_INVALID_TYPE,
+                additional_context=f"Parsed value: {max_format}",
+            ),
+            line,
+            file,
+            "max_format is an invalid type after processing!",
+        )
+    elif not len(min_format) == 2:
+        return MCprepError(
+            MCMetaIncorrectFormatException(
+                resource_pack_name=name,
+                err_type=MCMetaErrorType.PARSED_FIELD_INVALID_TYPE,
+                additional_context=f"Parsed value: {min_format}",
+            ),
+            line,
+            file,
+            "min_format is an invalid type after procesing!",
+        )
+    elif not len(max_format) == 2:
+        return MCprepError(
+            MCMetaIncorrectFormatException(
+                resource_pack_name=name,
+                err_type=MCMetaErrorType.PARSED_FIELD_INVALID_TYPE,
+                additional_context=f"Parsed value: {max_format}",
+            ),
+            line,
+            file,
+            "max_format is an invalid type after procesing!",
+        )
+    elif not isinstance(min_format[0], int) or not isinstance(min_format[1], int):
+        return MCprepError(
+            MCMetaIncorrectFormatException(
+                resource_pack_name=name,
+                err_type=MCMetaErrorType.PARSED_FIELD_INVALID_TYPE,
+                additional_context=f"Parsed value: {min_format}",
+            ),
+            line,
+            file,
+            "min_format is an invalid type after procesing!",
+        )
+    elif not isinstance(max_format[0], int) or not isinstance(max_format[1], int):
+        return MCprepError(
+            MCMetaIncorrectFormatException(
+                resource_pack_name=name,
+                err_type=MCMetaErrorType.PARSED_FIELD_INVALID_TYPE,
+                additional_context=f"Parsed value: {max_format}",
+            ),
+            line,
+            file,
+            "max_format is an invalid type after procesing!",
+        )
+
+    return MCResourcePack(name, path, PackVersionData(min_format, max_format))

--- a/MCprep_addon/materials/resource_pack.py
+++ b/MCprep_addon/materials/resource_pack.py
@@ -19,8 +19,11 @@
 from dataclasses import dataclass
 from enum import auto, Enum
 import json
+import os
 from pathlib import Path
-from typing import Tuple, Union
+from typing import cast, Optional, Tuple, Union
+
+import bpy
 
 from MCprep_addon.conf import MCprepError, env
 
@@ -240,3 +243,95 @@ def get_resource_pack_info(path: Path) -> Union[MCResourcePack, MCprepError]:
         )
 
     return MCResourcePack(name, path, PackVersionData(min_format, max_format))
+
+
+def find_from_texturepack(
+    blockname: str, resource_folder: Optional[Path] = None
+) -> Union[Path, MCprepError]:
+    """Given a blockname (and resource folder), find image filepath.
+
+    Finds textures following any pack which should have this structure, and
+    the input folder or default resource folder could target at any of the
+    following sublevels above the <subfolder> level.
+    //pack_name/assets/minecraft/textures/<subfolder>/<blockname.png>
+
+    Returns:
+            - Path if successful
+            - MCprepError if error occurs (may return with a message)
+    """
+    if resource_folder is None:
+        # default to internal pack
+        resource_folder = Path(
+            cast(str, bpy.path.abspath(bpy.context.scene.mcprep_texturepack_path))
+        )
+
+    if not resource_folder.exists() or not resource_folder.is_dir():
+        env.log("Error, resource folder does not exist")
+        line, file = env.current_line_and_file()
+        return MCprepError(
+            FileNotFoundError(),
+            line,
+            file,
+            f"Resource pack folder at {resource_folder} does not exist!",
+        )
+
+    # Check multiple paths, picking the first match (order is important),
+    # goal of picking out the /textures folder.
+    check_dirs = [
+        Path(resource_folder, "textures"),
+        Path(resource_folder, "minecraft", "textures"),
+        Path(resource_folder, "assets", "minecraft", "textures"),
+    ]
+    for path in check_dirs:
+        if path.exists():
+            resource_folder = path
+            break
+
+    search_paths = [
+        resource_folder,
+        # Both singular and plural shown below as it has varied historically.
+        Path(resource_folder, "blocks"),
+        Path(resource_folder, "block"),
+        Path(resource_folder, "items"),
+        Path(resource_folder, "item"),
+        Path(resource_folder, "entity"),
+        Path(resource_folder, "models"),
+        Path(resource_folder, "model"),
+    ]
+    res = None
+
+    # first see if subpath included is found, prioritize use of that
+    extensions = [".png", ".jpg", ".jpeg"]
+    if "/" in blockname:
+        newpath = blockname.replace("/", os.path.sep)
+        for ext in extensions:
+            if Path(resource_folder, newpath + ext).exists():
+                res = Path(resource_folder, newpath + ext)
+                return res
+        newpath = os.path.basename(blockname)  # case where goes into other subpaths
+        for ext in extensions:
+            if Path(resource_folder, newpath + ext).exists():
+                res = Path(resource_folder, newpath + ext)
+                return res
+
+    # fallback (more common case), wide-search for
+    for path in search_paths:
+        if not path.is_dir():
+            continue
+        for ext in extensions:
+            check_path = Path(path, blockname + ext)
+            if check_path.exists() and check_path.is_file():
+                res = Path(path, blockname + ext)
+                return res
+
+    # Mineways fallback
+    for suffix in ["-Alpha", "-RGB", "-RGBA"]:
+        if blockname.endswith(suffix):
+            res = Path(resource_folder, "mineways_assets", f"mineways{suffix}.png")
+            if res.exists() and res.is_file():
+                return res
+
+    if res is None:
+        line, file = env.current_line_and_file()
+        return MCprepError(FileNotFoundError(), line, file)
+    return res

--- a/MCprep_addon/materials/sequences.py
+++ b/MCprep_addon/materials/sequences.py
@@ -29,6 +29,7 @@ import bpy
 from bpy.types import Context, Material, Image, Texture
 
 from . import generate
+from . import resource_pack
 from . import uv_tools
 from .. import tracking
 from .. import util
@@ -71,7 +72,14 @@ def animate_single_material(
 		affectable = True  # retroactively assign to true, as tiled image found
 
 	# get the base image from the texturepack (cycles/BI general)
-	image_path_canon = generate.find_from_texturepack(canon)
+	internal_pack = resource_pack.get_default_pack()
+
+	if isinstance(internal_pack, MCprepError):
+		if internal_pack.msg:
+			env.log(internal_pack.msg)
+		return affectable, False, None
+
+	image_path_canon = resource_pack.find_texture_from_layers(canon, [internal_pack])
 
 	if isinstance(image_path_canon, MCprepError):
 		if image_path_canon.msg:

--- a/MCprep_addon/materials/vivy_materials.py
+++ b/MCprep_addon/materials/vivy_materials.py
@@ -30,6 +30,7 @@ from .. import tracking
 from .. import util
 from ..conf import MCprepError, env
 from . import generate
+from . import resource_pack
 from . import sync
 from . import vivy_utils as vu
 from .generate import checklist, get_mc_canonical_name
@@ -481,7 +482,14 @@ class MCPREP_OT_vivy_swap_texture_pack(
 		run the swap (and auto load e.g. normals and specs if avail.)
 		"""
 		mc_name, _ = get_mc_canonical_name(material.name)
-		image = generate.find_from_texturepack(mc_name, Path(folder) if not isinstance(folder, Path) else folder)
+		parsed_pack = resource_pack.get_resource_pack_info(Path(folder) if not isinstance(folder, Path) else folder)
+
+		if isinstance(parsed_pack, MCprepError):
+			if parsed_pack.msg:
+				env.log(parsed_pack.msg)
+			return False
+
+		image = resource_pack.find_texture_from_layers(mc_name, [parsed_pack])
 
 		if isinstance(image, MCprepError):
 			if image.msg:


### PR DESCRIPTION
(Currently a draft)

This PR aims to implement support for layered resource packs internally; in other words, support layered resource packs in material generation, but without a proper UI to add layers (reserved for a future PR). The goal is to make it so that, internally, material generation can handle multiple textures, with texture swap being functionally equivalent to having two resource packs in Minecraft (the custom resource pack, and the default resource pack as a fallback). That way, when the time does come for implementing the UI/UX side of things, the workload should be lighter overall.

