### PR TITLE
Ensure timecontorller never exists after importing a static world

### DIFF
--- a/MCprep_addon/world_tools.py
+++ b/MCprep_addon/world_tools.py
@@ -1272,7 +1272,7 @@ class MCPREP_OT_add_mc_sky(bpy.types.Operator):
 		if self.world_type in ("world_static_mesh", "world_static_only"):
 			# Create world dynamically (previous, simpler implementation)
 			new_sun = self.create_sunlamp(context)
-			new_objs.append(new_sun)	
+			new_objs.append(new_sun)
 			bpy.ops.mcprep.world(skipUsage=True)  # do rest of sky setup
 
 		elif engine == 'CYCLES' or engine == 'BLENDER_EEVEE' or engine == 'BLENDER_EEVEE_NEXT':
@@ -1286,7 +1286,7 @@ class MCPREP_OT_add_mc_sky(bpy.types.Operator):
 			if wname in bpy.data.worlds:
 				prev_world = bpy.data.worlds[wname]
 				prev_world.name = "-old"
-			new_objs += self.create_dynamic_world(context, blendfile, wname)	
+			new_objs += self.create_dynamic_world(context, blendfile, wname)
 
 		if self.world_type in ("world_static_mesh", "world_mesh"):
 			if not os.path.isfile(blendfile):
@@ -1308,6 +1308,7 @@ class MCPREP_OT_add_mc_sky(bpy.types.Operator):
 					# Sometimes would error, see report -MfO6dDjpxFF4lfqqYGM
 					moonmesh.parent = tobj
 				new_objs.append(moonmesh)
+				self.auto_cleanup_timeobj(context)
 			else:
 				self.report({'WARNING'}, "Could not add moon")
 
@@ -1320,6 +1321,7 @@ class MCPREP_OT_add_mc_sky(bpy.types.Operator):
 				if tobj != moonmesh:
 					sunmesh.parent = tobj
 				new_objs.append(sunmesh)
+				self.auto_cleanup_timeobj(context)
 			else:
 				self.report({'WARNING'}, "Could not add sun")
 
@@ -1352,6 +1354,14 @@ class MCPREP_OT_add_mc_sky(bpy.types.Operator):
 		self.track_param = self.world_type
 		self.track_param = engine
 		return {'FINISHED'}
+
+	def auto_cleanup_timeobj(self, context) -> None:
+		if "static" not in self.world_type or bpy.app.version < (3, 0):
+			# Pre 3.0, children don't import parents
+			return
+		tobj = get_time_object()
+		if tobj:
+			util.obj_unlink_remove(tobj, True, context)
 
 	def create_sunlamp(self, context: Context) -> bpy.types.Object:
 		"""Create new sun lamp from primitives"""

--- a/test_files/world_tools_test.py
+++ b/test_files/world_tools_test.py
@@ -361,7 +361,8 @@ class WorldToolsTest(unittest.TestCase):
                 self.assertGreater(
                     post_objs, pre_objs, "No timeobject imported")
                 obj = world_tools.get_time_object() is not None
-                if sub[0] == "world_static_only":
+                if sub[0] in ["world_static_mesh", "world_static_only"]:
+                    # Static worlds should not have a time object
                     self.assertFalse(obj, "Static scn should have no timeobj")
                 else:
                     self.assertTrue(obj, "Dynamic scn should have timeobj")


### PR DESCRIPTION
Because of differences in Blender import behavior across different versions, importing a Sun or Moon mesh in Blender 3.x and later would result in the time controller object also being imported. This has now been resolved

Follow on work after:

https://github.com/Moo-Ack-Productions/MCprep/pull/724

Tested locally across versions:

```
-------------------------------------------------------------------------------
bversion   	ran_tests	ran	skips	failed	errors
-------------------------------------------------------------------------------
(5.0.1)   	test_add_mc_sky	1	0	0	No errors
(4.5.3)   	test_add_mc_sky	1	0	0	No errors
(4.3.1)   	test_add_mc_sky	1	0	0	No errors
(4.2.3)   	test_add_mc_sky	1	0	0	No errors
(4.0.2)   	test_add_mc_sky	1	0	0	No errors
(3.6.2)   	test_add_mc_sky	1	0	0	No errors
(3.5.1)   	test_add_mc_sky	1	0	0	No errors
(3.1.0)   	test_add_mc_sky	1	0	0	No errors
(3.0.0)   	test_add_mc_sky	1	0	0	No errors
(2.93.0)   	test_add_mc_sky	1	0	0	No errors
(2.80.75)   	test_add_mc_sky	1	0	0	No errors
Compiled in 40.3s + tests ran in 16.5s
```