### PR TITLE
fix: Limit Mineways shading workaround to under Blender 5.1

### DIFF
--- a/MCprep_addon/world_tools.py
+++ b/MCprep_addon/world_tools.py
@@ -799,7 +799,7 @@ class WorldImporterBase:
 				self.track_exporter = header.exporter
 
 				# Mineways workaround for smooth shading artifacts
-				if mineways_fix_smooth_shading_artifacts and header.exporter == "mineways":
+				if bpy.app.version < (5, 1, 0) and mineways_fix_smooth_shading_artifacts and header.exporter == "mineways":
 					obj.data.polygons.foreach_set('use_smooth',  [False] * len(obj.data.polygons))
 			elif isinstance(header, ObjHeaderOptions):
 				obj["MCPREP_OBJ_HEADER"] = True
@@ -816,7 +816,7 @@ class WorldImporterBase:
 				self.track_exporter = addon_prefs.MCprep_exporter_type  # Soft detect.
 				
 				# Mineways workaround for smooth shading artifacts
-				if mineways_fix_smooth_shading_artifacts and header.exporter() == "Mineways":
+				if bpy.app.version < (5, 1, 0) and mineways_fix_smooth_shading_artifacts and header.exporter() == "Mineways":
 					obj.data.polygons.foreach_set('use_smooth',  [False] * len(obj.data.polygons))
 
 		# One final assignment of the preferences, to avoid doing each loop


### PR DESCRIPTION
The core issue we had to work around with Mineways imports isn't needed in Blender 5.1 and above, so we shouldn't apply it to Mineways imports done post-Blender 5.1.

- Initial bug report in Mineways: https://github.com/erich666/Mineways/issues/151
- Issue made by Eric upstream: https://projects.blender.org/blender/blender/issues/152496
- Pull request where issue is resolved: https://projects.blender.org/blender/blender/pulls/153836

Also some demonstrations of the fix in upstream Blender. Below is Blender 4.5, where a Mineways export is imported through the regular OBJ importer (not through MCprep) and Cycles has issues with custom normals:

<img width="3440" height="1440" alt="Screenshot_20260630_020648" src="https://github.com/user-attachments/assets/a6e38f92-c5e1-4720-85e5-483b8b7ba304" />

And here's the exact same file opened up in Blender 5.1, where the issue has been resolved:

<img width="3440" height="1440" alt="Screenshot_20260630_020758" src="https://github.com/user-attachments/assets/e128ebd9-a5ac-45a5-b17e-3a91cdf32b95" />
