### PR TITLE
Fix: Silent handling of permission errors & animation material pass mapping errors.

### DIFF
--- a/MCprep_addon/materials/generate.py
+++ b/MCprep_addon/materials/generate.py
@@ -458,7 +458,7 @@ def set_cycles_texture(
 				node.image = new_img
 				node.mute = False
 				node.hide = False
-				
+
 				res = util.apply_noncolor_data(node)
 				if res is not None:
 					env.log(f"TypeError on {res.line} in {res.file}: {res.err_type}")
@@ -501,7 +501,56 @@ def set_cycles_texture(
 
 		changed = True
 
+	# If extra passes exist but no labeled node was found, create them
+	if extra_passes and img_sets:
+		_create_missing_pass_nodes(material, img_sets)
+
 	return changed
+
+
+def _create_missing_pass_nodes(
+	material: Material, img_sets: dict) -> None:
+	"""Create missing normal/specular texture nodes if extra passes exist
+	but no labeled nodes are present in the material."""
+	if not material.node_tree:
+		return
+	nodes = material.node_tree.nodes
+
+	# Check if labeled nodes already exist
+	has_normal = any(
+		util.np_is_mcprep_node_prop(n, MCPREP_NORMAL)
+		for n in nodes if n.type == 'TEX_IMAGE')
+	has_specular = any(
+		util.np_is_mcprep_node_prop(n, MCPREP_SPECULAR)
+		for n in nodes if n.type == 'TEX_IMAGE')
+
+	# Create normal node if needed
+	if "normal" in img_sets and not has_normal:
+		new_img = util.loadTexture(img_sets["normal"])
+		node_nrm = create_node(
+			nodes, 'ShaderNodeTexImage',
+			name="Normal Texture",
+			label="Normal Texture")
+		node_nrm.mnp.MCPREP_normal = True
+		node_nrm.image = new_img
+		res = util.apply_noncolor_data(node_nrm)
+		if res is not None:
+			env.log(f"TypeError on {res.line} in {res.file}: {res.err_type}")
+		env.log("Created missing normal texture node for extra passes")
+
+	# Create specular node if needed
+	if "specular" in img_sets and not has_specular:
+		new_img = util.loadTexture(img_sets["specular"])
+		node_spec = create_node(
+			nodes, 'ShaderNodeTexImage',
+			name="Specular Texture",
+			label="Specular Texture")
+		node_spec.mnp.MCPREP_specular = True
+		node_spec.image = new_img
+		res = util.apply_noncolor_data(node_spec)
+		if res is not None:
+			env.log(f"TypeError on {res.line} in {res.file}: {res.err_type}")
+		env.log("Created missing specular texture node for extra passes")
 
 
 def get_node_for_pass(material: Material, pass_name: str) -> Optional[Node]:
@@ -522,9 +571,10 @@ def get_node_for_pass(material: Material, pass_name: str) -> Optional[Node]:
 			return_node = node
 		elif util.np_is_mcprep_node_prop(node, MCPREP_DISPLACE) and pass_name == "displace":
 			return_node = node
-		else:
-			if not return_node:
-				return_node = node
+		# Only use unlabeled fallback for diffuse pass, to avoid
+		# incorrectly applying normal/specular sequences to diffuse node
+		elif pass_name == "diffuse" and not return_node:
+			return_node = node
 	return return_node
 
 

--- a/MCprep_addon/materials/material_manager.py
+++ b/MCprep_addon/materials/material_manager.py
@@ -420,10 +420,13 @@ class MCPREP_OT_replace_missing_textures(bpy.types.Operator):
 				count += 1
 				env.log(f"Updated {mat.name}")
 				if self.animateTextures:
-					sequences.animate_single_material(
+					_, _, err = sequences.animate_single_material(
 						mat,
 						context.scene.render.engine,
 						export_location=sequences.ExportLocation.ORIGINAL)
+					if err:
+						self.report({'ERROR'}, str(err))
+						return {'CANCELLED'}
 		if count == 0:
 			self.report(
 				{'INFO'},

--- a/MCprep_addon/materials/prep.py
+++ b/MCprep_addon/materials/prep.py
@@ -272,10 +272,13 @@ class MCPREP_OT_prep_materials(bpy.types.Operator, McprepMaterialProps):
 				return {'CANCELLED'}
 
 			if self.animateTextures:
-				sequences.animate_single_material(
+				_, _, err = sequences.animate_single_material(
 					mat,
 					context.scene.render.engine,
 					export_location=sequences.ExportLocation.ORIGINAL)
+				if err:
+					self.report({'ERROR'}, str(err))
+					return {'CANCELLED'}
 
 		# Sync materials.
 		if self.syncMaterials is True:
@@ -509,13 +512,15 @@ class MCPREP_OT_swap_texture_pack(
 			self.preprocess_material(mat)
 			res += generate.set_texture_pack(mat, Path(folder), self.useExtraMaps)
 			if self.animateTextures:
-				sequences.animate_single_material(
+				_, _, err = sequences.animate_single_material(
 					mat,
 					context.scene.render.engine,
 					export_location=sequences.ExportLocation.ORIGINAL)
+				if err:
+					self.report({'ERROR'}, str(err))
+					return {'CANCELLED'}
 			# may be a double call if was animated tex
-			generate.set_saturation_material(mat)
-
+		generate.set_saturation_material(mat)
 		if self.prepMaterials:
 			bpy.ops.mcprep.prep_materials(
 				animateTextures=self.animateTextures,
@@ -660,10 +665,13 @@ class MCPREP_OT_load_material(bpy.types.Operator, McprepMaterialProps):
 		success = res == 0
 
 		if self.animateTextures:
-			sequences.animate_single_material(
+			_, _, err = sequences.animate_single_material(
 				mat,
 				context.scene.render.engine,
 				export_location=sequences.ExportLocation.ORIGINAL)
+			if err:
+				self.report({'ERROR'}, str(err))
+				return False, str(err)
 
 		return success, None
 

--- a/MCprep_addon/materials/sequences.py
+++ b/MCprep_addon/materials/sequences.py
@@ -216,7 +216,7 @@ def generate_material_sequence(source_path: Path, image_path: Path, form: Option
 
 	perm_denied = (
 		"Permission denied, could not make folder - "
-		"try running blender as admin")
+		"check that the target folder has write permissions")
 
 	for img_pass in img_pass_dict:
 		passfile = str(img_pass_dict[img_pass])  # Convert from Path
@@ -313,7 +313,11 @@ def export_image_to_sequence(image_path: Path, params: Tuple[str, int, bool], ou
 	try:  # check parent folder exists/create if needed
 		os.mkdir(output_folder)
 	except OSError as exc:
-		if exc.errno != errno.EEXIST:
+		if exc.errno == errno.EACCES:
+			env.log("Permission denied, could not make folder - "
+				"check that the target folder has write permissions")
+			return None
+		elif exc.errno != errno.EEXIST:
 			raise
 
 	# ind = self.get_sequence_int_index(first_img)

--- a/MCprep_addon/spawner/mcmodel.py
+++ b/MCprep_addon/spawner/mcmodel.py
@@ -221,7 +221,7 @@ def read_model(
 			obj_data = json.load(f)
 	except PermissionError as e:
 		print(e)
-		raise ModelException("Permission error, try running as admin") from e
+		raise ModelException("Permission error, check that you have read permissions for the file") from e
 	except UnicodeDecodeError as e:
 		print(e)
 		raise ModelException("Could not read file, select valid json file") from e

--- a/MCprep_addon/spawner/mobs.py
+++ b/MCprep_addon/spawner/mobs.py
@@ -439,24 +439,32 @@ class MCPREP_OT_install_mob(bpy.types.Operator, ImportHelper):
 				icon_files += self.identify_icons(install_groups, icondir)
 			if icon_files:
 				dst = os.path.join(end_path, "icons")
+				perm_denied = False
 				if not os.path.isdir(dst):
 					try:
 						os.mkdir(dst)
 					except OSError as exc:
 						if exc.errno == errno.EACCES:
-							print("Permission denied, try running blender as admin")
-							print(exc)
+							perm_denied = True
+							self.report(
+								{'WARNING'},
+								"Permission denied, could not create icons folder "
+								"- check folder permissions")
+							env.log(f"Permission denied: {dst}")
 						elif exc.errno != errno.EEXIST:
 							print(f"Path does not exist: {dst}")
 							print(exc)
-				for icn in icon_files:
-					icn_base = os.path.basename(icn)
-					try:
-						shutil.copy2(icn, os.path.join(dst, icn_base))
-					except IOError as err:
-						print(f"Failed to copy over icon file {icn}")
-						print(f"to {os.path.join(icondir, icn_base)}")
-						print(err)
+				if perm_denied:
+					pass  # skip icon copy if folder creation failed
+				else:
+					for icn in icon_files:
+						icn_base = os.path.basename(icn)
+						try:
+							shutil.copy2(icn, os.path.join(dst, icn_base))
+						except IOError as err:
+							print(f"Failed to copy over icon file {icn}")
+							print(f"to {os.path.join(icondir, icn_base)}")
+							print(err)
 
 		# reload the cache
 		update_rig_list(context)
@@ -622,7 +630,7 @@ class MCPREP_OT_install_mob_icon(bpy.types.Operator, ImportHelper):
 				os.mkdir(icon_dir)
 			except OSError as exc:
 				if exc.errno == errno.EACCES:
-					print("Permission denied, try running blender as admin")
+					print("Permission denied, check folder permissions")
 				elif exc.errno != errno.EEXIST:
 					print(f"Path does not exist: {icon_dir}")
 

--- a/MCprep_addon/util.py
+++ b/MCprep_addon/util.py
@@ -114,8 +114,12 @@ def np_is_mcprep_node_prop(node: Node, prop: str) -> bool:
 		except Exception:
 			print(f"Could not get old {prop} prop")
 	else:
-		setattr(node.mnp, new_prop, prop in node)
-	return getattr(node.mnp, new_prop)
+		# Only set new property if old dict property exists.
+		# If old prop doesn't exist, preserve any value already
+		# set via node.mnp.X API (e.g. from generate_base_material)
+		if prop in node:
+			setattr(node.mnp, new_prop, True)
+	return getattr(node.mnp, new_prop, False)
 
 def apply_noncolor_data(node: Node) -> Optional[MCprepError]:
 	"""
@@ -134,7 +138,8 @@ def apply_noncolor_data(node: Node) -> Optional[MCprepError]:
 
 	if not node.image:
 		env.log("Node has no image applied yet, cannot change colorspace")
-	
+		return None
+
 	# Blender 2.8+
 	if hasattr(node.image, "colorspace_settings"):
 		# Avoid hard-coding values into the 


### PR DESCRIPTION
## Fixes

### 1. Permission errors now trigger a warning and cancel the operation
**Issue**: When importing texture packs on Unix systems, folder creation could fail due to permission issues; however, the error was silently suppressed, resulting in the import of incorrect textures.

**Fixes**:
- `sequences.py`: All calls to `animate_single_material()` now check the return value; if a permission error occurs, the operation is cancelled and an error dialog is displayed.
- `prep.py`: 3 call sites fixed.
- `material_manager.py`: 1 call site fixed.
- `mobs.py`: Permission errors for the icon folder now trigger a warning instead of just printing to the console.

### 2. Animated material pass mapping error
**Issue**: When applying a PBR texture pack to animated materials, the `magma_n` (normal) and `magma_s` (specular) sequences were incorrectly applied to the same Diffuse Texture node.

**Root Causes**:
- `np_is_mcprep_node_prop` destructively set `node.mnp.X` to `False` when the old dictionary property was missing.
- The `else` fallback in `get_node_for_pass` treated the first `TEX_IMAGE` node as the fallback for *all* passes.
- `set_cycles_texture` did not create missing normal/specular nodes.

**Fixes**:
- `util.py`: `np_is_mcprep_node_prop` no longer performs destructive writes.
- `util.py`: `apply_noncolor_data` now returns safely when `node.image` is `None`.
- `generate.py`: The fallback in `get_node_for_pass` now applies only to the diffuse pass.
- `generate.py`: Added `_create_missing_pass_nodes` to automatically create missing tagged nodes.

### 3. Cross-platform wording for permission errors
**Issue**: Permission error prompts suggested running Blender as administrator, which was not applicable to Linux/macOS users.

**Fixes**: All permission error prompts have been updated to offer generic advice regarding folder/file permissions. ### Involved files
- `MCprep_addon/materials/sequences.py`
- `MCprep_addon/materials/prep.py`
- `MCprep_addon/materials/material_manager.py`
- `MCprep_addon/materials/generate.py`
- `MCprep_addon/spawner/mobs.py`
- `MCprep_addon/spawner/mcmodel.py`
- `MCprep_addon/util.py`