### PR TITLE
Fixed moon and sun mesh importing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ mcprep_venv_*
 .python-version
 venv/
 .venv/
+venv39/
 *.sublime-*
 MCprep_addon/import_bridge/conf
 MCprep_addon/import_bridge/nbt

--- a/MCprep_addon/world_tools.py
+++ b/MCprep_addon/world_tools.py
@@ -1296,7 +1296,7 @@ class MCPREP_OT_add_mc_sky(bpy.types.Operator):
 				env.log(
 					f"Source MCprep world blend file does not exist: {blendfile}")
 				return {'CANCELLED'}
-			resource = f"{blendfile}/bpy.types.Object"
+			resource = f"{blendfile}/Object"
 
 			util.bAppendLink(resource, "MoonMesh", False)
 			non_empties = [

--- a/test_files/world_tools_test.py
+++ b/test_files/world_tools_test.py
@@ -360,11 +360,22 @@ class WorldToolsTest(unittest.TestCase):
                 self.assertEqual(res, {'FINISHED'})
                 self.assertGreater(
                     post_objs, pre_objs, "No timeobject imported")
-                obj = world_tools.get_time_object()
-                if "static" in sub[0]:
+                obj = world_tools.get_time_object() is not None
+                if sub[0] == "world_static_only":
                     self.assertFalse(obj, "Static scn should have no timeobj")
                 else:
                     self.assertTrue(obj, "Dynamic scn should have timeobj")
+
+                has_moon = bool([ob.name.lower() for ob in bpy.data.objects
+                                if "moonmesh" in ob.name.lower()])
+                has_sun = bool([ob.name.lower() for ob in bpy.data.objects
+                                if "sunmesh" in ob.name.lower()])
+                if "mesh" in sub[0]:
+                    self.assertEqual(
+                        [has_moon, has_sun], [True, True], "Missing sun or moon mesh")
+                else:
+                    self.assertEqual(
+                        [has_moon, has_sun], [False, False], "Shouldn't have sun or moon mesh")
 
     def test_convert_mtl_simple(self):
         """Ensures that conversion of the mtl with other color space works."""


### PR DESCRIPTION
Previously, the mesh sun+moon importer was not working at all. It must have accidentally been changed while making some other typing updates. 

Now, the mesh sun/moon do properly import as they should have, and tests now better ensure this behavior is not lost again by accident.